### PR TITLE
[feat] MVT 전환 — Next.js 제거 및 nginx/CI 인프라 정리 (#117)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -82,14 +82,6 @@ jobs:
           push: true
           tags: leemdo/tailtalk-fastapi:latest
 
-      - name: Build & Push Frontend
-        uses: docker/build-push-action@v6
-        with:
-          context: services/frontend
-          platforms: linux/amd64
-          push: true
-          tags: leemdo/tailtalk-frontend:latest
-
   deploy:
     name: Deploy to EC2
     needs: push-images

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -13,7 +13,6 @@ services:
     depends_on:
       - django
       - fastapi
-      - frontend
     restart: unless-stopped
 
   # ── Django (Auth / User / Pet / Order / Admin) ───────────────────────────────
@@ -46,15 +45,6 @@ services:
         condition: service_healthy
       qdrant:
         condition: service_started
-    restart: unless-stopped
-
-  # ── Next.js ──────────────────────────────────────────────────────────────────
-  frontend:
-    image: leemdo/tailtalk-frontend:latest
-    build: ../services/frontend
-    platform: linux/amd64
-    expose:
-      - "3000"
     restart: unless-stopped
 
   # ── PostgreSQL 16 ────────────────────────────────────────────────────────────

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -7,10 +7,6 @@ http {
         server fastapi:8001;
     }
 
-    upstream frontend {
-        server frontend:3000;
-    }
-
     server {
         listen 80;
         server_name _;
@@ -51,13 +47,11 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
         }
 
-        # Next.js — Frontend
+        # Django — Template (MVT)
         location / {
-            proxy_pass http://frontend;
+            proxy_pass http://django;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
         }
     }
 }


### PR DESCRIPTION
## 요약

MVT 패턴 전환(#116)의 1단계 — Next.js 관련 인프라를 제거하고 모든 트래픽을 Django로 라우팅합니다.

## 변경 사항

- `infra/docker-compose.yml`: `frontend` 서비스 제거
- `infra/nginx/nginx.conf`: `location /` → `django:8000` (Django Template 서빙)
- `.github/workflows/ci-cd.yml`: Frontend 이미지 빌드/푸시 단계 제거

## 참고

- `services/frontend/` 디렉토리는 Django 템플릿 포팅 참고용으로 유지, 포팅 완료 후 삭제 예정
- 페이지 인증: Django Session / FastAPI 연동: JWT 유지

## 관련 이슈

closes #117
ref #116