### PR TITLE
[docs] S3 Medallion / Airflow 아키텍처 제거 및 로컬 전처리 파이프라인으로 문서 업데이트 (#83)

### DIFF
--- a/docs/data/02_data_collection_issues.md
+++ b/docs/data/02_data_collection_issues.md
@@ -8,18 +8,16 @@
 
 ## 개요
 
-어바웃펫(aboutpet.co.kr) 상품·리뷰 데이터를 수집하고, S3 Medallion 구조(Bronze → Silver → Gold)로 정제·증강한 뒤 PostgreSQL / Qdrant에 적재하는 파이프라인 전체를 정의한다.
-
-**아키텍처 확장성 원칙**: S3 Medallion 구조와 배치 스크립트 인터페이스를 프로토타입 단계에서 확정하여, Phase 2에서 Airflow DAG 전환 시 아키텍처 변경 없이 자동화만 추가할 수 있도록 한다.
+어바웃펫(aboutpet.co.kr) 상품·리뷰 데이터를 수집하고, Bronze → Silver → Gold 전처리 파이프라인으로 정제·증강한 뒤 PostgreSQL / Qdrant에 적재하는 파이프라인 전체를 정의한다.
 
 ```
 크롤링 (Playwright)
     ↓
-Bronze  S3 Parquet (원시 데이터)
+Bronze  로컬 Parquet (원시 데이터)
     ↓
-Silver  S3 Parquet (정제·정규화)
+Silver  로컬 Parquet (정제·정규화)
     ↓
-Gold    S3 Parquet (메타데이터 증강)
+Gold    로컬 Parquet (분석 및 추천 신호 파생)
     ↓
     ├── PostgreSQL  (관계형 서빙 DB)
     └── Qdrant      (벡터 임베딩 인덱싱)
@@ -59,19 +57,18 @@ Gold    S3 Parquet (메타데이터 증강)
 
 ### 이슈 2 — ETL 파이프라인 구현 (Bronze → Silver → Gold)
 
-**한 줄 설명**: 수집 데이터를 S3 Medallion 구조로 정제·증강
+**한 줄 설명**: 수집 데이터를 Bronze → Silver → Gold 전처리 파이프라인으로 정제·증강
 
 **배경**
 
-- S3 Medallion 구조를 프로토타입 단계에서 확정하여 추후 Airflow 연동 시 적재 로직 재작성 불필요
 - Gold 레이어의 추천 신호는 외부 데이터 없이 크롤링 데이터에서 파생 (리뷰 timestamp, review_count 등)
 - LLM 요약은 비용 및 시간 이슈로 Phase 2 이후 적용
 - Bronze/Silver/Gold 컬럼 정의 확정: `docs/data/03_medallion_schema.md` 참고
 
 **서브 이슈**
 
-- [ ] Bronze: 원시 크롤링 데이터 S3 Parquet 저장
-  - 파티션 구조 설계 (예: `s3://bucket/bronze/goods/`, `s3://bucket/bronze/reviews/`)
+- [ ] Bronze: 원시 크롤링 데이터 로컬 저장
+  - 디렉터리 구조 설계 (`data/bronze/goods/`, `data/bronze/reviews/`)
   - 스키마 정의 (크롤링 원본 필드 그대로 보존)
 - [ ] Silver: 정제·정규화
   - 평점 스케일 통일 (목록 API 10점 → 5점 기준)
@@ -119,14 +116,14 @@ Gold    S3 Parquet (메타데이터 증강)
 
 ---
 
-### 이슈 4 — 배치 스크립트 작성 (Airflow stub)
+### 이슈 4 — 배치 스크립트 작성
 
-**한 줄 설명**: Phase 2 Airflow DAG 전환을 위한 수동 실행 스크립트
+**한 줄 설명**: 점수 재계산 및 가중치 갱신을 위한 수동 실행 스크립트
 
 **배경**
 
-- 프로토타입 단계에서는 자동화(Airflow) 없이 수동 실행
-- 스크립트 인터페이스(입력·출력·실행 단위)를 Airflow DAG Task 단위와 일치시켜 추후 전환 비용 최소화
+- 프로토타입 단계에서는 자동화 없이 수동 실행
+- 스크립트 단위를 명확히 분리하여 추후 자동화 전환 비용 최소화
 
 **서브 이슈**
 
@@ -138,7 +135,6 @@ Gold    S3 Parquet (메타데이터 증강)
   - 추천 가중치 재계산 → PostgreSQL 반영
 
 > 신규 리뷰 수집은 프로토타입 범위 외 (상품 수 대비 API 호출 비용 큼). 필요 시 이슈 1 크롤링 스크립트 재실행으로 대체.
-> Phase 2 전환 시 각 스크립트를 Airflow DAG의 PythonOperator Task로 래핑하면 됨.
 
 ---
 
@@ -147,9 +143,9 @@ Gold    S3 Parquet (메타데이터 증강)
 | 항목 | 프로토타입 (현재) | Phase 2 |
 |---|---|---|
 | 크롤링 | Playwright 수동 실행 | Playwright + 스케줄링 |
-| ETL | 스크립트 수동 실행 | Airflow DAG 자동화 |
+| ETL | 스크립트 수동 실행 | 자동화 스케줄러 전환 |
 | 성분·알레르기 정보 | 상품명 추출 (1차) + OCR (2차) | 어드민 수동 수정 인터페이스 |
-| 신규 리뷰 수집 | 미구현 (전체 재크롤링으로 대체) | Airflow weekly DAG |
+| 신규 리뷰 수집 | 미구현 (전체 재크롤링으로 대체) | 정기 크롤링 스케줄링 |
 | 트렌드 수집 | 미구현 | 네이버 DataLab API 연동 |
 | LLM 요약 | 미구현 | Gold 레이어 증강 추가 |
-| 모니터링 | 미구현 | Airflow DAG 실행 현황 알림 |
+| 모니터링 | 미구현 | 배치 실행 현황 알림 |

--- a/docs/data/03_medallion_schema.md
+++ b/docs/data/03_medallion_schema.md
@@ -1,7 +1,7 @@
-# S3 Medallion 스키마 정의
+# 전처리 파이프라인 스키마 정의
 
-> **범위**: Bronze → Silver → Gold S3 Parquet 레이어 컬럼 정의
-> 각 레이어는 `s3://bucket/{layer}/{table}/` 경로에 Parquet로 저장
+> **범위**: Bronze → Silver → Gold 전처리 레이어 컬럼 정의
+> 각 레이어는 로컬 디렉터리(`data/{layer}/{table}/`)에 Parquet로 저장
 
 ---
 

--- a/docs/planning/02_system_architecture.md
+++ b/docs/planning/02_system_architecture.md
@@ -41,16 +41,13 @@ flowchart TD
         direction LR
         PG[("PostgreSQL<br>user · pet · order<br>goods · review")]
         QDRANT[("Qdrant<br>Vector DB<br>Hybrid Search + RRF")]
-        S3[("AWS S3<br>Medallion<br>Bronze / Silver / Gold")]
     end
 
     subgraph PIPELINE["🔄 Data Pipeline"]
         direction LR
         ABOUTPET["어바웃펫<br>aboutpet.co.kr"]
         PW["Playwright<br>크롤링"]
-        NAVER["네이버 DataLab API<br>트렌드 수집"]
-        AIRFLOW["Apache Airflow<br>DAG 오케스트레이션"]
-        DUCKDB["DuckDB<br>S3 Parquet 분석"]
+        PREPROCESS["전처리 파이프라인<br>Bronze → Silver → Gold"]
     end
 
     subgraph MONITORING["📊 Monitoring"]
@@ -79,12 +76,9 @@ flowchart TD
 
     %% 데이터 파이프라인
     PW --> ABOUTPET
-    PW --> S3
-    NAVER --> AIRFLOW
-    AIRFLOW --> S3
-    S3 --> PG
-    S3 --> QDRANT
-    S3 --> DUCKDB
+    PW --> PREPROCESS
+    PREPROCESS --> PG
+    PREPROCESS --> QDRANT
 
     %% 모니터링
     DJANGO --> LOKI
@@ -114,8 +108,8 @@ flowchart TD
     class DJANGO,FASTAPI backend
     class LANGGRAPH,LLM ai
     class YOLO,STT multimodal
-    class PG,QDRANT,S3 db
-    class ABOUTPET,PW,NAVER,AIRFLOW,DUCKDB pipeline
+    class PG,QDRANT db
+    class ABOUTPET,PW,PREPROCESS pipeline
     class PROM,LOKI,GRAFANA monitoring
     class JENKINS infra
 ```
@@ -161,24 +155,17 @@ flowchart TD
   Playwright
       │
       ▼
-[Bronze Layer]  S3 (Parquet) ── 원시 데이터 보존
+[Bronze]  원시 크롤링 데이터 (로컬 Parquet)
       │
       ▼
-[Silver Layer]  S3 (Parquet) ── 정제 · 정규화
+[Silver]  정제 · 정규화 (HTML 제거, 인코딩, 중복 제거)
       │
       ▼
-[Gold Layer]    S3 (Parquet) ── 메타데이터 증강
-  (알레르기 태그, 건강 관심사 매핑, 리뷰 감성 점수, LLM 요약)
+[Gold]    분석 및 추천 신호 파생
+  (OCR, 감성 분석, ABSA, popularity_score, trend_score, 건강 관심사 태그)
       │
       ├──► PostgreSQL  (관계형 서빙 DB)
       └──► Qdrant      (벡터 임베딩 인덱싱)
-
-[Airflow DAG]  트렌드 수집 오케스트레이션
-  daily_trend_dag    : 네이버 DataLab + 어바웃펫 인기 랭킹
-  weekly_review_dag  : 신규 리뷰 + 리뷰 급증 상품 감지
-  monthly_weight_dag : 계절성 가중치 갱신 + 추천 가중치 재계산
-
-[DuckDB]  S3 Parquet 분석 쿼리 (어드민 대시보드 · 데이터 분석)
 ```
 
 ---
@@ -188,7 +175,7 @@ flowchart TD
 ```
 [AWS]
   ├── EC2          앱 서버 (Docker Compose)
-  ├── S3           데이터 레이크 (Medallion Bronze/Silver/Gold)
+  ├── S3           이미지 스토리지 (펫 프로필, OCR 원본)
   ├── IAM          최소 권한 원칙
   └── Secrets Manager  API 키 · DB 접속 정보
 
@@ -199,7 +186,6 @@ flowchart TD
   ├── nginx        리버스 프록시 / LB
   ├── postgres     PostgreSQL 16
   ├── qdrant       Vector DB
-  ├── airflow      DAG 오케스트레이션
   ├── prometheus   메트릭 수집
   ├── grafana      모니터링 대시보드
   └── loki         로그 수집

--- a/docs/planning/03_requirements_spec.md
+++ b/docs/planning/03_requirements_spec.md
@@ -68,13 +68,11 @@
 | NFR-001 | 성능 | NF-PERF-03 | 브라우저 지원 | Chrome 최신, Safari 최신. 모바일 미지원 (프로토타입, 데스크탑 우선). |
 | NFR-002 | 데이터 수집 | NF-DATA-01 | 크롤링 대상 | 어바웃펫(aboutpet.co.kr) 전체 카테고리 (강아지/고양이, 소분류 98개). 수집 항목: 상품 정보, 평점, 리뷰, 원산지, 제조사. |
 | NFR-002 | 데이터 수집 | NF-DATA-02 | 크롤링 방식 | **Playwright** 사용 (JS 동적 렌더링 대응). 요청 간 딜레이 설정으로 서버 부하 방지. goodsId 기준 중복 제거. |
-| NFR-002 | 데이터 수집 | NF-DATA-03 | 데이터 갱신 주기 | 상품 데이터 갱신은 Playwright 크롤링 파이프라인에서 별도 처리. Airflow DAG는 트렌드 수집 전용으로 운영. |
-| NFR-002 | 데이터 수집 | NF-DATA-04 | 트렌드 수집 소스 | ① **어바웃펫 인기 랭킹** 크롤링 (Playwright, 상품 랭킹 변화 추적). ② **네이버 DataLab API** (공식 무료 API, 반려동물 검색어 트렌드). ③ **계절성** 날짜 기반 규칙 처리 (별도 수집 없음). |
-| NFR-002 | 데이터 수집 | NF-DATA-05 | 트렌드 DAG 구성 | `daily_trend_dag`: 네이버 DataLab + 어바웃펫 인기 랭킹. `weekly_review_dag`: 신규 리뷰 수집 + 리뷰 급증 상품 감지. `monthly_weight_dag`: 계절성 가중치 갱신 + 추천 가중치 재계산 → PostgreSQL / Qdrant 반영. |
+| NFR-002 | 데이터 수집 | NF-DATA-03 | 데이터 갱신 주기 | 상품 데이터 갱신은 Playwright 크롤링 파이프라인에서 별도 처리. |
 | NFR-003 | 데이터 전처리 | NF-PREP-01 | 텍스트 정제 | 크롤링 수집 데이터의 HTML 태그 제거, 특수문자 정규화, 인코딩 처리. |
 | NFR-003 | 데이터 전처리 | NF-PREP-02 | 리뷰 데이터 전처리 | 리뷰 텍스트 노이즈 제거, 중복 리뷰 필터링. 추천 모델 학습용 레이블링 전략 수립 필요 (시계열 판매 실적 데이터의 특정 기간 라벨링 여부 TBD). |
 | NFR-003 | 데이터 전처리 | NF-PREP-03 | 벡터 임베딩 | 상품 정보 + 리뷰 텍스트를 임베딩 모델로 벡터화하여 **Qdrant**에 인덱싱. Dense + Sparse 벡터 저장, Hybrid Search (RRF) RAG 검색에 활용. |
-| NFR-003 | 데이터 전처리 | NF-PREP-04 | 데이터 레이어 구조 (Medallion) | **Bronze → Silver → Gold** 3단계 레이어 구조 적용. Bronze: 원시 크롤링 데이터 (S3 Parquet). Silver: 정제·정규화 데이터. Gold: 메타데이터 증강 데이터 (성분 기반 알레르기 태그, 건강 관심사 매핑, 리뷰 감성 점수, LLM 요약 등). Airflow DAG 오케스트레이션. DuckDB로 S3 Parquet 직접 쿼리 (BigQuery 모방). |
+| NFR-003 | 데이터 전처리 | NF-PREP-04 | 데이터 전처리 레이어 (Medallion) | **Bronze → Silver → Gold** 3단계 전처리 파이프라인. Bronze: 원시 크롤링 데이터. Silver: 정제·정규화 (HTML 제거, 인코딩, 중복 제거). Gold: 분석 및 추천 신호 파생 (OCR, 감성 분석, ABSA, popularity_score, trend_score, 건강 관심사 태그). 결과물은 PostgreSQL 및 Qdrant에 직접 적재. |
 | NFR-004 | 추천 시스템 | NF-REC-01 | 추천 알고리즘 | Matrix Factorization (MF), Factorization Machines (FM), 딥러닝 기반 추천 모델 중 선택 또는 앙상블. 추천 시스템 조사 및 비교 후 결정. |
 | NFR-004 | 추천 시스템 | NF-REC-02 | 추천 입력 데이터 | 유저 프로필(종, 나이, 건강 관심사, 알레르기, 예산), 상품 리뷰 텍스트, 리뷰 평점 활용. |
 | NFR-004 | 추천 시스템 | NF-REC-03 | 추천 메타데이터 | 시계열 판매 실적 데이터, 클릭 로그, 클릭 후 구매 전환 로그를 추천 모델 보조 피처로 활용. |
@@ -90,7 +88,7 @@
 | NFR-007 | 모니터링 | NF-MON-01 | 시스템 모니터링 | Prometheus + Grafana를 활용하여 API 응답 시간, 서버 리소스, 에러율 등 전체 시스템 지표 수집 및 대시보드 시각화. |
 | NFR-007 | 모니터링 | NF-MON-02 | 로그 수집 및 검색 | **Grafana Loki** 활용. 애플리케이션 로그, LLM 요청/응답 로그, 추천 결과 로그 수집. Prometheus + Grafana와 동일 스택으로 통합 운영. OpenSearch 대비 메모리 사용량 대폭 절감. |
 | NFR-007 | 모니터링 | NF-MON-03 | LLM 품질 모니터링 | 사용자 질의응답 내역 리스트 조회. 응답 품질 좋아요/싫어요 집계. 어드민 페이지에서 확인 가능. |
-| NFR-007 | 모니터링 | NF-MON-04 | 데이터 파이프라인 모니터링 | Airflow DAG 실행 현황 및 실패 알림. 크롤링 수집량, 전처리 완료량 지표 추적. |
+| NFR-007 | 모니터링 | NF-MON-04 | 데이터 파이프라인 모니터링 | 크롤링 수집량, 전처리 완료량 지표 추적. |
 | NFR-007 | 모니터링 | NF-MON-05 | 보안 감사 로그 | 회원 탈퇴, 데이터 초기화, 주요 설정 변경 등 민감 액션에 대한 이력 관리. Loki에 별도 감사 로그 스트림으로 수집. |
 | NFR-008 | 보안 | NF-SEC-01 | 인증 및 세션 관리 | JWT 기반 인증. HTTPS 통신 필수. 토큰 만료 및 갱신 처리. 로그아웃 시 토큰 즉시 폐기. |
 | NFR-008 | 보안 | NF-SEC-02 | PII 마스킹 | 사용자 입력 및 LLM 응답 내 개인정보(이름·연락처·주소 등) 마스킹 처리. 로그에 PII 미포함. |
@@ -103,7 +101,7 @@
 | NFR-009 | 인프라 | NF-INFRA-05 | 부하 분산 (LB) | 트래픽 증가 시 챗봇 서비스 가용성 확보를 위한 로드 밸런싱 적용. **Nginx** 확정. |
 | NFR-009 | 인프라 | NF-INFRA-06 | 레이턴시 최적화 | RAG 기반 상품 추천 응답 속도 최적화. Qdrant 검색 + LLM 호출 구간별 타임아웃 관리. 병목 구간 프로파일링 및 캐싱 전략 수립. |
 | NFR-009 | 인프라 | NF-INFRA-02 | CI/CD | CI 전략 수립 (테스트 자동화 포함). CD는 Jenkins 또는 Crontab 기반 자동 배포. 전략 TBD. |
-| NFR-009 | 인프라 | NF-INFRA-03 | 데이터 파이프라인 오케스트레이션 | Apache Airflow를 활용한 DAG 기반 배치 파이프라인 운영. 일 배치 및 월 배치 스케줄 정의. |
+
 | NFR-011 | 데이터 관리 | NF-DM-01 | 실시간 데이터 동기화 | 반려동물 프로필 변경 시 챗봇 시스템 프롬프트에 실시간 반영. 프로필 업데이트 이벤트 발생 시 세션 컨텍스트 즉시 갱신. |
 | NFR-011 | 데이터 관리 | NF-DM-02 | 대화 이력 보존 및 요약 | 대화 세션별 토큰 제한 초과 시 이전 대화 요약본 저장 및 컨텍스트 유지. 요약 전략 및 Max Token 기준 TBD. |
 | NFR-011 | 데이터 관리 | NF-DM-03 | 구매 및 주문 데이터 정합성 | 구매 완료 후 주문 내역을 PostgreSQL에 안전하게 저장. 트랜잭션 처리 및 실패 시 롤백 보장. 주문 이력 조회 기능 제공. |
@@ -157,15 +155,13 @@
 |---|---|---|
 | PostgreSQL on EC2 (Docker) | 관계형 데이터 (user, pet, order, goods, review) | 확정 |
 | Qdrant | Vector DB, Hybrid Search (Dense + Sparse) + RRF | 확정 |
-| AWS S3 (Parquet) | 데이터 레이크 (Medallion Bronze / Silver / Gold) | 확정 |
+| AWS S3 | 이미지 스토리지 (펫 프로필, OCR 원본) | 확정 |
 
 ### Data Pipeline - 임도형
 
 | 기술 | 용도 | 상태 |
 |---|---|---|
 | Playwright | 어바웃펫 크롤링 | 확정 |
-| Apache Airflow | DAG 기반 트렌드 수집 오케스트레이션 | 확정 |
-| DuckDB | S3 Parquet 분석 쿼리 (BigQuery 모방) | 확정 |
 
 ### Infra / DevOps - 임도형
 


### PR DESCRIPTION
## Summary

- `docs/data/02_data_collection_issues.md`: Airflow stub 이슈 제거, Phase 구분 표 수정, S3 → 로컬 파이프라인으로 변경
- `docs/data/03_medallion_schema.md`: S3 Medallion 제목·설명 제거, 경로 `s3://bucket/` → `data/`
- `docs/planning/02_system_architecture.md`: 아키텍처 다이어그램에서 S3, Airflow, DuckDB 제거
- `docs/planning/03_requirements_spec.md`: Airflow DAG 관련 요구사항 항목 제거

## 배경

프로토타입 단계에서 S3 Medallion 데이터 레이크 및 Airflow ETL을 사용하지 않기로 결정.
Bronze → Silver → Gold 전처리 단계는 로컬 Parquet 기반으로만 운영.

Closes #83