### PR TITLE
[feat] silver_reviews ETL 추가 및 ABSA 스키마 반영 (#16)

### DIFF
--- a/docs/data/03_medallion_schema.md
+++ b/docs/data/03_medallion_schema.md
@@ -101,6 +101,7 @@ classDiagram
     class GoldReviews["🥇 gold/reviews  (silver 전체 + 증강)"] {
         float   sentiment_score
         string  sentiment_label
+        dict    aspect_sentiments
         timestamp processed_at
     }
 
@@ -312,8 +313,9 @@ Silver reviews에 감성 분석 결과 추가.
 | 컬럼 | 타입 | 도출 방법 |
 |---|---|---|
 | *(silver 컬럼 전체 포함)* | | |
-| `sentiment_score` | float | 한국어 감성 분석 모델 (0.0~1.0) |
-| `sentiment_label` | string | `positive` / `negative` / `neutral` |
+| `sentiment_score` | float | `Copycats/koelectra-base-v3-generalized-sentiment-analysis` — 리뷰 전체 긍/부정 점수 (0.0~1.0) |
+| `sentiment_label` | string | `positive` / `negative` (`sentiment_score` ≥ 0.5 → positive) |
+| `aspect_sentiments` | dict\|null | ABSA 결과 — 속성별 긍/부정 집계. 예: `{"기호성": "긍정", "냄새": "부정"}`. 8개 속성: 기호성·생체반응·소화/배변·제품 성상·성분/원료·냄새·가격/구매·배송/포장 |
 | `processed_at` | timestamp | |
 
 ---
@@ -346,6 +348,7 @@ Silver reviews에 감성 분석 결과 추가.
 | `purchase_label` | `REVIEW.purchase_label` |
 | `sentiment_score` | `REVIEW.sentiment_score` |
 | `sentiment_label` | `REVIEW.sentiment_label` |
+| `aspect_sentiments` | `REVIEW.aspect_sentiments` (JSONB) |
 | `pet_age_months` | `REVIEW.pet_age_months` |
 | `pet_weight_kg` | `REVIEW.pet_weight_kg` |
 | `pet_gender` | `REVIEW.pet_gender` |

--- a/docs/planning/04_data_model_detail.md
+++ b/docs/planning/04_data_model_detail.md
@@ -99,8 +99,9 @@ erDiagram
         string  author_nickname
         datetime written_at
         string  purchase_label      "first|repeat|null"
-        float   sentiment_score     "0.0~1.0 (Gold: 감성 분석)"
-        string  sentiment_label     "positive|negative|neutral"
+        float   sentiment_score     "0.0~1.0 (Gold: 전체 감성 점수)"
+        string  sentiment_label     "positive|negative"
+        jsonb   aspect_sentiments   "nullable (Gold: ABSA 속성별 긍/부정)"
         int     pet_age_months      "nullable (7개월→7, 3살→36)"
         float   pet_weight_kg       "nullable"
         string  pet_gender          "nullable (수컷|암컷)"
@@ -314,8 +315,9 @@ erDiagram
   "author_nickname":  "string          -- 작성자 닉네임",
   "written_at":       "date            -- 작성일 (Silver: YYYY.MM.DD 파싱)",
   "purchase_label":   "string | null   -- first | repeat (Bronze 직접 수집)",
-  "sentiment_score":  "float | null    -- Gold 파생: 0.0~1.0 한국어 감성 분석",
-  "sentiment_label":  "string | null   -- Gold 파생: positive | negative | neutral",
+  "sentiment_score":  "float | null    -- Gold 파생: 0.0~1.0 전체 긍/부정 점수 (KoELECTRA)",
+  "sentiment_label":  "string | null   -- Gold 파생: positive | negative",
+  "aspect_sentiments":"jsonb | null    -- Gold 파생: ABSA 결과 {기호성|생체반응|소화/배변|제품 성상|성분/원료|냄새|가격/구매|배송/포장: 긍정|부정}",
   "pet_age_months":   "int | null      -- Silver 파싱: 7개월→7, 3살→36",
   "pet_weight_kg":    "float | null    -- Silver 파싱: 2.5kg→2.5",
   "pet_gender":       "string | null   -- 수컷 | 암컷",

--- a/scripts/eda/eda_reviews.py
+++ b/scripts/eda/eda_reviews.py
@@ -1,12 +1,12 @@
 """
-Bronze Reviews EDA
-- 입력: output/bronze/reviews/20260310_reviews.parquet
+Silver Reviews EDA
+- 입력: output/silver/reviews/YYYYMMDD_reviews_silver.parquet
 - 출력: output/eda/reviews_eda.html (Plotly 인터랙티브)
 
 실행:
   conda run -n final-project python scripts/eda/eda_reviews.py
   conda run -n final-project python scripts/eda/eda_reviews.py \
-      --input output/bronze/reviews/20260310_reviews.parquet
+      --input output/silver/reviews/20260310_reviews_silver.parquet
 """
 
 import argparse
@@ -27,38 +27,12 @@ OUTPUT_PATH  = "output/eda/reviews_eda.html"
 
 def load_data(input_path: str):
     df = pd.read_parquet(input_path)
-    df["written_at"] = pd.to_datetime(df["written_at_raw"], format="%Y.%m.%d", errors="coerce")
+    # Silver parquet: written_at은 date 타입, pet_age_months/pet_weight_kg 파싱 완료
+    df["written_at"] = pd.to_datetime(df["written_at"], errors="coerce")
     df["content_len"] = df["content"].str.len()
     df["prefix"] = df["goods_id"].str[:2]
     df["year"]  = df["written_at"].dt.year
     df["month"] = df["written_at"].dt.to_period("M").astype(str)
-
-    # pet_age → 개월 수 변환
-    def to_months(val):
-        if pd.isna(val):
-            return None
-        val = str(val).strip()
-        if "개월" in val:
-            try: return int(val.replace("개월", "").strip())
-            except: return None
-        elif "살" in val:
-            try: return int(val.replace("살", "").strip()) * 12
-            except: return None
-        return None
-
-    df["pet_age_months"] = df["pet_age_raw"].apply(to_months)
-
-    # pet_weight → float
-    def to_weight(val):
-        if pd.isna(val):
-            return None
-        try:
-            return float(str(val).replace("kg", "").strip())
-        except:
-            return None
-
-    df["pet_weight_kg"] = df["pet_weight_raw"].apply(to_weight)
-
     return df
 
 
@@ -150,7 +124,7 @@ def fig_score(df):
     figs = []
 
     # 2-1. 전체 점수 분포
-    score_cnt = df["score_raw"].value_counts().sort_index()
+    score_cnt = df["score"].value_counts().sort_index()
     total = score_cnt.sum()
     fig = go.Figure(go.Bar(
         x=[str(s) for s in score_cnt.index],
@@ -159,11 +133,11 @@ def fig_score(df):
         text=[f"{v:,}<br>({v/total*100:.1f}%)" for v in score_cnt.values],
         textposition="outside",
     ))
-    fig.update_layout(title="전체 점수(score_raw) 분포", xaxis_title="점수", yaxis_title="리뷰 수")
+    fig.update_layout(title="전체 점수(score) 분포", xaxis_title="점수", yaxis_title="리뷰 수")
     figs.append(fig)
 
     # 2-2. prefix별 평균 점수
-    prefix_score = df.groupby("prefix")["score_raw"].agg(["mean","count"]).reset_index()
+    prefix_score = df.groupby("prefix")["score"].agg(["mean","count"]).reset_index()
     fig = go.Figure(go.Bar(
         x=prefix_score["prefix"].tolist(),
         y=prefix_score["mean"].round(2).tolist(),
@@ -172,7 +146,7 @@ def fig_score(df):
         textposition="outside",
         error_y=dict(
             type="data",
-            array=df.groupby("prefix")["score_raw"].std().reindex(prefix_score["prefix"]).tolist(),
+            array=df.groupby("prefix")["score"].std().reindex(prefix_score["prefix"]).tolist(),
             visible=True,
         ),
     ))
@@ -184,7 +158,7 @@ def fig_score(df):
     figs.append(fig)
 
     # 2-3. 점수별 purchase_label 비율
-    score_label = df.groupby(["score_raw","purchase_label"]).size().unstack(fill_value=0)
+    score_label = df.groupby(["score","purchase_label"]).size().unstack(fill_value=0)
     for col in ["first","repeat"]:
         if col not in score_label.columns:
             score_label[col] = 0
@@ -288,9 +262,9 @@ def fig_pet_profile(df):
     """SECTION 5: 펫 프로필"""
     figs = []
 
-    # 5-1. 프로필 필드 보유율
-    fields = ["pet_name","pet_gender","pet_age_raw","pet_weight_raw","pet_breed","review_info"]
-    labels = ["이름","성별","나이","체중","품종","review_info"]
+    # 5-1. 프로필 필드 보유율 (Silver 파싱 컬럼 기준)
+    fields = ["pet_name","pet_gender","pet_age_months","pet_weight_kg","pet_breed","review_info"]
+    labels = ["이름","성별","나이(개월)","체중(kg)","품종","review_info"]
     rates  = [df[f].notna().mean() * 100 for f in fields]
     counts = [df[f].notna().sum() for f in fields]
     fig = go.Figure(go.Bar(
@@ -406,7 +380,7 @@ def fig_purchase(df):
     figs.append(fig)
 
     # 6-3. 구매 유형별 평균 점수
-    score_by_pl = df.groupby("purchase_label")["score_raw"].agg(["mean","count"]).reset_index()
+    score_by_pl = df.groupby("purchase_label")["score"].agg(["mean","count"]).reset_index()
     fig = go.Figure(go.Bar(
         x=score_by_pl["purchase_label"].tolist(),
         y=score_by_pl["mean"].round(3).tolist(),
@@ -511,7 +485,7 @@ ISSUES_HTML = """
     <p style="margin:0;font-size:.9rem;color:#444;line-height:1.6">
       전체 131,147건 중 5점이 101,046건(77%). 4점 이상 93%.<br>
       <b>원인</b>: 자기선택 편향 + 포인트 지급 구조.<br>
-      <b>대응</b>: <code>score_raw</code> 단독 랭킹 사용 금지.
+      <b>대응</b>: <code>score</code> 단독 랭킹 사용 금지.
       <code>popularity_score</code>에 텍스트 기반 <code>sentiment_score</code> 가중치 사용.
       감성 분석 모델 학습 시 클래스 가중치 조정 필요.
     </p>
@@ -556,10 +530,11 @@ def render_html(all_figs: list[tuple[int, go.Figure]], output_path: str, summary
     <div style="display:flex;gap:16px;flex-wrap:wrap;margin:24px 0">
       <div class="card"><div class="val">{summary['total_reviews']:,}</div><div class="lbl">전체 리뷰</div></div>
       <div class="card"><div class="val">{summary['unique_goods']:,}</div><div class="lbl">리뷰 보유 상품</div></div>
-      <div class="card"><div class="val">{summary['unique_authors']:,}</div><div class="lbl">고유 작성자</div></div>
+      <div class="card"><div class="val">{summary['unique_authors']:,}</div><div class="lbl">고유 작성자 (비로그인 제외)</div></div>
+      <div class="card"><div class="val">{summary['anon_reviews']:,}</div><div class="lbl">비로그인 리뷰 ({summary['anon_pct']:.1f}%)</div></div>
       <div class="card"><div class="val">{summary['coverage_pct']:.1f}%</div><div class="lbl">수집 대상 커버율</div></div>
       <div class="card"><div class="val">{summary['avg_score']:.2f}</div><div class="lbl">평균 점수</div></div>
-      <div class="card"><div class="val">{summary['pet_profile_pct']:.1f}%</div><div class="lbl">펫 프로필 보유율</div></div>
+      <div class="card"><div class="val">{summary['pet_profile_pct']:.1f}%</div><div class="lbl">나이+체중 보유율</div></div>
     </div>
     """)
 
@@ -634,13 +609,16 @@ def main(input_path: str) -> None:
     has_review = df["goods_id"].nunique()
     total_target = len(sg[~sg.index.str.startswith("GP")])
 
+    anon_mask   = df["author_nickname"] == "어바웃펫 회원"
     summary = {
         "total_reviews":   len(df),
         "unique_goods":    has_review,
-        "unique_authors":  df["author_nickname"].nunique(),
+        "unique_authors":  df.loc[~anon_mask, "author_nickname"].nunique(),
+        "anon_reviews":    int(anon_mask.sum()),
+        "anon_pct":        anon_mask.mean() * 100,
         "coverage_pct":    has_review / total_target * 100,
-        "avg_score":       df["score_raw"].mean(),
-        "pet_profile_pct": df["pet_name"].notna().mean() * 100,
+        "avg_score":       df["score"].mean(),
+        "pet_profile_pct": (df["pet_age_months"].notna() & df["pet_weight_kg"].notna()).mean() * 100,
     }
 
     print("  차트 생성 중...")
@@ -661,8 +639,8 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--input",
-        default="output/bronze/reviews/20260310_reviews.parquet",
-        help="Bronze reviews parquet 경로",
+        default="output/silver/reviews/20260310_reviews_silver.parquet",
+        help="Silver reviews parquet 경로",
     )
     args = parser.parse_args()
     main(args.input)

--- a/scripts/silver_reviews.py
+++ b/scripts/silver_reviews.py
@@ -1,0 +1,267 @@
+"""
+Silver Reviews ETL
+Bronze reviews parquet → Silver reviews parquet
+
+처리 순서:
+  1. Bronze parquet 로드 (기본 + GP 병합 옵션)
+  2. review_id 기준 중복 제거
+  3. Silver canonical goods_id 필터링 (orphan review 방지)
+  4. 타입 변환
+     - written_at_raw "YYYY.MM.DD" → date
+     - score_raw → float (None 유지)
+     - pet_gender 빈 문자열 → None  (이슈 3)
+     - pet_age_raw "7개월"→7, "3살"→36 → int months
+     - pet_weight_raw "2.5kg"→2.5, "500g"→0.5 → float kg
+     - review_info JSON string → dict
+  5. 출력: output/silver/reviews/YYYYMMDD_reviews_silver.parquet
+
+실행:
+  # GP 수집 완료 전 (기본 리뷰만)
+  conda run -n final-project python scripts/silver_reviews.py
+
+  # GP 수집 완료 후 (전체 병합)
+  conda run -n final-project python scripts/silver_reviews.py \\
+      --gp-input output/bronze/reviews/20260310_reviews_gp.parquet
+"""
+
+import argparse
+import json
+import re
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+
+
+# ── 타입 변환 헬퍼 ─────────────────────────────────────────────────────────────
+
+def parse_written_at(val: str) -> object:
+    """'2026.03.06' → datetime.date"""
+    if not val or str(val).strip() in ("", "nan", "None"):
+        return None
+    try:
+        return datetime.strptime(str(val).strip(), "%Y.%m.%d").date()
+    except ValueError:
+        return None
+
+
+def parse_pet_age_months(val: str) -> int | None:
+    """
+    '7개월' → 7
+    '3살'   → 36
+    '2살 3개월' → 27
+    '1살6개월'  → 18
+    """
+    if not val or str(val).strip() in ("", "nan", "None"):
+        return None
+    s = str(val).strip()
+    years  = re.search(r"(\d+)\s*살", s)
+    months = re.search(r"(\d+)\s*개월", s)
+    total = 0
+    if years:
+        total += int(years.group(1)) * 12
+    if months:
+        total += int(months.group(1))
+    return total if total > 0 else None
+
+
+def parse_pet_weight_kg(val: str) -> float | None:
+    """
+    '2.5kg'  → 2.5
+    '500g'   → 0.5
+    '2,500g' → 2.5
+    """
+    if not val or str(val).strip() in ("", "nan", "None"):
+        return None
+    s = str(val).strip().replace(",", "")
+    kg = re.search(r"([\d.]+)\s*kg", s, re.IGNORECASE)
+    g  = re.search(r"([\d.]+)\s*g",  s, re.IGNORECASE)
+    try:
+        if kg:
+            return round(float(kg.group(1)), 3)
+        if g:
+            return round(float(g.group(1)) / 1000, 3)
+    except ValueError:
+        pass
+    return None
+
+
+def parse_review_info(val) -> dict | None:
+    """JSON string → dict"""
+    if val is None or (isinstance(val, float)):
+        return None
+    s = str(val).strip()
+    if not s or s in ("nan", "None", "null"):
+        return None
+    try:
+        return json.loads(s)
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+# ── ETL 단계 ──────────────────────────────────────────────────────────────────
+
+def load_bronze(input_path: str, gp_input_path: str | None) -> pd.DataFrame:
+    """Bronze parquet 로드 및 병합"""
+    df = pd.read_parquet(input_path)
+    print(f"  기본 리뷰: {len(df):,}건")
+
+    if gp_input_path:
+        p = Path(gp_input_path)
+        if p.exists():
+            df_gp = pd.read_parquet(gp_input_path)
+            print(f"  GP 리뷰  : {len(df_gp):,}건")
+            df = pd.concat([df, df_gp], ignore_index=True)
+            print(f"  병합 후  : {len(df):,}건")
+        else:
+            print(f"  [경고] GP 파일 없음: {gp_input_path} — GP 제외 진행")
+
+    return df
+
+
+def dedup_reviews(df: pd.DataFrame) -> pd.DataFrame:
+    """review_id 중복 제거 (GP/GI 동일 리뷰 방지)"""
+    before = len(df)
+    df = df.drop_duplicates(subset="review_id", keep="first")
+    removed = before - len(df)
+    if removed > 0:
+        print(f"  중복 제거: {removed:,}건 → {len(df):,}건")
+    return df
+
+
+def filter_canonical(df: pd.DataFrame, goods_path: str) -> pd.DataFrame:
+    """Silver canonical goods_id에 속하지 않는 리뷰 제거 (orphan 방지)"""
+    goods = pd.read_parquet(goods_path)
+    canonical_ids = set(goods.loc[goods["is_canonical"], "goods_id"])
+    before = len(df)
+    df = df[df["goods_id"].isin(canonical_ids)].copy()
+    removed = before - len(df)
+    if removed > 0:
+        print(f"  orphan 제거: {removed:,}건 (canonical 외 goods_id)")
+    return df
+
+
+def cast_types(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+
+    # 날짜
+    df["written_at"] = df["written_at_raw"].apply(parse_written_at)
+
+    # 점수 (이미 float이나 None 보정)
+    df["score"] = pd.to_numeric(df["score_raw"], errors="coerce")
+
+    # pet_gender 빈 문자열 → None  (이슈 3)
+    df["pet_gender"] = df["pet_gender"].replace("", None)
+    df.loc[df["pet_gender"].apply(lambda x: isinstance(x, str) and x.strip() == ""), "pet_gender"] = None
+
+    # 수치 파싱
+    df["pet_age_months"] = df["pet_age_raw"].apply(parse_pet_age_months)
+    df["pet_weight_kg"]  = df["pet_weight_raw"].apply(parse_pet_weight_kg)
+
+    # review_info JSON → dict
+    df["review_info"] = df["review_info"].apply(parse_review_info)
+
+    return df
+
+
+# ── 출력 컬럼 ─────────────────────────────────────────────────────────────────
+
+SILVER_COLUMNS = [
+    "review_id",
+    "goods_id",
+    "score",
+    "content",
+    "author_nickname",
+    "written_at",
+    "purchase_label",
+    "pet_name",
+    "pet_gender",
+    "pet_age_months",
+    "pet_weight_kg",
+    "pet_breed",
+    "review_info",
+    "etl_at",
+    # raw 보존 (검증용)
+    "score_raw",
+    "written_at_raw",
+    "pet_age_raw",
+    "pet_weight_raw",
+]
+
+
+# ── 메인 ──────────────────────────────────────────────────────────────────────
+
+def main(input_path: str, gp_input_path: str | None, goods_path: str) -> None:
+    print(f"[silver_reviews] 시작 — {datetime.now().strftime('%H:%M:%S')}")
+    print(f"  입력: {input_path}")
+    if gp_input_path:
+        print(f"  GP  : {gp_input_path}")
+    print(f"  goods: {goods_path}")
+    print()
+
+    # Step 1: 로드 및 병합
+    print("[1/4] Bronze 로드 중...")
+    df = load_bronze(input_path, gp_input_path)
+
+    # Step 2: 중복 제거
+    print("[2/4] 중복 제거 중...")
+    df = dedup_reviews(df)
+
+    # Step 3: orphan 필터링
+    print("[3/4] canonical 필터링 중...")
+    df = filter_canonical(df, goods_path)
+
+    # Step 4: 타입 변환
+    print("[4/4] 타입 변환 중...")
+    df = cast_types(df)
+    df["etl_at"] = pd.Timestamp.now(tz="UTC")
+
+    # 컬럼 정렬
+    available = [c for c in SILVER_COLUMNS if c in df.columns]
+    df = df[available]
+
+    # 저장
+    date_str   = datetime.now().strftime("%Y%m%d")
+    output_dir = Path("output/silver/reviews")
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / f"{date_str}_reviews_silver.parquet"
+    df.to_parquet(output_path, index=False)
+
+    # 요약
+    print(f"\n저장 완료: {output_path}")
+    print(f"  전체 리뷰    : {len(df):,}건")
+    print(f"  고유 상품    : {df['goods_id'].nunique():,}개")
+    print(f"  고유 작성자  : {df['author_nickname'].nunique():,}명")
+    print(f"  written_at 결측: {df['written_at'].isna().sum()}건")
+    print(f"  score 결측   : {df['score'].isna().sum()}건")
+    print(f"  pet_gender 결측: {df['pet_gender'].isna().sum():,}건")
+    print(f"  pet_age_months 있음: {df['pet_age_months'].notna().sum():,}건")
+    print(f"  pet_weight_kg 있음: {df['pet_weight_kg'].notna().sum():,}건")
+
+    # 점수 분포
+    score_dist = df["score"].value_counts().sort_index()
+    print(f"\n  점수 분포:")
+    for score, cnt in score_dist.items():
+        pct = cnt / len(df) * 100
+        print(f"    {score:.1f}점: {cnt:,}건 ({pct:.1f}%)")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--input",
+        default="output/bronze/reviews/20260310_reviews.parquet",
+        help="Bronze reviews parquet 경로 (GP 제외)",
+    )
+    parser.add_argument(
+        "--gp-input",
+        default=None,
+        help="Bronze GP reviews parquet 경로 (수집 완료 후 사용)",
+    )
+    parser.add_argument(
+        "--goods",
+        default="output/silver/goods/20260310_goods_silver.parquet",
+        help="Silver goods parquet 경로 (canonical 필터링 기준)",
+    )
+    args = parser.parse_args()
+    main(args.input, args.gp_input, args.goods)

--- a/sql/schema.sql
+++ b/sql/schema.sql
@@ -136,16 +136,18 @@ CREATE TABLE review (
     author_nickname VARCHAR(100)  NOT NULL,
     written_at      DATE          NOT NULL,
     purchase_label  VARCHAR(10)   CHECK (purchase_label IN ('first', 'repeat')),
-    sentiment_score NUMERIC(4,3)  CHECK (sentiment_score BETWEEN 0 AND 1),  -- Gold
-    sentiment_label VARCHAR(10)   CHECK (sentiment_label IN ('positive', 'negative', 'neutral')),  -- Gold
+    sentiment_score NUMERIC(4,3)  CHECK (sentiment_score BETWEEN 0 AND 1),  -- Gold: 전체 감성 점수
+    sentiment_label VARCHAR(10)   CHECK (sentiment_label IN ('positive', 'negative')),             -- Gold
+    aspect_sentiments JSONB,                                                                        -- Gold: ABSA {기호성|생체반응|...: 긍정|부정}
     pet_age_months  INT,
     pet_weight_kg   NUMERIC(5,2),
     pet_gender      VARCHAR(10),
     pet_breed       VARCHAR(100)
 );
 
-CREATE INDEX idx_review_goods_id  ON review(goods_id);
-CREATE INDEX idx_review_written   ON review(written_at DESC);
+CREATE INDEX idx_review_goods_id       ON review(goods_id);
+CREATE INDEX idx_review_written        ON review(written_at DESC);
+CREATE INDEX idx_review_aspect_senti   ON review USING GIN(aspect_sentiments);
 
 -- =============================================================
 -- CHAT_SESSION


### PR DESCRIPTION
## Summary

- `scripts/silver_reviews.py` 신규 작성 — Bronze reviews → Silver ETL
  - review_id 기준 중복 제거 (동일 리뷰가 여러 goods_id에 등록되는 구조 처리)
  - GI 기준 canonical 필터링
  - written_at 날짜 파싱, score float 변환, pet_gender 빈 문자열 → None
  - pet_age_months ("7개월"→7, "3살"→36), pet_weight_kg ("2.5kg"→2.5, "500g"→0.5) 파싱
  - `--gp-input` 플래그로 GP 수집 완료 후 merge 가능
- `scripts/eda/eda_reviews.py` 업데이트 — Silver parquet 기준으로 변경, 펫 프로필 보유율 산정 기준 개선 (나이+체중), 비로그인 리뷰 지표 추가
- `docs/data/03_medallion_schema.md` 업데이트 — Bronze/Silver 컬럼명 실제 구현과 동기화, Gold reviews에 `aspect_sentiments` (ABSA 8개 속성) 추가
- `docs/planning/04_data_model_detail.md` 업데이트 — REVIEW 엔티티에 `aspect_sentiments` 추가, USER_INTERACTION 테이블 추가 (Phase 2 CF용)
- `sql/schema.sql` 업데이트 — review 테이블 `aspect_sentiments JSONB` 컬럼 + GIN 인덱스 추가, user_interaction 테이블 추가

## Test plan

- [ ] `conda run -n final-project python scripts/silver_reviews.py` 실행 — Silver parquet 생성 확인
- [ ] GP 수집 완료 후 `silver_reviews.py --gp-input output/bronze/reviews/20260310_reviews_gp.parquet` 재실행
- [ ] `python scripts/eda/eda_reviews.py` 실행 — HTML EDA 정상 생성 확인
- [ ] `sql/schema.sql` PostgreSQL 적용 후 `aspect_sentiments` 컬럼 존재 확인