### PR TITLE
feat(django): implement issue #44 social auth flow

### DIFF
--- a/docs/planning/04_data_model_detail.md
+++ b/docs/planning/04_data_model_detail.md
@@ -32,6 +32,17 @@ erDiagram
         datetime updated_at
     }
 
+    SOCIAL_ACCOUNT {
+        int     id                PK
+        int     user_id           FK
+        string  provider          "google|naver|kakao"
+        string  provider_user_id
+        string  email             "blank 허용"
+        jsonb   extra_data
+        datetime created_at
+        datetime updated_at
+    }
+
     PET {
         uuid    pet_id          PK
         int     user_id         FK
@@ -185,7 +196,7 @@ erDiagram
         uuid    id               PK
         int     user_id          FK
         string  product_id       FK
-        uuid    session_id       FK  "nullable"
+        uuid    session_id       "nullable. FK 미적용"
         string  interaction_type "click|cart|purchase|reject"
         int     weight           "click=1|cart=3|purchase=5|reject=-1"
         datetime created_at
@@ -193,6 +204,7 @@ erDiagram
 
     USER            ||--o{ PET                  : "1:N"
     USER            ||--o|  USER_PROFILE         : "1:1(optional before onboarding)"
+    USER            ||--o{ SOCIAL_ACCOUNT       : "1:N"
     USER            ||--o{ CHAT_SESSION          : "1:N"
     USER            ||--o|  CART                 : "1:1"
     USER            ||--o{ ORDER                 : "1:N"
@@ -224,9 +236,9 @@ erDiagram
 
 ## 1. User
 
-> OAuth 전용 인증. 자체 가입(이메일+비밀번호) 미지원.
 > Django `AbstractBaseUser` + `PermissionsMixin` 기반 커스텀 유저 모델.
-> OAuth provider 정보는 `social_auth_usersocialauth` 테이블에서 관리 (`social-auth-app-django`).
+> 현재 구현에는 이메일/비밀번호 로그인과 OAuth 로그인이 모두 존재한다.
+> OAuth 계정 연결 정보는 프로젝트 커스텀 `social_account` 테이블에서 관리한다.
 
 ```json
 {
@@ -236,7 +248,7 @@ erDiagram
   "is_active":      "boolean",
 
   // Django AbstractBaseUser 자동 관리 필드 (직접 사용 X)
-  "password":       "string",   // unusable password로 설정 — OAuth이므로 실제 비밀번호 없음
+  "password":       "string",
   "last_login":     "datetime | null",  // Django 로그인 시 자동 갱신
   "is_superuser":   "boolean",  // Django Admin 권한
   "is_staff":       "boolean"   // Django Admin 접근 제어
@@ -245,20 +257,38 @@ erDiagram
 
 ### USER_PROFILE
 
-> 온보딩 완료 시 생성되는 1:1 프로필 엔티티.
-> 로그인만 완료된 회원은 `user`만 존재할 수 있으며, `user_profile`이 생성되기 전까지 채팅/장바구니/구매 기능을 사용할 수 없다.
+> 사용자 기본 프로필을 저장하는 1:1 엔티티.
+> 현재 구현의 소셜 로그인 흐름에서는 최초 로그인 시점에 함께 생성될 수 있다.
 
 ```json
 {
   "user_id":           "int",            // PK, FK → USER.id (1:1)
-  "nickname":          "string",         // OAuth provider에서 pre-fill 후 수정 가능
+  "nickname":          "string",
   "age":               "int | null",
   "gender":            "string | null",
-  "address":           "string | null",  // 기본 배송지. 주문 시 pre-fill 용도
+  "address":           "string | null",
   "phone":             "string | null",
-  "marketing_consent": "boolean",        // 기본 false
+  "marketing_consent": "boolean",
   "profile_image_url": "string | null",
   "updated_at":        "datetime"
+}
+```
+
+### SOCIAL_ACCOUNT
+
+> OAuth provider 계정과 우리 서비스 `user`를 연결하는 테이블.
+> `provider + provider_user_id` 조합에 유니크 제약이 걸려 있다.
+
+```json
+{
+  "id":               "bigint",
+  "user_id":          "int",            // FK → USER.id
+  "provider":         "google | naver | kakao",
+  "provider_user_id": "string",
+  "email":            "string",         // blank 허용
+  "extra_data":       "object",         // provider 원본 프로필 payload
+  "created_at":       "datetime",
+  "updated_at":       "datetime"
 }
 ```
 
@@ -289,19 +319,17 @@ erDiagram
 
 ## 3. Chat Session
 
-> 온보딩이 완료되어 `user_profile`이 생성된 회원만 사용할 수 있다.
-
 ```json
 {
   "session_id":    "uuid",
   "user_id":       "int",
-  "title":         "string",             // 첫 메시지 기반 LLM 자동 생성
-  "target_pet_id": "uuid | null",        // 대화 대상 펫. 미선택 시 null
+  "title":         "string",
+  "target_pet_id": "uuid | null",
   "messages": [
     {
+      "message_id":     "uuid",
       "role":          "user | assistant",
       "content":       "string",
-      "product_cards": ["goods_id"],     // MESSAGE_PRODUCT_CARD. 어시스턴트 메시지만 존재
       "created_at":    "datetime"
     }
   ],
@@ -352,16 +380,15 @@ erDiagram
 
 ### PRODUCT_ADMIN_CONFIG
 
-> 파이프라인이 소유하는 PRODUCT와 분리된 어드민 전용 설정 테이블. TBD.
-> 추천 점수 계산: `effective_score = popularity_score × admin_weight`
+> `product`와 1:1로 연결되는 어드민 설정 테이블.
 
 ```json
 {
   "id":           "uuid",
-  "product_id":   "string",        // FK → PRODUCT (1:1). 설정 없는 상품은 행 없음 (admin_weight=1.0 기본값)
-  "admin_weight": "numeric",       // 추천 노출 가중치. 기본 1.0. >1.0 부스트, <1.0 다운랭크
-  "pinned":       "boolean",       // 추천 결과 최상단 고정. admin_weight와 별개
-  "memo":         "string | null", // 어드민 내부 메모. 사용자에게 노출 안 됨
+  "product_id":   "string",        // FK → PRODUCT (1:1)
+  "admin_weight": "numeric",       // default 1.0
+  "pinned":       "boolean",
+  "memo":         "string | null",
   "updated_at":   "datetime"
 }
 ```
@@ -391,16 +418,14 @@ erDiagram
 
 ---
 
-## 6. User Interaction (Phase 2 — CF 준비)
-
-> Day 1부터 로깅. CF 모델 학습 전에도 데이터 축적 목적.
+## 6. User Interaction
 
 ```json
 {
   "id":               "uuid",
   "user_id":          "int",              // FK → USER.id
   "goods_id":         "string",           // FK → PRODUCT
-  "session_id":       "uuid | null",      // FK → CHAT_SESSION
+  "session_id":       "uuid | null",      // 현재는 UUID만 저장, FK 제약 없음
   "interaction_type": "click | cart | purchase | reject",
   "weight":           "int",              // click=1 | cart=3 | purchase=5 | reject=-1
   "created_at":       "datetime"
@@ -411,18 +436,14 @@ erDiagram
 
 ## 7. Cart
 
-> 온보딩이 완료되어 `user_profile`이 생성된 회원만 사용할 수 있다.
-
 ```json
 {
   "cart_id":    "uuid",
-  "user_id":    "int",     // FK → USER.id. 온보딩 완료 회원 기준 1인 1카트
+  "user_id":    "int",     // FK → USER.id, 1:1
   "items": [
     {
+      "cart_item_id":   "uuid",
       "goods_id":      "string",
-      "goods_name":    "string",
-      "price":         "int",
-      "thumbnail_url": "string",
       "quantity":      "int",
       "added_at":      "datetime"
     }
@@ -433,14 +454,12 @@ erDiagram
 
 ## 8. Order
 
-> 온보딩이 완료되어 `user_profile`이 생성된 회원만 사용할 수 있다.
-
 ```json
 {
   "order_id":         "uuid",
   "user_id":          "int",
-  "recipient_name":   "string",   // 주문 시 스냅샷. user_profile.nickname 기본값
-  "delivery_address": "string",   // 주문 시 스냅샷. user_profile.address 기본값
+  "recipient_name":   "string",
+  "delivery_address": "string",
   "items":            ["OrderItem"],
   "total_price":      "int",
   "status":           "pending | completed | cancelled",

--- a/infra/.env.example
+++ b/infra/.env.example
@@ -19,6 +19,7 @@ NAVER_CLIENT_ID=
 NAVER_CLIENT_SECRET=
 KAKAO_CLIENT_ID=
 KAKAO_CLIENT_SECRET=
+SOCIAL_AUTH_REQUESTS_TIMEOUT=10
 
 # ── FastAPI ───────────────────────────────────────────────────
 FASTAPI_ENV=development

--- a/services/django/config/settings.py
+++ b/services/django/config/settings.py
@@ -19,6 +19,7 @@ INSTALLED_APPS = [
     "rest_framework",
     "rest_framework_simplejwt",
     "rest_framework_simplejwt.token_blacklist",
+    "social_django",
     "corsheaders",
     "users",
     "pets",
@@ -28,6 +29,13 @@ INSTALLED_APPS = [
 ]
 
 AUTH_USER_MODEL = "users.User"
+
+AUTHENTICATION_BACKENDS = (
+    "social_core.backends.google.GoogleOAuth2",
+    "social_core.backends.kakao.KakaoOAuth2",
+    "social_core.backends.naver.NaverOAuth2",
+    "django.contrib.auth.backends.ModelBackend",
+)
 
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
@@ -53,6 +61,7 @@ TEMPLATES = [
                 "django.template.context_processors.request",
                 "django.contrib.auth.context_processors.auth",
                 "django.contrib.messages.context_processors.messages",
+                "social_django.context_processors.backends",
             ],
         },
     },
@@ -98,6 +107,36 @@ SESSION_COOKIE_SECURE = config("DJANGO_SESSION_COOKIE_SECURE", default=False, ca
 CSRF_COOKIE_SECURE = config("DJANGO_CSRF_COOKIE_SECURE", default=False, cast=bool)
 
 CORS_ALLOWED_ORIGINS = config("CORS_ALLOWED_ORIGINS", default="").split(",")
+
+SOCIAL_AUTH_GOOGLE_OAUTH2_KEY = config("GOOGLE_CLIENT_ID", default="")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SECRET = config("GOOGLE_CLIENT_SECRET", default="")
+SOCIAL_AUTH_GOOGLE_OAUTH2_SCOPE = ["openid", "email", "profile"]
+SOCIAL_AUTH_GOOGLE_OAUTH2_USE_UNIQUE_USER_ID = True
+
+SOCIAL_AUTH_NAVER_KEY = config("NAVER_CLIENT_ID", default="")
+SOCIAL_AUTH_NAVER_SECRET = config("NAVER_CLIENT_SECRET", default="")
+
+SOCIAL_AUTH_KAKAO_KEY = config("KAKAO_CLIENT_ID", default="")
+SOCIAL_AUTH_KAKAO_SECRET = config("KAKAO_CLIENT_SECRET", default="")
+SOCIAL_AUTH_KAKAO_SCOPE = ["account_email", "profile_nickname", "profile_image"]
+
+SOCIAL_AUTH_REQUESTS_TIMEOUT = config("SOCIAL_AUTH_REQUESTS_TIMEOUT", default=10, cast=int)
+SOCIAL_AUTH_RAISE_EXCEPTIONS = False
+SOCIAL_AUTH_LOGIN_ERROR_URL = "/login/"
+SOCIAL_AUTH_USER_FIELDS = ["email"]
+SOCIAL_AUTH_PIPELINE = (
+    "social_core.pipeline.social_auth.social_details",
+    "social_core.pipeline.social_auth.social_uid",
+    "users.social_pipeline.ensure_email",
+    "social_core.pipeline.social_auth.auth_allowed",
+    "social_core.pipeline.social_auth.social_user",
+    "social_core.pipeline.social_auth.associate_by_email",
+    "social_core.pipeline.user.create_user",
+    "social_core.pipeline.social_auth.associate_user",
+    "social_core.pipeline.social_auth.load_extra_data",
+    "social_core.pipeline.user.user_details",
+    "users.social_pipeline.sync_tailtalk_social_data",
+)
 
 SOCIAL_AUTH_PROVIDERS = {
     "google": {

--- a/services/django/config/test_settings.py
+++ b/services/django/config/test_settings.py
@@ -1,0 +1,13 @@
+from .settings import *  # noqa: F403,F401
+
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": BASE_DIR / "test.sqlite3",  # noqa: F405
+    }
+}
+
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
+]

--- a/services/django/requirements.txt
+++ b/services/django/requirements.txt
@@ -1,6 +1,8 @@
 django==5.2.12
 djangorestframework==3.16.1
 djangorestframework-simplejwt==5.5.1
+social-auth-app-django==5.4.2
+social-auth-core==4.8.5
 django-cors-headers==4.9.0
 psycopg2-binary==2.9.10
 gunicorn==25.1.0

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -42,15 +42,15 @@
 
         <!-- 소셜 버튼 -->
         <div class="flex justify-center gap-4" id="socialLoginButtons">
-          <a href="/auth/kakao/start/?remember=on" data-provider="kakao" aria-label="카카오 로그인">
+          <a href="/auth/social/kakao/?remember=on" data-provider="kakao" aria-label="카카오 로그인">
             <img alt="카카오" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
           </a>
-          <a href="/auth/naver/start/?remember=on" data-provider="naver" aria-label="네이버 로그인">
+          <a href="/auth/social/naver/?remember=on" data-provider="naver" aria-label="네이버 로그인">
             <img alt="네이버" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
           </a>
-          <a href="/auth/google/start/?remember=on" data-provider="google" aria-label="구글 로그인">
+          <a href="/auth/social/google/?remember=on" data-provider="google" aria-label="구글 로그인">
             <img alt="구글" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
           </a>
@@ -105,7 +105,7 @@
         event.preventDefault();
         const provider = link.getAttribute('data-provider');
         const remember = checked ? 'on' : 'off';
-        window.location.href = '/auth/' + provider + '/start/?remember=' + remember;
+        window.location.href = '/auth/social/' + provider + '/?remember=' + remember;
       });
     });
   })();

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -45,15 +45,15 @@
 
         <!-- 소셜 버튼 -->
         <div class="flex justify-center gap-4">
-          <a href="/auth/kakao/start/?remember=on" aria-label="카카오 로그인">
+          <a href="/auth/social/kakao/?remember=on" aria-label="카카오 로그인">
             <img alt="카카오" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
           </a>
-          <a href="/auth/naver/start/?remember=on" aria-label="네이버 로그인">
+          <a href="/auth/social/naver/?remember=on" aria-label="네이버 로그인">
             <img alt="네이버" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
           </a>
-          <a href="/auth/google/start/?remember=on" aria-label="구글 로그인">
+          <a href="/auth/social/google/?remember=on" aria-label="구글 로그인">
             <img alt="구글" class="h-[40px] w-[40px]"
                  src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
           </a>

--- a/services/django/users/auth_urls.py
+++ b/services/django/users/auth_urls.py
@@ -1,6 +1,13 @@
 from django.urls import path
 
-from .views import AuthLoginView, AuthLogoutView, AuthWithdrawView, SocialLoginView, SocialProviderListView
+from .views import (
+    AuthLoginView,
+    AuthLogoutView,
+    AuthWithdrawView,
+    SocialLoginCallbackView,
+    SocialLoginView,
+    SocialProviderListView,
+)
 
 urlpatterns = [
     path("login/", AuthLoginView.as_view(), name="auth-login"),
@@ -8,4 +15,5 @@ urlpatterns = [
     path("withdraw/", AuthWithdrawView.as_view(), name="auth-withdraw"),
     path("providers/", SocialProviderListView.as_view(), name="social-provider-list"),
     path("social/<str:provider>/", SocialLoginView.as_view(), name="social-login"),
+    path("social/<str:provider>/callback/", SocialLoginCallbackView.as_view(), name="social-login-callback-api"),
 ]

--- a/services/django/users/page_urls.py
+++ b/services/django/users/page_urls.py
@@ -7,6 +7,8 @@ urlpatterns = [
     path("signup/", page_views.signup_view, name="signup"),
     path("logout/", page_views.logout_view, name="logout"),
     path("profile/", page_views.profile_view, name="profile"),
-    path("auth/<str:provider>/start/", page_views.social_login_start_view, name="social-login-start"),
-    path("auth/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback"),
+    path("auth/social/<str:provider>/", page_views.social_login_start_view, name="social-login-start"),
+    path("auth/social/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback"),
+    path("auth/<str:provider>/start/", page_views.social_login_start_view, name="social-login-start-legacy"),
+    path("auth/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback-legacy"),
 ]

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -5,15 +5,21 @@ from django.contrib.auth import authenticate, get_user_model, login, logout
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import redirect, render
 from django.urls import reverse
+from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthException, AuthForbidden, AuthMissingParameter
 
 from .models import UserProfile
-from .oauth import OAuthProviderClient, SocialAuthError
-from .views import get_or_create_social_user
+from .social_auth import (
+    SOCIAL_AUTH_ACCESS_SESSION_KEY,
+    SOCIAL_AUTH_REFRESH_SESSION_KEY,
+    SOCIAL_AUTH_REMEMBER_SESSION_KEY,
+    SocialAuthServiceError,
+    build_authorization_url,
+    complete_social_login,
+)
+from .views import issue_user_tokens
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
-SOCIAL_STATE_SESSION_KEY = "tailtalk_social_oauth_state"
-SOCIAL_REMEMBER_SESSION_KEY = "tailtalk_social_oauth_remember"
 
 
 def _get_profile(user):
@@ -70,6 +76,8 @@ def signup_view(request):
 
 
 def logout_view(request):
+    request.session.pop(SOCIAL_AUTH_ACCESS_SESSION_KEY, None)
+    request.session.pop(SOCIAL_AUTH_REFRESH_SESSION_KEY, None)
     logout(request)
     return redirect("login")
 
@@ -96,20 +104,21 @@ def profile_view(request):
 def social_login_start_view(request, provider):
     remember = request.GET.get("remember") == "on"
     redirect_uri = request.build_absolute_uri(reverse("social-login-callback", kwargs={"provider": provider}))
+    next_url = f"{reverse('profile')}?setup=1"
 
     try:
-        client = OAuthProviderClient(provider)
-        provider_data = client.build_authorization_url(redirect_uri=redirect_uri)
-    except SocialAuthError as exc:
+        authorization_url = build_authorization_url(
+            request=request,
+            provider=provider,
+            redirect_uri=redirect_uri,
+            next_url=next_url,
+        )
+    except SocialAuthServiceError as exc:
         messages.error(request, str(exc))
         return redirect("login")
 
-    request.session[SOCIAL_STATE_SESSION_KEY] = {
-        "provider": provider,
-        "state": provider_data["state"],
-    }
-    request.session[SOCIAL_REMEMBER_SESSION_KEY] = remember
-    return redirect(provider_data["authorization_url"])
+    request.session[SOCIAL_AUTH_REMEMBER_SESSION_KEY] = remember
+    return redirect(authorization_url)
 
 
 def social_login_callback_view(request, provider):
@@ -118,46 +127,28 @@ def social_login_callback_view(request, provider):
         messages.error(request, "소셜 로그인 인증이 취소되었거나 실패했습니다.")
         return redirect("login")
 
-    code = request.GET.get("code")
-    state = request.GET.get("state")
     redirect_uri = request.build_absolute_uri(reverse("social-login-callback", kwargs={"provider": provider}))
-    oauth_state = request.session.get(SOCIAL_STATE_SESSION_KEY, {})
-
-    if not code:
-        logger.warning("OAuth callback missing code", extra={"provider": provider})
-        messages.error(request, "인가 코드가 없어 로그인을 완료할 수 없습니다.")
-        return redirect("login")
-
-    if oauth_state.get("provider") != provider:
-        logger.warning(
-            "OAuth callback provider mismatch",
-            extra={"provider": provider, "session_provider": oauth_state.get("provider")},
-        )
-        messages.error(request, "소셜 로그인 상태 정보가 올바르지 않습니다.")
-        return redirect("login")
-
-    if provider == "naver" and oauth_state.get("state") != state:
-        logger.warning("Naver OAuth state mismatch", extra={"provider": provider})
-        messages.error(request, "네이버 로그인 state 검증에 실패했습니다.")
-        return redirect("login")
 
     try:
-        profile = OAuthProviderClient(provider).exchange_code(
-            code=code,
+        result = complete_social_login(
+            request=request,
+            provider=provider,
             redirect_uri=redirect_uri,
-            state=state,
         )
-        user, _ = get_or_create_social_user(profile)
-    except SocialAuthError as exc:
+    except (AuthCanceled, AuthConnectionError, AuthMissingParameter, AuthForbidden, AuthException, SocialAuthServiceError) as exc:
         logger.warning("Social login exchange failed", extra={"provider": provider, "error": str(exc)})
         messages.error(request, str(exc))
         return redirect("login")
 
+    user = result.user
+    user.backend = result.backend_path
     login(request, user)
-    if not request.session.get(SOCIAL_REMEMBER_SESSION_KEY):
+    if not request.session.get(SOCIAL_AUTH_REMEMBER_SESSION_KEY):
         request.session.set_expiry(0)
 
-    request.session.pop(SOCIAL_STATE_SESSION_KEY, None)
-    request.session.pop(SOCIAL_REMEMBER_SESSION_KEY, None)
+    tokens = issue_user_tokens(user)
+    request.session[SOCIAL_AUTH_ACCESS_SESSION_KEY] = tokens["access"]
+    request.session[SOCIAL_AUTH_REFRESH_SESSION_KEY] = tokens["refresh"]
+    request.session.pop(SOCIAL_AUTH_REMEMBER_SESSION_KEY, None)
     messages.success(request, "소셜 로그인이 완료되었습니다. 추가 정보를 입력해 주세요.")
     return redirect(f"{reverse('profile')}?setup=1")

--- a/services/django/users/social_auth.py
+++ b/services/django/users/social_auth.py
@@ -1,0 +1,78 @@
+from dataclasses import dataclass
+
+from django.http import HttpResponseBase
+from social_django.utils import load_backend, load_strategy
+from social_core.exceptions import MissingBackend
+
+
+SOCIAL_AUTH_REMEMBER_SESSION_KEY = "tailtalk_social_oauth_remember"
+SOCIAL_AUTH_ACCESS_SESSION_KEY = "tailtalk_api_access_token"
+SOCIAL_AUTH_REFRESH_SESSION_KEY = "tailtalk_api_refresh_token"
+
+PROVIDER_BACKEND_NAMES = {
+    "google": "google-oauth2",
+    "kakao": "kakao",
+    "naver": "naver",
+}
+
+BACKEND_PROVIDER_NAMES = {backend: provider for provider, backend in PROVIDER_BACKEND_NAMES.items()}
+
+
+class SocialAuthServiceError(Exception):
+    pass
+
+
+@dataclass
+class SocialLoginResult:
+    user: object
+    backend_path: str
+    provider: str
+    is_new_user: bool
+
+
+def get_backend_name(provider: str) -> str:
+    try:
+        return PROVIDER_BACKEND_NAMES[provider]
+    except KeyError as exc:
+        raise SocialAuthServiceError(f"Unsupported provider: {provider}") from exc
+
+
+def get_provider_name(backend_name: str) -> str:
+    return BACKEND_PROVIDER_NAMES.get(backend_name, backend_name)
+
+
+def build_authorization_url(request, provider: str, redirect_uri: str, next_url: str | None = None) -> str:
+    strategy = load_strategy(request)
+    backend_name = get_backend_name(provider)
+
+    try:
+        backend = load_backend(strategy, backend_name, redirect_uri)
+    except MissingBackend as exc:
+        raise SocialAuthServiceError(f"Unsupported provider: {provider}") from exc
+
+    if next_url:
+        strategy.session_set("next", next_url)
+    return backend.auth_url()
+
+
+def complete_social_login(request, provider: str, redirect_uri: str) -> SocialLoginResult:
+    strategy = load_strategy(request)
+    backend_name = get_backend_name(provider)
+
+    try:
+        backend = load_backend(strategy, backend_name, redirect_uri)
+    except MissingBackend as exc:
+        raise SocialAuthServiceError(f"Unsupported provider: {provider}") from exc
+
+    user = backend.complete(user=None)
+    if isinstance(user, HttpResponseBase):
+        raise SocialAuthServiceError("Social auth returned an unexpected response.")
+    if user is None:
+        raise SocialAuthServiceError("Social login did not return a user.")
+
+    return SocialLoginResult(
+        user=user,
+        backend_path=f"{backend.__module__}.{backend.__class__.__name__}",
+        provider=get_provider_name(backend.name),
+        is_new_user=bool(getattr(user, "is_new", False)),
+    )

--- a/services/django/users/social_pipeline.py
+++ b/services/django/users/social_pipeline.py
@@ -1,0 +1,76 @@
+from .models import SocialAccount, UserProfile
+
+
+PROVIDER_NAME_MAP = {
+    "google-oauth2": "google",
+    "kakao": "kakao",
+    "naver": "naver",
+}
+
+
+def build_fallback_email(provider: str, provider_user_id: str) -> str:
+    return f"{provider}_{provider_user_id}@oauth.local"
+
+
+def ensure_email(details, backend, response, uid=None, *args, **kwargs):
+    if details.get("email"):
+        return None
+
+    provider = PROVIDER_NAME_MAP.get(backend.name, backend.name)
+    provider_user_id = uid or backend.get_user_id(details, response)
+    fallback_email = build_fallback_email(provider, provider_user_id)
+    normalized_details = details.copy()
+    normalized_details["email"] = fallback_email
+    return {"details": normalized_details}
+
+
+def sync_tailtalk_social_data(backend, user=None, uid=None, response=None, *args, **kwargs):
+    if user is None:
+        return None
+
+    provider = PROVIDER_NAME_MAP.get(backend.name, backend.name)
+    profile, _ = UserProfile.objects.get_or_create(
+        user=user,
+        defaults={"nickname": user.email.split("@")[0]},
+    )
+
+    nickname = (
+        response.get("name")
+        or response.get("nickname")
+        or (response.get("properties") or {}).get("nickname")
+        or ((response.get("kakao_account") or {}).get("profile") or {}).get("nickname")
+        or profile.nickname
+    )
+    profile_image_url = (
+        response.get("picture")
+        or response.get("profile_image")
+        or (response.get("properties") or {}).get("profile_image")
+        or ((response.get("kakao_account") or {}).get("profile") or {}).get("profile_image_url")
+        or profile.profile_image_url
+    )
+    email = (
+        response.get("email")
+        or (response.get("kakao_account") or {}).get("email")
+        or user.email
+    )
+
+    dirty_fields = []
+    if nickname and profile.nickname != nickname:
+        profile.nickname = nickname
+        dirty_fields.append("nickname")
+    if profile_image_url and profile.profile_image_url != profile_image_url:
+        profile.profile_image_url = profile_image_url
+        dirty_fields.append("profile_image_url")
+    if dirty_fields:
+        profile.save(update_fields=[*dirty_fields, "updated_at"])
+
+    SocialAccount.objects.update_or_create(
+        provider=provider,
+        provider_user_id=str(uid),
+        defaults={
+            "user": user,
+            "email": email,
+            "extra_data": response or {},
+        },
+    )
+    return None

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -1,11 +1,17 @@
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from users.models import SocialAccount, User, UserProfile
 from users.oauth import SocialUserProfile
+from users.social_auth import (
+    SOCIAL_AUTH_ACCESS_SESSION_KEY,
+    SOCIAL_AUTH_REFRESH_SESSION_KEY,
+    SocialLoginResult,
+)
 
 
 TEST_SOCIAL_PROVIDERS = {
@@ -107,6 +113,79 @@ class SocialLoginViewTests(TestCase):
             self.assertTrue(provider["configured"])
             self.assertIn("authorization_url", provider)
             self.assertIn("state", provider)
+
+    @patch("users.views.build_authorization_url")
+    def test_social_login_get_returns_authorization_url(self, build_authorization_url_mock):
+        build_authorization_url_mock.return_value = "https://accounts.google.com/o/oauth2/auth?state=test"
+
+        response = self.client.get("/api/auth/social/google/?remember=on")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["provider"], "google")
+        self.assertIn("authorization_url", response.data)
+        self.assertIn("callback_url", response.data)
+
+    @patch("users.views.complete_social_login")
+    def test_social_login_callback_returns_tokens_and_logs_in_session(self, complete_social_login_mock):
+        user = User.objects.create_user(email="callback@example.com")
+        UserProfile.objects.create(user=user, nickname="Callback User")
+        complete_social_login_mock.return_value = SocialLoginResult(
+            user=user,
+            backend_path="social_core.backends.google.GoogleOAuth2",
+            provider="google",
+            is_new_user=False,
+        )
+
+        session = self.client.session
+        session["tailtalk_social_oauth_remember"] = True
+        session.save()
+
+        response = self.client.get("/api/auth/social/google/callback/?code=test-code&state=test-state")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("access", response.data)
+        self.assertIn("refresh", response.data)
+        self.assertEqual(response.data["user"]["email"], "callback@example.com")
+
+        session = self.client.session
+        self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)
+        self.assertIn(SOCIAL_AUTH_REFRESH_SESSION_KEY, session)
+
+
+@override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)
+class SocialLoginPageViewTests(TestCase):
+    @patch("users.page_views.build_authorization_url")
+    def test_social_login_start_redirects_to_provider(self, build_authorization_url_mock):
+        build_authorization_url_mock.return_value = "https://nid.naver.com/oauth2.0/authorize?state=test"
+
+        response = self.client.get("/auth/social/naver/?remember=on")
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], "https://nid.naver.com/oauth2.0/authorize?state=test")
+
+    @patch("users.page_views.complete_social_login")
+    def test_social_login_callback_redirects_to_profile_and_stores_jwt(self, complete_social_login_mock):
+        user = User.objects.create_user(email="page@example.com")
+        UserProfile.objects.create(user=user, nickname="Page User")
+        complete_social_login_mock.return_value = SocialLoginResult(
+            user=user,
+            backend_path="social_core.backends.kakao.KakaoOAuth2",
+            provider="kakao",
+            is_new_user=True,
+        )
+
+        session = self.client.session
+        session["tailtalk_social_oauth_remember"] = False
+        session.save()
+
+        response = self.client.get("/auth/social/kakao/callback/?code=test-code&state=test-state")
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], f"{reverse('profile')}?setup=1")
+
+        session = self.client.session
+        self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)
+        self.assertIn(SOCIAL_AUTH_REFRESH_SESSION_KEY, session)
 
 
 @override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -1,15 +1,25 @@
 from django.conf import settings
-from django.contrib.auth import authenticate, logout
+from django.contrib.auth import authenticate, login, logout
 from django.db.models import ProtectedError
 from django.db import transaction
+from django.urls import reverse
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework import status
 from rest_framework_simplejwt.tokens import RefreshToken
+from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthException, AuthForbidden, AuthMissingParameter
 
 from .models import SocialAccount, User, UserProfile
 from .oauth import OAuthProviderClient, SocialAuthError
+from .social_auth import (
+    SOCIAL_AUTH_ACCESS_SESSION_KEY,
+    SOCIAL_AUTH_REFRESH_SESSION_KEY,
+    SOCIAL_AUTH_REMEMBER_SESSION_KEY,
+    SocialAuthServiceError,
+    build_authorization_url,
+    complete_social_login,
+)
 
 
 @transaction.atomic
@@ -80,6 +90,24 @@ def build_fallback_email(provider: str, provider_user_id: str) -> str:
     return f"{provider}_{provider_user_id}@oauth.local"
 
 
+def issue_user_tokens(user):
+    refresh = RefreshToken.for_user(user)
+    return {
+        "access": str(refresh.access_token),
+        "refresh": str(refresh),
+    }
+
+
+def serialize_user(user):
+    profile, _ = UserProfile.objects.get_or_create(user=user, defaults={"nickname": user.email.split("@")[0]})
+    return {
+        "id": user.id,
+        "email": user.email,
+        "nickname": profile.nickname,
+        "profile_image_url": profile.profile_image_url,
+    }
+
+
 class RegisterView(APIView):
     permission_classes = [AllowAny]
 
@@ -97,17 +125,11 @@ class RegisterView(APIView):
         user = User.objects.create_user(email=email, password=password)
         UserProfile.objects.create(user=user, nickname=nickname or email.split("@")[0])
 
-        refresh = RefreshToken.for_user(user)
+        tokens = issue_user_tokens(user)
         return Response(
             {
-                "access": str(refresh.access_token),
-                "refresh": str(refresh),
-                "user": {
-                    "id": user.id,
-                    "email": user.email,
-                    "nickname": user.profile.nickname,
-                    "profile_image_url": user.profile.profile_image_url,
-                },
+                **tokens,
+                "user": serialize_user(user),
             },
             status=status.HTTP_201_CREATED,
         )
@@ -127,17 +149,11 @@ class AuthLoginView(APIView):
         if user is None:
             return Response({"detail": "이메일 또는 비밀번호가 올바르지 않습니다."}, status=status.HTTP_401_UNAUTHORIZED)
 
-        refresh = RefreshToken.for_user(user)
+        tokens = issue_user_tokens(user)
         return Response(
             {
-                "access": str(refresh.access_token),
-                "refresh": str(refresh),
-                "user": {
-                    "id": user.id,
-                    "email": user.email,
-                    "nickname": user.profile.nickname,
-                    "profile_image_url": user.profile.profile_image_url,
-                },
+                **tokens,
+                "user": serialize_user(user),
             }
         )
 
@@ -214,6 +230,30 @@ class SocialProviderListView(APIView):
 class SocialLoginView(APIView):
     permission_classes = [AllowAny]
 
+    def get(self, request, provider):
+        remember = request.query_params.get("remember") == "on"
+        redirect_uri = request.build_absolute_uri(
+            reverse("social-login-callback-api", kwargs={"provider": provider})
+        )
+
+        try:
+            authorization_url = build_authorization_url(
+                request=request,
+                provider=provider,
+                redirect_uri=redirect_uri,
+            )
+        except SocialAuthServiceError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        request.session[SOCIAL_AUTH_REMEMBER_SESSION_KEY] = remember
+        return Response(
+            {
+                "provider": provider,
+                "authorization_url": authorization_url,
+                "callback_url": redirect_uri,
+            }
+        )
+
     def post(self, request, provider):
         code = request.data.get("code")
         redirect_uri = request.data.get("redirect_uri")
@@ -235,18 +275,53 @@ class SocialLoginView(APIView):
         except SocialAuthError as exc:
             return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
 
-        refresh = RefreshToken.for_user(user)
+        tokens = issue_user_tokens(user)
         return Response(
             {
                 "provider": provider,
-                "access": str(refresh.access_token),
-                "refresh": str(refresh),
+                **tokens,
                 "is_new_user": is_new_user,
-                "user": {
-                    "id": user.id,
-                    "email": user.email,
-                    "nickname": user.profile.nickname,
-                    "profile_image_url": user.profile.profile_image_url,
-                },
+                "user": serialize_user(user),
+            }
+        )
+
+
+class SocialLoginCallbackView(APIView):
+    permission_classes = [AllowAny]
+
+    def get(self, request, provider):
+        redirect_uri = request.build_absolute_uri(
+            reverse("social-login-callback-api", kwargs={"provider": provider})
+        )
+
+        try:
+            result = complete_social_login(
+                request=request,
+                provider=provider,
+                redirect_uri=redirect_uri,
+            )
+        except (AuthCanceled, AuthConnectionError, AuthMissingParameter, AuthForbidden, AuthException, SocialAuthServiceError) as exc:
+            return Response(
+                {"detail": f"{provider} OAuth failed: {exc}"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        user = result.user
+        user.backend = result.backend_path
+        login(request, user)
+        if not request.session.get(SOCIAL_AUTH_REMEMBER_SESSION_KEY):
+            request.session.set_expiry(0)
+
+        tokens = issue_user_tokens(user)
+        request.session[SOCIAL_AUTH_ACCESS_SESSION_KEY] = tokens["access"]
+        request.session[SOCIAL_AUTH_REFRESH_SESSION_KEY] = tokens["refresh"]
+        request.session.pop(SOCIAL_AUTH_REMEMBER_SESSION_KEY, None)
+
+        return Response(
+            {
+                "provider": result.provider,
+                **tokens,
+                "is_new_user": result.is_new_user,
+                "user": serialize_user(user),
             }
         )


### PR DESCRIPTION
## 요약
`social-auth-app-django` 기반 Google / Kakao / Naver 소셜 로그인 흐름을 추가하고, OAuth 완료 후 Django Session과 JWT를 함께 처리하도록 구현했습니다.

## 변경 사항
- `social-auth-app-django`, `social-auth-core`를 추가하고 Google / Kakao / Naver backend, pipeline, timeout 설정을 반영했습니다.
- `GET /api/auth/social/{provider}`와 `GET /api/auth/social/{provider}/callback`를 구현해 OAuth Redirect URL 반환과 완료 후 JWT 발급을 처리했습니다.
- MVT 로그인/회원가입 화면도 `/auth/social/{provider}` 경로를 사용하도록 정리하고, OAuth 완료 후 Session 로그인과 JWT 저장을 함께 처리하도록 변경했습니다.
- 소셜 로그인 관련 테스트를 추가했고 `docker exec tailtalk-django-1 python manage.py test users` 기준 10건 통과를 확인했습니다.
- 실제 구현 기준으로 `docs/planning/04_data_model_detail.md`를 동기화했습니다.

## 관련 이슈
closes #44
ref #43

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- `social-auth-app-django`와 기존 `SocialAccount`를 함께 유지하는 현재 구조가 팀 의도와 맞는지 확인 부탁드립니다.
- provider별 이메일이 다르게 내려올 때 계정 병합 정책을 추가할지 검토 부탁드립니다.
