### PR TITLE
[feat] 인증 UI 템플릿 포팅 — 로그인 / 회원가입 (#119)

### DIFF
--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -1,5 +1,99 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}로그인 — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: users/login.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="relative h-screen w-full overflow-hidden bg-[#f7fafc] flex items-center justify-center">
+
+    <div class="relative w-[400px]">
+
+      <!-- 로고 -->
+      <div class="mb-6 text-center text-[26px] font-bold text-[#2d3748]">
+        <a href="/"><span class="text-[#3182ce]">Tail</span><span>Talk</span></a>
+      </div>
+
+      <!-- 카드 -->
+      <div class="rounded-xl bg-white shadow-md px-10 py-8">
+
+        <!-- 이메일 로그인 폼 -->
+        <form method="post" id="login-form">
+          {% csrf_token %}
+          <input type="hidden" name="remember_me" id="rememberMeInput" value="on" />
+          {% if error %}
+          <p class="mb-2 text-center text-[12px] text-red-500">{{ error }}</p>
+          {% endif %}
+          <input type="email" name="email" placeholder="이메일" required
+                 class="mb-2 w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+          <input type="password" name="password" placeholder="비밀번호" required
+                 class="w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+        </form>
+
+        <!-- 간편 로그인 구분선 -->
+        <div class="my-4 flex items-center gap-2">
+          <div class="h-[1px] flex-1 bg-[#e2e8f0]"></div>
+          <span class="text-[12px] text-[#a0aec0]">간편 로그인</span>
+          <div class="h-[1px] flex-1 bg-[#e2e8f0]"></div>
+        </div>
+
+        <!-- 소셜 버튼 -->
+        <div class="flex justify-center gap-4">
+          <a href="/api/auth/social/kakao/" aria-label="카카오 로그인">
+            <img alt="카카오" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
+          </a>
+          <a href="/api/auth/social/naver/" aria-label="네이버 로그인">
+            <img alt="네이버" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
+          </a>
+          <a href="/api/auth/social/google/" aria-label="구글 로그인">
+            <img alt="구글" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
+          </a>
+        </div>
+
+        <!-- 하단: 로그인 상태 유지 + 로그인 버튼 -->
+        <div class="mt-4 flex items-center justify-between">
+          <label class="flex cursor-pointer items-center gap-2 text-[13px] text-[#4a5568]" id="rememberLabel">
+            <span id="checkboxIcon"
+                  class="flex h-[18px] w-[18px] items-center justify-center rounded border border-[#3182ce] bg-white">
+              <span id="checkmark" class="text-[10px] font-bold text-[#3182ce]">✓</span>
+            </span>
+            로그인 상태 유지
+          </label>
+          <button type="submit" form="login-form"
+                  class="rounded bg-[#3182ce] px-5 py-2 text-[13px] font-medium text-white hover:bg-[#2b6cb0]">
+            로그인
+          </button>
+        </div>
+
+      </div>
+
+      <!-- 회원가입 링크 -->
+      <p class="mt-4 text-center text-[13px] text-[#718096]">
+        계정이 없으신가요?
+        <a href="/signup/" class="text-[#3182ce] hover:underline">회원가입</a>
+      </p>
+
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    let checked = true;
+    const label = document.getElementById('rememberLabel');
+    const icon = document.getElementById('checkboxIcon');
+    const mark = document.getElementById('checkmark');
+    const input = document.getElementById('rememberMeInput');
+
+    label.addEventListener('click', function () {
+      checked = !checked;
+      input.value = checked ? 'on' : '';
+      mark.style.display = checked ? 'block' : 'none';
+      icon.style.borderColor = checked ? '#3182ce' : '#cbd5e0';
+    });
+  })();
+</script>
 {% endblock %}

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -1,5 +1,102 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}회원가입 — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: users/signup.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="relative h-screen w-full overflow-hidden bg-[#f7fafc] flex items-center justify-center">
+
+    <div class="relative w-[400px]">
+
+      <!-- 로고 -->
+      <div class="mb-6 text-center text-[26px] font-bold text-[#2d3748]">
+        <a href="/"><span class="text-[#3182ce]">Tail</span><span>Talk</span></a>
+      </div>
+
+      <!-- 카드 -->
+      <div class="rounded-xl bg-white shadow-md px-10 py-8">
+
+        <form method="post" id="signup-form">
+          {% csrf_token %}
+          {% if error %}
+          <p class="mb-2 text-center text-[12px] text-red-500">{{ error }}</p>
+          {% endif %}
+          <input type="text" name="nickname" placeholder="닉네임" required
+                 class="mb-2 w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+          <input type="email" name="email" placeholder="이메일" required
+                 class="mb-2 w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+          <input type="password" name="password" placeholder="비밀번호" required id="pw1"
+                 class="mb-2 w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+          <input type="password" name="password2" placeholder="비밀번호 확인" required id="pw2"
+                 class="w-full rounded border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2 text-[13px] text-[#2d3748] outline-none focus:border-[#3182ce]" />
+          <p id="pwError" class="mt-1 hidden text-[11px] text-red-500">비밀번호가 일치하지 않습니다.</p>
+        </form>
+
+        <!-- 간편 가입 구분선 -->
+        <div class="my-4 flex items-center gap-2">
+          <div class="h-[1px] flex-1 bg-[#e2e8f0]"></div>
+          <span class="text-[12px] text-[#a0aec0]">간편 로그인으로 가입</span>
+          <div class="h-[1px] flex-1 bg-[#e2e8f0]"></div>
+        </div>
+
+        <!-- 소셜 버튼 -->
+        <div class="flex justify-center gap-4">
+          <a href="/api/auth/social/kakao/" aria-label="카카오 로그인">
+            <img alt="카카오" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
+          </a>
+          <a href="/api/auth/social/naver/" aria-label="네이버 로그인">
+            <img alt="네이버" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
+          </a>
+          <a href="/api/auth/social/google/" aria-label="구글 로그인">
+            <img alt="구글" class="h-[40px] w-[40px]"
+                 src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
+          </a>
+        </div>
+
+        <!-- 가입 버튼 -->
+        <div class="mt-4 flex justify-end">
+          <button type="submit" form="signup-form" id="submitBtn"
+                  class="rounded bg-[#3182ce] px-5 py-2 text-[13px] font-medium text-white hover:bg-[#2b6cb0]">
+            회원가입
+          </button>
+        </div>
+
+      </div>
+
+      <!-- 로그인 링크 -->
+      <p class="mt-4 text-center text-[13px] text-[#718096]">
+        이미 계정이 있으신가요?
+        <a href="/login/" class="text-[#3182ce] hover:underline">로그인</a>
+      </p>
+
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    const pw1 = document.getElementById('pw1');
+    const pw2 = document.getElementById('pw2');
+    const pwError = document.getElementById('pwError');
+    const form = document.getElementById('signup-form');
+
+    function checkPw() {
+      const mismatch = pw2.value && pw1.value !== pw2.value;
+      pwError.classList.toggle('hidden', !mismatch);
+    }
+
+    pw1.addEventListener('input', checkPw);
+    pw2.addEventListener('input', checkPw);
+
+    form.addEventListener('submit', function (e) {
+      if (pw1.value !== pw2.value) {
+        e.preventDefault();
+        pwError.classList.remove('hidden');
+      }
+    });
+  })();
+</script>
 {% endblock %}

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -1,6 +1,8 @@
-from django.contrib.auth import logout
+from django.contrib.auth import authenticate, get_user_model, login, logout
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
+
+User = get_user_model()
 
 
 def home(request):
