### PR TITLE
[docs] user_interaction 테이블 추가 및 데이터 모델 문서 업데이트 (#31)

### DIFF
--- a/docs/planning/04_data_model_detail.md
+++ b/docs/planning/04_data_model_detail.md
@@ -167,6 +167,16 @@ erDiagram
         string  goods_id        FK
     }
 
+    USER_INTERACTION {
+        uuid    id               PK
+        uuid    user_id          FK  "nullable(guest)"
+        string  goods_id         FK
+        uuid    session_id       FK  "nullable"
+        string  interaction_type "click|cart|purchase|reject"
+        int     weight           "click=1|cart=3|purchase=5|reject=-1"
+        datetime created_at
+    }
+
     USER            ||--o{ PET                  : "1:N"
     USER            ||--||  USER_PREFERENCE      : "1:1"
     USER            ||--o{ CHAT_SESSION          : "1:N"
@@ -192,6 +202,10 @@ erDiagram
 
     CART            ||--o{ CART_ITEM             : "1:N"
     ORDER           ||--o{ ORDER_ITEM            : "1:N"
+
+    USER            ||--o{ USER_INTERACTION      : "1:N"
+    PRODUCT         ||--o{ USER_INTERACTION      : "1:N"
+    CHAT_SESSION    ||--o{ USER_INTERACTION      : "1:N"
 ```
 
 ---
@@ -320,6 +334,24 @@ erDiagram
   "pet_weight_kg":    "float | null    -- Silver 파싱: 2.5kg→2.5",
   "pet_gender":       "string | null   -- 수컷 | 암컷",
   "pet_breed":        "string | null   -- 품종명 (등록 시에만)"
+}
+```
+
+---
+
+## 6.3-C User Interaction (Phase 2 — CF 준비)
+
+> Day 1부터 로깅. CF 모델 학습 전에도 데이터 축적 목적.
+
+```json
+{
+  "id":               "uuid",
+  "user_id":          "uuid | null  -- guest = null",
+  "goods_id":         "string       -- FK → PRODUCT",
+  "session_id":       "uuid | null  -- FK → CHAT_SESSION",
+  "interaction_type": "click | cart | purchase | reject",
+  "weight":           "int          -- click=1 | cart=3 | purchase=5 | reject=-1",
+  "created_at":       "datetime"
 }
 ```
 

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -244,3 +244,20 @@ CREATE TABLE pet_used_product (
     goods_id VARCHAR(20) NOT NULL REFERENCES product(goods_id) ON DELETE RESTRICT,
     UNIQUE (pet_id, goods_id)
 );
+
+-- =============================================================
+-- USER_INTERACTION  (Phase 2 CF 준비 — Day 1부터 로깅)
+-- =============================================================
+CREATE TABLE user_interaction (
+    id               UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id          UUID         REFERENCES "user"(user_id) ON DELETE SET NULL,   -- guest = NULL
+    goods_id         VARCHAR(20)  REFERENCES product(goods_id) ON DELETE CASCADE,
+    session_id       UUID         REFERENCES chat_session(session_id) ON DELETE SET NULL,
+    interaction_type VARCHAR(20)  NOT NULL
+                     CHECK (interaction_type IN ('click', 'cart', 'purchase', 'reject')),
+    weight           SMALLINT     NOT NULL DEFAULT 1,
+    created_at       TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_ui_user_id  ON user_interaction(user_id);
+CREATE INDEX idx_ui_goods_id ON user_interaction(goods_id);


### PR DESCRIPTION
## 요약
Phase 2 CF 준비를 위한 `user_interaction` 테이블을 데이터 모델 문서 및 SQL 스키마에 추가.

## 변경 사항
- `docs/planning/04_data_model_detail.md`: ERD에 `USER_INTERACTION` 엔티티 및 관계선 추가, `6.3-C User Interaction` 섹션 추가
- `sql/schema.sql`: `user_interaction` 테이블 및 인덱스(`user_id`, `goods_id`) 추가

## 관련 이슈
ref #31
ref #25
ref #16

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다