### PR TITLE
[feat] Django 템플릿 기본 설정 — settings, urls, static (#118)

### DIFF
--- a/services/django/chat/page_urls.py
+++ b/services/django/chat/page_urls.py
@@ -1,0 +1,6 @@
+from django.urls import path
+from . import page_views
+
+urlpatterns = [
+    path("chat/", page_views.chat_view, name="chat"),
+]

--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,0 +1,5 @@
+from django.shortcuts import render
+
+
+def chat_view(request):
+    return render(request, "chat/index.html")

--- a/services/django/config/settings.py
+++ b/services/django/config/settings.py
@@ -44,7 +44,7 @@ ROOT_URLCONF = "config.urls"
 TEMPLATES = [
     {
         "BACKEND": "django.template.backends.django.DjangoTemplates",
-        "DIRS": [],
+        "DIRS": [BASE_DIR / "templates"],
         "APP_DIRS": True,
         "OPTIONS": {
             "context_processors": [
@@ -99,6 +99,14 @@ USE_I18N = True
 USE_TZ = True
 
 STATIC_URL = "/static/"
+STATICFILES_DIRS = [BASE_DIR / "static"]
 STATIC_ROOT = BASE_DIR / "staticfiles"
+
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
+
+LOGIN_URL = "/login/"
+LOGIN_REDIRECT_URL = "/"
+LOGOUT_REDIRECT_URL = "/login/"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/services/django/config/urls.py
+++ b/services/django/config/urls.py
@@ -1,12 +1,28 @@
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 
 urlpatterns = [
+    # ── Admin ────────────────────────────────────────────────────────────────
     path("admin/", admin.site.urls),
+
+    # ── API — Auth ────────────────────────────────────────────────────────────
     path("api/auth/token/", TokenObtainPairView.as_view(), name="token_obtain_pair"),
     path("api/auth/token/refresh/", TokenRefreshView.as_view(), name="token_refresh"),
+
+    # ── API — Resources ───────────────────────────────────────────────────────
     path("api/users/", include("users.urls")),
     path("api/pets/", include("pets.urls")),
     path("api/orders/", include("orders.urls")),
+
+    # ── Pages (MVT) ───────────────────────────────────────────────────────────
+    path("", include("users.page_urls")),
+    path("", include("pets.page_urls")),
+    path("", include("chat.page_urls")),
+    path("", include("orders.page_urls")),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/services/django/orders/page_urls.py
+++ b/services/django/orders/page_urls.py
@@ -1,0 +1,7 @@
+from django.urls import path
+from . import page_views
+
+urlpatterns = [
+    path("orders/", page_views.order_list, name="order_list"),
+    path("products/", page_views.used_products, name="used_products"),
+]

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,0 +1,12 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import render
+
+
+@login_required
+def order_list(request):
+    return render(request, "orders/list.html")
+
+
+@login_required
+def used_products(request):
+    return render(request, "orders/products.html")

--- a/services/django/pets/page_urls.py
+++ b/services/django/pets/page_urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from . import page_views
+
+urlpatterns = [
+    path("pets/", page_views.pet_list, name="pet_list"),
+    path("pets/add/", page_views.pet_add, name="pet_add"),
+    path("pets/<int:pet_id>/edit/", page_views.pet_edit, name="pet_edit"),
+]

--- a/services/django/pets/page_views.py
+++ b/services/django/pets/page_views.py
@@ -1,0 +1,21 @@
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import get_object_or_404, render
+
+from .models import Pet
+
+
+@login_required
+def pet_list(request):
+    pets = Pet.objects.filter(user=request.user)
+    return render(request, "pets/list.html", {"pets": pets})
+
+
+@login_required
+def pet_add(request):
+    return render(request, "pets/form.html")
+
+
+@login_required
+def pet_edit(request, pet_id):
+    pet = get_object_or_404(Pet, id=pet_id, user=request.user)
+    return render(request, "pets/form.html", {"pet": pet})

--- a/services/django/static/css/main.css
+++ b/services/django/static/css/main.css
@@ -1,0 +1,10 @@
+/* TailTalk — global styles */
+* {
+  box-sizing: border-box;
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+}

--- a/services/django/static/js/main.js
+++ b/services/django/static/js/main.js
@@ -1,0 +1,1 @@
+// TailTalk — global JS

--- a/services/django/templates/base.html
+++ b/services/django/templates/base.html
@@ -1,0 +1,17 @@
+{% load static %}
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>{% block title %}TailTalk{% endblock %}</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="{% static 'css/main.css' %}" />
+  {% block head %}{% endblock %}
+</head>
+<body class="antialiased bg-white text-gray-800">
+  {% block content %}{% endblock %}
+  <script src="{% static 'js/main.js' %}"></script>
+  {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: chat/index.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/orders/list.html
+++ b/services/django/templates/orders/list.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: orders/list.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: orders/products.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/pets/form.html
+++ b/services/django/templates/pets/form.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: pets/form.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: pets/list.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: users/login.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: users/profile.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -1,0 +1,5 @@
+{% extends "base.html" %}
+{% block title %}TailTalk{% endblock %}
+{% block content %}
+<!-- TODO: users/signup.html 포팅 (#119~#121) -->
+{% endblock %}

--- a/services/django/users/page_urls.py
+++ b/services/django/users/page_urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from . import page_views
+
+urlpatterns = [
+    path("", page_views.home, name="home"),
+    path("login/", page_views.login_view, name="login"),
+    path("signup/", page_views.signup_view, name="signup"),
+    path("logout/", page_views.logout_view, name="logout"),
+    path("profile/", page_views.profile_view, name="profile"),
+]

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -1,0 +1,31 @@
+from django.contrib.auth import logout
+from django.contrib.auth.decorators import login_required
+from django.shortcuts import redirect, render
+
+
+def home(request):
+    if request.user.is_authenticated:
+        return redirect("chat")
+    return render(request, "chat/index.html")
+
+
+def login_view(request):
+    if request.user.is_authenticated:
+        return redirect("chat")
+    return render(request, "users/login.html")
+
+
+def signup_view(request):
+    if request.user.is_authenticated:
+        return redirect("chat")
+    return render(request, "users/signup.html")
+
+
+def logout_view(request):
+    logout(request)
+    return redirect("login")
+
+
+@login_required
+def profile_view(request):
+    return render(request, "users/profile.html")


### PR DESCRIPTION
## 요약

MVT 전환(#116) 2단계 — Django 템플릿 서빙을 위한 기반 설정.

## 변경 사항

**settings.py**
- `TEMPLATES.DIRS`: `templates/` 디렉토리 등록
- `STATICFILES_DIRS`: `static/` 디렉토리 등록
- `MEDIA_URL` / `MEDIA_ROOT` 추가
- `LOGIN_URL`, `LOGIN_REDIRECT_URL`, `LOGOUT_REDIRECT_URL` 추가

**config/urls.py**
- 각 앱의 `page_urls.py` 연결 (페이지 라우팅 분리)
- DEBUG 환경 MEDIA 파일 서빙 추가

**page_urls.py / page_views.py** (users, pets, chat, orders)
- 페이지별 URL 및 뷰 스텁 생성
- `@login_required` 데코레이터 적용

**templates/**
- `base.html`: Tailwind CDN 포함 공통 레이아웃
- 페이지별 스텁 템플릿 (실제 UI는 #119~#121에서 포팅)

**static/**
- `css/main.css`, `js/main.js` 기본 파일

## 관련 이슈

closes #118
ref #116