### PR TITLE
[feat] 프로필 / 반려동물 UI 템플릿 포팅 (#121)

### DIFF
--- a/services/django/pets/page_views.py
+++ b/services/django/pets/page_views.py
@@ -1,7 +1,13 @@
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from .models import Pet
+
+SPECIES_OPTIONS = [
+    ("dog", "강아지", "🐶"),
+    ("cat", "고양이", "🐱"),
+    ("future", "예비 집사", "🏠"),
+]
 
 
 @login_required
@@ -12,10 +18,37 @@ def pet_list(request):
 
 @login_required
 def pet_add(request):
-    return render(request, "pets/form.html")
+    if request.method == "POST":
+        species = request.POST.get("species")
+        if species not in ("dog", "cat"):
+            return redirect("pet_add")
+        Pet.objects.create(
+            user=request.user,
+            species=species,
+            name=request.POST.get("name", "").strip(),
+            breed=request.POST.get("breed", "").strip() or None,
+            gender=request.POST.get("gender", "male"),
+            age_years=int(request.POST.get("age_years", 0) or 0),
+            age_months=int(request.POST.get("age_months", 0) or 0),
+            weight_kg=request.POST.get("weight_kg") or None,
+            neutered={"yes": True, "no": False}.get(request.POST.get("neutered")),
+            budget_range="",
+        )
+        return redirect("pet_list")
+    return render(request, "pets/form.html", {"species_options": SPECIES_OPTIONS})
 
 
 @login_required
 def pet_edit(request, pet_id):
-    pet = get_object_or_404(Pet, id=pet_id, user=request.user)
-    return render(request, "pets/form.html", {"pet": pet})
+    pet = get_object_or_404(Pet, pet_id=pet_id, user=request.user)
+    if request.method == "POST":
+        pet.name = request.POST.get("name", "").strip()
+        pet.breed = request.POST.get("breed", "").strip() or None
+        pet.gender = request.POST.get("gender", "male")
+        pet.age_years = int(request.POST.get("age_years", 0) or 0)
+        pet.age_months = int(request.POST.get("age_months", 0) or 0)
+        pet.weight_kg = request.POST.get("weight_kg") or None
+        pet.neutered = {"yes": True, "no": False}.get(request.POST.get("neutered"))
+        pet.save()
+        return redirect("pet_list")
+    return render(request, "pets/form.html", {"pet": pet, "species_options": SPECIES_OPTIONS})

--- a/services/django/templates/pets/form.html
+++ b/services/django/templates/pets/form.html
@@ -1,5 +1,241 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}{% if pet %}반려동물 수정{% else %}반려동물 등록{% endif %} — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: pets/form.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+<div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
+
+  <a href="/chat/" class="absolute left-8 top-8 text-[26px] font-bold leading-none text-[#2d3748]">
+    <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+  </a>
+
+  <div class="w-full max-w-[860px] rounded-[20px] border border-[#dbe7f5] bg-white px-8 py-8 shadow-[0_6px_20px_rgba(45,55,72,0.04)]">
+
+    <!-- 진행 바 -->
+    <div class="h-[5px] w-full rounded-full bg-[#e2e8f0]">
+      <div id="progressBar" class="h-full rounded-full bg-[#3182ce] transition-all duration-300"
+           style="width: {% if pet %}100%{% else %}50%{% endif %}"></div>
+    </div>
+
+    <div class="mt-6 text-[14px] font-bold text-[#3182ce]" id="stepLabel">
+      {% if pet %}수정{% else %}STEP 1 / 2{% endif %}
+    </div>
+    <h1 class="mt-2 text-[28px] font-bold leading-[1.3] text-[#2d3748]" id="stepTitle">
+      {% if pet %}아이의 정보를 수정해 주세요{% else %}어떤 반려동물과 함께하고 계신가요?{% endif %}
+    </h1>
+    <p class="mt-3 text-[16px] text-[#718096]" id="stepDesc">
+      {% if pet %}정확한 맞춤형 케어를 위해 빈칸을 채워주세요.{% else %}원하는 동물을 클릭하여 추가해 주세요. (최대 5마리){% endif %}
+    </p>
+
+    <form method="post" id="petForm">
+      {% csrf_token %}
+
+      <!-- STEP 1: 종류 선택 -->
+      <div id="step1" {% if pet %}style="display:none"{% endif %}>
+        <p class="mt-1 text-[14px] text-[#e53e3e]">※ 필수 입력 단계입니다.</p>
+        <div class="mt-8 grid grid-cols-3 gap-5">
+          {% for value, label, emoji in species_options %}
+          <button type="button"
+                  class="species-btn flex h-[160px] flex-col items-center justify-center rounded-[14px] border border-[#e2e8f0] bg-white transition-all duration-150 hover:border-[#90cdf4] hover:bg-[#fbfdff]"
+                  data-value="{{ value }}" onclick="selectSpecies('{{ value }}')">
+            <div class="flex h-[56px] w-[56px] items-center justify-center rounded-full bg-[#edf2f7] text-[24px]">{{ emoji }}</div>
+            <div class="mt-6 text-[18px] font-bold text-[#4a5568]">{{ label }}</div>
+          </button>
+          {% endfor %}
+        </div>
+        <button type="button" id="toStep2Btn" disabled
+                onclick="goToStep2()"
+                class="mt-8 flex h-[48px] w-full items-center justify-center rounded-[10px] text-[16px] font-bold bg-[#cbd5e0] text-white transition-colors">
+          다음 단계로 (기본 정보 입력)
+        </button>
+      </div>
+
+      <!-- STEP 2: 기본 정보 -->
+      <div id="step2" {% if not pet %}style="display:none"{% endif %}>
+        <input type="hidden" name="species" id="speciesInput" value="{{ pet.species|default:'' }}" />
+
+        <!-- 종 탭 (수정 모드에서는 고정) -->
+        {% if not pet %}
+        <div class="mt-6 flex border-b border-[#e2e8f0]" id="speciesTabs">
+          <button type="button" id="tabDog"
+                  class="relative flex h-[44px] min-w-[120px] items-center justify-center gap-2 text-[16px] font-bold text-[#3182ce]"
+                  onclick="switchSpeciesTab('dog')">
+            <span>🐶</span><span>강아지</span>
+            <span id="tabDogLine" class="absolute bottom-[-1px] left-0 h-[3px] w-full rounded-full bg-[#3182ce]"></span>
+          </button>
+          <button type="button" id="tabCat"
+                  class="relative flex h-[44px] min-w-[120px] items-center justify-center gap-2 text-[16px] font-bold text-[#a0aec0] hover:text-[#4a5568]"
+                  onclick="switchSpeciesTab('cat')">
+            <span>🐱</span><span>고양이</span>
+            <span id="tabCatLine" class="absolute bottom-[-1px] left-0 h-[3px] w-full rounded-full bg-[#3182ce] opacity-0"></span>
+          </button>
+        </div>
+        {% endif %}
+
+        <div class="mt-8 grid grid-cols-2 gap-x-7 gap-y-5">
+          <!-- 이름 -->
+          <div>
+            <label class="text-[14px] font-bold text-[#4a5568]">이름 <span class="text-[#e53e3e]">(필수)</span></label>
+            <input name="name" value="{{ pet.name|default:'' }}" required
+                   placeholder="반려동물의 이름을 입력해주세요"
+                   class="mt-2 h-[40px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[14px] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+          </div>
+          <!-- 품종 -->
+          <div>
+            <label class="text-[14px] font-bold text-[#4a5568]">품종 <span class="text-[#a0aec0]">(선택)</span></label>
+            <input name="breed" value="{{ pet.breed|default:'' }}"
+                   placeholder="품종을 검색해주세요"
+                   class="mt-2 h-[40px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[14px] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+          </div>
+          <!-- 성별 -->
+          <div>
+            <div class="text-[14px] font-bold text-[#4a5568]">성별 <span class="text-[#e53e3e]">(필수)</span></div>
+            <div class="mt-2 flex gap-2">
+              <button type="button" id="genderMale"
+                      class="gender-btn flex h-[40px] flex-1 items-center justify-center rounded-[8px] border text-[14px] font-bold transition-colors {% if pet.gender == 'male' or not pet %}border-[#3182ce] bg-[#ebf8ff] text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}"
+                      onclick="selectGender('male')">수컷 (남아)</button>
+              <button type="button" id="genderFemale"
+                      class="gender-btn flex h-[40px] flex-1 items-center justify-center rounded-[8px] border text-[14px] font-bold transition-colors {% if pet.gender == 'female' %}border-[#3182ce] bg-[#ebf8ff] text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}"
+                      onclick="selectGender('female')">암컷 (여아)</button>
+              <input type="hidden" name="gender" id="genderInput" value="{{ pet.gender|default:'male' }}" />
+            </div>
+          </div>
+          <!-- 나이 -->
+          <div>
+            <div class="text-[14px] font-bold text-[#4a5568]">나이 <span class="text-[#e53e3e]">(필수)</span></div>
+            <div class="mt-2 flex items-center gap-2">
+              <input name="age_years" type="number" min="0" max="30" value="{{ pet.age_years|default:'0' }}" required
+                     class="h-[40px] w-[90px] rounded-[8px] border border-[#e2e8f0] px-3 text-center text-[14px] outline-none focus:border-[#90cdf4]" />
+              <span class="text-[14px] text-[#4a5568]">년</span>
+              <input name="age_months" type="number" min="0" max="11" value="{{ pet.age_months|default:'0' }}" required
+                     class="h-[40px] w-[86px] rounded-[8px] border border-[#e2e8f0] px-3 text-center text-[14px] outline-none focus:border-[#90cdf4]" />
+              <span class="text-[14px] text-[#4a5568]">개월</span>
+            </div>
+          </div>
+          <!-- 체중 -->
+          <div>
+            <label class="text-[14px] font-bold text-[#4a5568]">체중 <span class="text-[#a0aec0]">(선택)</span></label>
+            <div class="relative mt-2">
+              <input name="weight_kg" type="number" step="0.1" min="0" value="{{ pet.weight_kg|default:'' }}"
+                     placeholder="체중 입력"
+                     class="h-[40px] w-full rounded-[8px] border border-[#e2e8f0] px-3 pr-10 text-[14px] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+              <span class="absolute right-3 top-1/2 -translate-y-1/2 text-[14px] text-[#4a5568]">kg</span>
+            </div>
+          </div>
+          <!-- 중성화 -->
+          <div>
+            <div class="text-[14px] font-bold text-[#4a5568]">중성화 여부 <span class="text-[#a0aec0]">(선택)</span></div>
+            <div class="mt-2 flex gap-2">
+              <button type="button" id="neuteredYes"
+                      class="neuter-btn flex h-[40px] flex-1 items-center justify-center rounded-[8px] border text-[14px] font-bold transition-colors {% if pet.neutered == True %}border-[#3182ce] bg-[#ebf8ff] text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}"
+                      onclick="selectNeutered('yes')">예</button>
+              <button type="button" id="neuteredNo"
+                      class="neuter-btn flex h-[40px] flex-1 items-center justify-center rounded-[8px] border text-[14px] font-bold transition-colors {% if pet.neutered == False %}border-[#3182ce] bg-[#ebf8ff] text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}"
+                      onclick="selectNeutered('no')">아니오</button>
+              <input type="hidden" name="neutered" id="neuteredInput" value="{% if pet.neutered == True %}yes{% elif pet.neutered == False %}no{% endif %}" />
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-8 flex gap-4">
+          {% if pet %}
+          <a href="/pets/" class="flex h-[48px] w-[130px] items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] hover:bg-[#e2e8f0]">취소</a>
+          {% else %}
+          <button type="button" onclick="goToStep1()"
+                  class="flex h-[48px] w-[130px] items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] hover:bg-[#e2e8f0]">이전으로</button>
+          {% endif %}
+          <button type="submit"
+                  class="flex h-[48px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white hover:bg-[#2b6cb0]">
+            {% if pet %}저장하기{% else %}등록하기{% endif %}
+          </button>
+        </div>
+      </div>
+
+    </form>
+  </div>
+</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var selectedSpecies = '{{ pet.species|default:"" }}';
+
+  // ── STEP 1: 종 선택 ──────────────────────────────────────────
+  window.selectSpecies = function (value) {
+    selectedSpecies = value;
+    document.querySelectorAll('.species-btn').forEach(function (btn) {
+      var active = btn.dataset.value === value;
+      btn.style.borderColor = active ? '#3182ce' : '';
+      btn.style.backgroundColor = active ? '#f7fbff' : '';
+    });
+    var nextBtn = document.getElementById('toStep2Btn');
+    if (value && value !== 'future') {
+      nextBtn.disabled = false;
+      nextBtn.style.backgroundColor = '#3182ce';
+    } else {
+      nextBtn.disabled = true;
+      nextBtn.style.backgroundColor = '#cbd5e0';
+    }
+  };
+
+  window.goToStep2 = function () {
+    document.getElementById('speciesInput').value = selectedSpecies;
+    document.getElementById('step1').style.display = 'none';
+    document.getElementById('step2').style.display = 'block';
+    document.getElementById('progressBar').style.width = '100%';
+    document.getElementById('stepLabel').textContent = 'STEP 2 / 2';
+    document.getElementById('stepTitle').textContent = '아이들의 기본 정보를 알려주세요';
+    document.getElementById('stepDesc').textContent = '정확한 맞춤형 케어를 위해 빈칸을 채워주세요.';
+    switchSpeciesTab(selectedSpecies);
+  };
+
+  window.goToStep1 = function () {
+    document.getElementById('step2').style.display = 'none';
+    document.getElementById('step1').style.display = 'block';
+    document.getElementById('progressBar').style.width = '50%';
+    document.getElementById('stepLabel').textContent = 'STEP 1 / 2';
+    document.getElementById('stepTitle').textContent = '어떤 반려동물과 함께하고 계신가요?';
+    document.getElementById('stepDesc').textContent = '원하는 동물을 클릭하여 추가해 주세요. (최대 5마리)';
+  };
+
+  // ── 종 탭 전환 ─────────────────────────────────────────────
+  window.switchSpeciesTab = function (species) {
+    document.getElementById('speciesInput').value = species;
+    ['dog', 'cat'].forEach(function (s) {
+      var tab = document.getElementById('tab' + (s === 'dog' ? 'Dog' : 'Cat'));
+      var line = document.getElementById('tab' + (s === 'dog' ? 'Dog' : 'Cat') + 'Line');
+      if (!tab) return;
+      var active = s === species;
+      tab.style.color = active ? '#3182ce' : '#a0aec0';
+      if (line) line.style.opacity = active ? '1' : '0';
+    });
+  };
+
+  // ── 성별 선택 ──────────────────────────────────────────────
+  window.selectGender = function (value) {
+    document.getElementById('genderInput').value = value;
+    ['male', 'female'].forEach(function (v) {
+      var btn = document.getElementById('gender' + (v === 'male' ? 'Male' : 'Female'));
+      var active = v === value;
+      btn.style.borderColor = active ? '#3182ce' : '#e2e8f0';
+      btn.style.backgroundColor = active ? '#ebf8ff' : 'white';
+      btn.style.color = active ? '#3182ce' : '#4a5568';
+    });
+  };
+
+  // ── 중성화 선택 ────────────────────────────────────────────
+  window.selectNeutered = function (value) {
+    document.getElementById('neuteredInput').value = value;
+    ['yes', 'no'].forEach(function (v) {
+      var btn = document.getElementById('neutered' + (v === 'yes' ? 'Yes' : 'No'));
+      var active = v === value;
+      btn.style.borderColor = active ? '#3182ce' : '#e2e8f0';
+      btn.style.backgroundColor = active ? '#ebf8ff' : 'white';
+      btn.style.color = active ? '#3182ce' : '#4a5568';
+    });
+  };
+})();
+</script>
 {% endblock %}

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -1,5 +1,72 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}반려동물 정보 — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: pets/list.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+<div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
+
+  <a href="/chat/" class="absolute left-8 top-8 text-[26px] font-bold leading-none text-[#2d3748]">
+    <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+  </a>
+
+  <div class="w-full max-w-[860px] rounded-[20px] border border-[#dbe7f5] bg-white px-10 py-10 shadow-[0_6px_20px_rgba(45,55,72,0.04)]">
+    <div class="flex items-end justify-between gap-4">
+      <div>
+        <h1 class="text-[24px] font-bold text-[#2d3748]">반려동물 정보</h1>
+        <p class="mt-2 text-[14px] text-[#718096]">
+          등록된 아이들의 정보를 수정하거나, 새로운 아이를 추가할 수 있습니다.
+        </p>
+      </div>
+      <div class="text-[14px] font-bold text-[#3182ce]">등록 현황: {{ pets|length }} / 5마리</div>
+    </div>
+
+    <div class="mt-5 h-px w-full bg-[#edf2f7]"></div>
+
+    <div class="mt-8 space-y-4">
+      {% for pet in pets %}
+      <div class="flex items-center gap-5 rounded-[14px] border border-[#e2e8f0] bg-white px-4 py-4 shadow-[0_1px_2px_rgba(45,55,72,0.02)]">
+        <div class="flex h-[56px] w-[56px] items-center justify-center rounded-full bg-[#edf2f7] text-[24px]">
+          {% if pet.species == "dog" %}🐶{% else %}🐱{% endif %}
+        </div>
+        <div class="min-w-0 flex-1">
+          <div class="text-[18px] font-bold text-[#2d3748]">
+            {{ pet.name }} ({{ pet.get_species_display }})
+          </div>
+          <div class="mt-1 text-[14px] text-[#718096]">
+            {{ pet.age_years }}년 {{ pet.age_months }}개월
+            · {{ pet.get_gender_display }}
+            {% if pet.breed %} · {{ pet.breed }}{% endif %}
+          </div>
+        </div>
+        <div class="flex items-center gap-3">
+          <a href="/pets/{{ pet.pet_id }}/edit/"
+             class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568] hover:bg-[#e2e8f0]">
+            수정
+          </a>
+          <form method="post" action="/api/pets/{{ pet.pet_id }}/" style="display:contents"
+                onsubmit="return confirm('정말 삭제하시겠습니까?')">
+            {% csrf_token %}
+            <input type="hidden" name="_method" value="DELETE" />
+            <button type="submit"
+                    class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] border border-[#feb2b2] bg-white text-[14px] font-bold text-[#e53e3e] hover:bg-[#fff5f5]">
+              삭제
+            </button>
+          </form>
+        </div>
+      </div>
+      {% empty %}
+      <p class="py-8 text-center text-[14px] text-[#a0aec0]">등록된 반려동물이 없습니다.</p>
+      {% endfor %}
+    </div>
+
+    {% if pets|length < 5 %}
+    <a href="/pets/add/"
+       class="mt-4 flex h-[44px] w-full items-center justify-center rounded-[12px] border border-dashed border-[#90cdf4] bg-[#f8fbff] text-[16px] font-bold text-[#3182ce] hover:bg-[#eef7ff]">
+      + 새로운 반려동물 추가하기
+    </a>
+    {% endif %}
+  </div>
+
+</div>
+</div>
 {% endblock %}

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -1,5 +1,158 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}설정 — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: users/profile.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+<div class="relative w-full px-4 py-10">
+
+  <!-- 탈퇴 모달 -->
+  <div id="withdrawModal" class="absolute inset-0 z-[60] hidden items-center justify-center bg-black/10"
+       onclick="closeWithdrawModal(event)">
+    <div class="relative h-[279px] w-[399px] rounded-[20px] border border-[#dbe7f5] bg-white shadow-[0_14px_36px_rgba(45,55,72,0.10)]"
+         onclick="event.stopPropagation()">
+      <div class="absolute left-1/2 top-[27px] flex h-[81px] w-[81px] -translate-x-1/2 items-center justify-center rounded-full border-[4px] border-[#ef4444]">
+        <span class="relative top-[-1px] text-[48px] font-bold leading-none text-[#ef4444]">!</span>
+      </div>
+      <p class="absolute left-1/2 top-[127px] -translate-x-1/2 whitespace-nowrap text-center text-[19px] font-bold leading-none text-[#2d3748]">정말 탈퇴하시겠습니까?</p>
+      <p class="absolute left-1/2 top-[171px] -translate-x-1/2 whitespace-nowrap text-center text-[14px] leading-none text-[#718096]">모든 사용자 데이터가 영구적으로 삭제됩니다</p>
+      <div class="absolute bottom-[24px] left-[40px] right-[40px] flex h-[42px] items-center justify-between">
+        <button type="button" onclick="closeWithdrawModal()"
+                class="flex h-full w-[150px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">취소</button>
+        <form method="post" action="/api/users/me/withdraw/" style="display:contents">
+          {% csrf_token %}
+          <button type="submit"
+                  class="flex h-full w-[150px] items-center justify-center rounded-[8px] bg-[#ef4444] text-[14px] font-bold text-white">탈퇴하기</button>
+        </form>
+      </div>
+    </div>
+  </div>
+
+  <!-- 로고 -->
+  <a href="/chat/" class="absolute left-8 top-8 text-[26px] font-bold leading-none text-[#2d3748]">
+    <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+  </a>
+
+  <div class="mx-auto w-full max-w-[860px] rounded-[20px] border border-[#e2e8f0] bg-white mt-16">
+    <div class="px-8 pt-6 pb-4 text-[24px] font-bold text-[#2d3748]">설정</div>
+    <div class="h-px w-full bg-[#e2e8f0]"></div>
+
+    <form method="post" class="px-8 py-6">
+      {% csrf_token %}
+      {% if messages %}
+      {% for msg in messages %}
+      <p class="mb-4 text-center text-[13px] {% if msg.tags == 'error' %}text-red-500{% else %}text-green-600{% endif %}">{{ msg }}</p>
+      {% endfor %}
+      {% endif %}
+
+      <div class="text-[18px] font-bold text-[#2d3748]">1. 프로필 관리</div>
+
+      <!-- 프로필 이미지 -->
+      <div class="mt-6 flex flex-col items-center">
+        <div class="relative flex h-[72px] w-[72px] items-center justify-center rounded-full bg-[#cbd5e0] text-[12px] text-[#4a5568]">
+          IMG
+          <div class="absolute -right-1 -bottom-1 flex h-5 w-5 items-center justify-center rounded-full bg-[#3182ce] text-white text-[12px]">+</div>
+        </div>
+        <div class="mt-3 text-[12px] text-[#718096]">클릭하여 이미지 업로드</div>
+      </div>
+
+      <!-- 닉네임 / 연락처 -->
+      <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div>
+          <div class="mb-2 text-[14px] font-bold text-[#4a5568]">닉네임</div>
+          <div class="flex gap-3">
+            <input name="nickname" value="{{ user.profile.nickname|default:'' }}"
+                   class="h-[36px] flex-1 rounded-[8px] border border-[#e2e8f0] px-3 text-[14px] outline-none focus:border-[#3182ce]" />
+            <button type="button"
+                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">중복확인</button>
+          </div>
+        </div>
+        <div>
+          <div class="mb-2 text-[14px] font-bold text-[#4a5568]">연락처</div>
+          <div class="flex gap-3">
+            <input name="phone" value="{{ user.profile.phone|default:'' }}" placeholder="- 없이 숫자만 입력해주세요"
+                   class="h-[36px] flex-1 rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce]" />
+            <button type="button"
+                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">인증요청</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- 알림 설정 -->
+      <div class="mt-6">
+        <div class="mb-2 text-[14px] font-bold text-[#4a5568]">알림 설정</div>
+        <div class="flex items-center gap-3 rounded-[10px] border border-[#e2e8f0] px-3 py-2">
+          <span class="text-[14px] text-[#718096]">마케팅 푸시/이메일 수신 동의</span>
+          <div class="ml-auto">
+            <button type="button" id="marketingToggle"
+                    class="h-[20px] w-[36px] rounded-full p-[2px] transition bg-[#3182ce]"
+                    onclick="toggleMarketing(this)" aria-pressed="true">
+              <span id="marketingThumb" class="block h-[16px] w-[16px] rounded-full bg-white transition translate-x-[16px]"></span>
+            </button>
+            <input type="hidden" name="marketing" id="marketingInput" value="on" />
+          </div>
+        </div>
+      </div>
+
+      <div class="mt-8 h-px w-full bg-[#e2e8f0]"></div>
+
+      <!-- 계정 관리 -->
+      <div class="mt-6 text-[18px] font-bold text-[#2d3748]">2. 계정 관리</div>
+      <div class="mt-4 rounded-[14px] border border-[#e2e8f0] bg-[#f7fafc] p-4">
+        <div class="flex items-center gap-3">
+          <img alt="Kakao" class="h-8 w-8" src="https://www.figma.com/api/mcp/asset/527049c9-ee7f-443c-a0c6-0e70f4b905e3" />
+          <div class="flex-1">
+            <div class="text-[14px] font-bold text-[#2d3748]">Kakao 계정 연동하기</div>
+          </div>
+        </div>
+        <div class="my-4 h-px w-full bg-[#e2e8f0]"></div>
+        <div class="flex items-center gap-3">
+          <img alt="Naver" class="h-8 w-8" src="https://www.figma.com/api/mcp/asset/7a5a2941-cee1-4c91-a571-7ad9b01bcfc6" />
+          <div class="flex-1">
+            <div class="text-[14px] font-bold text-[#2d3748]">NAVER 계정 연동하기</div>
+          </div>
+        </div>
+        <div class="my-4 h-px w-full bg-[#e2e8f0]"></div>
+        <div class="flex items-center gap-3">
+          <img alt="Google" class="h-8 w-8" src="https://www.figma.com/api/mcp/asset/e3eff93a-1607-4896-8a57-8b1125091b0a" />
+          <div class="flex-1">
+            <div class="text-[14px] font-bold text-[#2d3748]">Google 계정 연동하기</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- 버튼 -->
+      <div class="mt-6 flex flex-col gap-3 md:flex-row">
+        <a href="/chat/" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568]">취소</a>
+        <button type="submit"
+                class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white hover:bg-[#2b6cb0]">
+          변경사항 저장
+        </button>
+      </div>
+
+      <button type="button" onclick="document.getElementById('withdrawModal').style.display='flex'"
+              class="mt-4 text-[13px] font-bold text-[#c53030]">회원 탈퇴</button>
+
+    </form>
+  </div>
+
+</div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  window.closeWithdrawModal = function (e) {
+    if (e && e.target !== document.getElementById('withdrawModal')) return;
+    document.getElementById('withdrawModal').style.display = 'none';
+  };
+
+  window.toggleMarketing = function (btn) {
+    var pressed = btn.getAttribute('aria-pressed') === 'true';
+    var next = !pressed;
+    btn.setAttribute('aria-pressed', next);
+    btn.style.backgroundColor = next ? '#3182ce' : '#cbd5e0';
+    document.getElementById('marketingThumb').style.transform = next ? 'translateX(16px)' : 'translateX(0)';
+    document.getElementById('marketingInput').value = next ? 'on' : '';
+  };
+</script>
 {% endblock %}


### PR DESCRIPTION
## 요약

MVT 전환(#116) 5단계(마지막) — 프로필/반려동물 페이지 Django Template 포팅.

## 변경 사항

**templates/users/profile.html**
- 닉네임, 연락처, 알림 설정 (토글 Vanilla JS), 소셜 계정 연동 섹션
- 탈퇴 모달 (Vanilla JS)
- 변경사항 저장 POST 폼

**templates/pets/list.html**
- 반려동물 목록 (종류 이모지, 나이/성별/품종)
- 수정/삭제 버튼 (삭제 confirm)
- 5마리 미만 시 추가 버튼 노출

**templates/pets/form.html**
- 2단계 폼: STEP1 종류 선택 → STEP2 기본정보 입력
- Vanilla JS 스텝 전환, 종 탭 전환, 성별/중성화 토글
- 수정 모드 지원 (pet 컨텍스트 있을 때 STEP2 바로 진입)

**pets/page_views.py**
- `pet_add` / `pet_edit` POST 처리 추가

## 관련 이슈

closes #121
ref #116