### PR TITLE
[chore] Docker Hub 빌드 파이프라인 적용 및 jenkins 제거

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -27,7 +27,7 @@ jobs:
           cat <<'EOF' > infra/.env
           DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_DEBUG=False
-          DJANGO_ALLOWED_HOSTS=localhost,tailtalk.leemdo.com,3.38.220.193
+          DJANGO_ALLOWED_HOSTS=localhost,tailtalk.leemdo.com
           POSTGRES_DB=${{ secrets.POSTGRES_DB }}
           POSTGRES_USER=${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
@@ -48,8 +48,8 @@ jobs:
         if: always()
         run: docker compose -f infra/docker-compose.yml down -v
 
-  deploy:
-    name: Deploy to EC2
+  push-images:
+    name: Push Images to Docker Hub
     needs: build-and-test
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
@@ -58,16 +58,57 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & Push Django
+        uses: docker/build-push-action@v6
+        with:
+          context: services/django
+          platforms: linux/amd64
+          push: true
+          tags: leemdo/tailtalk-django:latest
+
+      - name: Build & Push FastAPI
+        uses: docker/build-push-action@v6
+        with:
+          context: services/fastapi
+          platforms: linux/amd64
+          push: true
+          tags: leemdo/tailtalk-fastapi:latest
+
+      - name: Build & Push Frontend
+        uses: docker/build-push-action@v6
+        with:
+          context: services/frontend
+          platforms: linux/amd64
+          push: true
+          tags: leemdo/tailtalk-frontend:latest
+
+  deploy:
+    name: Deploy to EC2
+    needs: push-images
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
       - name: Deploy via SSH
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USER }}
           key: ${{ secrets.EC2_SSH_KEY }}
-          command_timeout: 20m
+          command_timeout: 8m
           script: |
             cd ~/SKN22-Final-2Team-WEB
             git pull origin main
-            docker compose -f infra/docker-compose.yml up -d --build
-            docker compose -f infra/docker-compose.yml exec django python manage.py migrate --noinput
-            docker compose -f infra/docker-compose.yml exec django python manage.py collectstatic --noinput
+            docker compose -f infra/docker-compose.yml pull
+            docker compose -f infra/docker-compose.yml up -d
+            docker compose -f infra/docker-compose.yml exec -T django python manage.py migrate --noinput
+            docker compose -f infra/docker-compose.yml exec -T django python manage.py collectstatic --noinput

--- a/docs/infra/00_getting_started.md
+++ b/docs/infra/00_getting_started.md
@@ -213,9 +213,36 @@ docker compose up -d
 
 ## 8. CI/CD
 
-PR을 `develop`에 올리면 **자동으로 Build & Test**가 실행된다.
-`main`에 머지되면 **EC2 자동 배포**까지 진행된다.
+### 흐름
 
-- 배포 주소: http://tailtalk.leemdo.com
+```
+코드 push / PR
+  │
+  ▼
+[GitHub Actions] Build & Test
+  │  develop, main 모두 실행
+  │
+  ▼ (main push 시에만)
+[GitHub Actions] Docker Hub push
+  │  leemdo/tailtalk-django:latest
+  │  leemdo/tailtalk-fastapi:latest
+  │  leemdo/tailtalk-frontend:latest
+  │
+  ▼
+[EC2] docker pull → docker compose up -d
+```
+
+> 빌드는 GitHub Actions에서 수행. EC2는 이미지 pull + 실행만 한다.
+
+### 트리거
+
+| 이벤트 | 브랜치 | 실행 |
+|---|---|---|
+| `push` / `pull_request` | `develop` | Build & Test |
+| `push` | `main` | Build & Test → Docker Hub push → EC2 배포 |
+
+### 배포 주소
+
+- http://tailtalk.leemdo.com
 
 상세 내용: `docs/infra/04_github_actions_guide.md`

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -87,21 +87,6 @@ services:
       - "6333"
     restart: unless-stopped
 
-  # ── Jenkins (CI/CD) ──────────────────────────────────────────────────────────
-  jenkins:
-    image: jenkins/jenkins:lts
-    platform: linux/amd64
-    volumes:
-      - jenkins_data:/var/jenkins_home
-      - /var/run/docker.sock:/var/run/docker.sock  # 호스트 Docker 제어
-    environment:
-      - JAVA_OPTS=-Djenkins.install.runSetupWizard=false
-    expose:
-      - "8080"
-    restart: unless-stopped
-
-
 volumes:
   postgres_data:
   qdrant_data:
-  jenkins_data:

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -18,6 +18,7 @@ services:
 
   # ── Django (Auth / User / Pet / Order / Admin) ───────────────────────────────
   django:
+    image: leemdo/tailtalk-django:latest
     build: ../services/django
     platform: linux/amd64
     command: >
@@ -33,6 +34,7 @@ services:
 
   # ── FastAPI (챗봇 / 추천) ────────────────────────────────────────────────────
   fastapi:
+    image: leemdo/tailtalk-fastapi:latest
     build: ../services/fastapi
     platform: linux/amd64
     command: uvicorn main:app --host 0.0.0.0 --port 8001 --workers 2
@@ -48,6 +50,7 @@ services:
 
   # ── Next.js ──────────────────────────────────────────────────────────────────
   frontend:
+    image: leemdo/tailtalk-frontend:latest
     build: ../services/frontend
     platform: linux/amd64
     expose:


### PR DESCRIPTION
## Summary

- GitHub Actions에서 이미지 빌드 후 Docker Hub push, EC2는 pull만 하도록 변경
- jenkins 서비스 docker-compose에서 제거 (필요시 추가 예정)
- docs/infra/00_getting_started.md CI/CD 흐름 추가