@@ -12,13 +14,43 @@ def home(request):
 def login_view(request):
     if request.user.is_authenticated:
         return redirect("chat")
-    return render(request, "users/login.html")
+
+    error = None
+    if request.method == "POST":
+        email = request.POST.get("email", "").strip()
+        password = request.POST.get("password", "")
+        remember_me = request.POST.get("remember_me") == "on"
+        user = authenticate(request, username=email, password=password)
+        if user is not None:
+            login(request, user)
+            if not remember_me:
+                request.session.set_expiry(0)
+            return redirect(request.GET.get("next", "chat"))
+        error = "이메일 또는 비밀번호가 올바르지 않습니다."
+
+    return render(request, "users/login.html", {"error": error})
 
 
 def signup_view(request):
     if request.user.is_authenticated:
         return redirect("chat")
-    return render(request, "users/signup.html")
+
+    error = None
+    if request.method == "POST":
+        email = request.POST.get("email", "").strip()
+        password = request.POST.get("password", "")
+        nickname = request.POST.get("nickname", "").strip()
+        if User.objects.filter(email=email).exists():
+            error = "이미 사용 중인 이메일입니다."
+        else:
+            user = User.objects.create_user(username=email, email=email, password=password)
+            if nickname:
+                user.nickname = nickname
+                user.save(update_fields=["nickname"])
+            login(request, user)
+            return redirect("chat")
+
+    return render(request, "users/signup.html", {"error": error})
 
 
 def logout_view(request):


### PR DESCRIPTION
## 요약

MVT 전환(#116) 3단계 — 로그인 / 회원가입 페이지 Django Template 포팅.

## 변경 사항

**users/page_views.py**
- `login_view`: POST 처리 추가 (이메일+비밀번호 인증, remember_me 세션 만료 제어)
- `signup_view`: POST 처리 추가 (이메일 회원가입, 중복 체크)

**templates/users/login.html**
- 이메일 로그인 폼 + 소셜 로그인 (카카오/네이버/구글)
- "로그인 상태 유지" 체크박스 — Vanilla JS 토글
- 에러 메시지 표시

**templates/users/signup.html**
- 닉네임/이메일/비밀번호 회원가입 폼 + 소셜 가입 버튼
- 비밀번호 확인 불일치 — Vanilla JS 실시간 검증

## 관련 이슈

closes #119
ref #116