### PR TITLE
[data] 도메인 데이터 파이프라인 구축 (#142)

### DIFF
--- a/scripts/domain/convert_domain_data.py
+++ b/scripts/domain/convert_domain_data.py
@@ -1,0 +1,181 @@
+"""
+domain-data/ Excel → output/domain/ Parquet 변환
+
+출력:
+    output/domain/qna.parquet        -- QnA 6개 파일 통합 (2,412행)
+    output/domain/breed_meta.parquet -- 강아지(900행) + 고양이(225행) 통합 (1,125행)
+
+명세: docs/domain/01_domain_preprocessing.md
+"""
+
+from pathlib import Path
+
+import pandas as pd
+
+BASE_DIR = Path(__file__).resolve().parents[2]
+DOMAIN_DIR = BASE_DIR / "domain-data"
+OUTPUT_DIR = BASE_DIR / "output" / "domain"
+OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
+
+# ──────────────────────────────────────────────
+# size_class 정규화 매핑
+# ──────────────────────────────────────────────
+
+SIZE_MAP = {
+    "초소형":   ["XS"],
+    "소형":     ["S"],
+    "소형/중형": ["S", "M"],
+    "중형":     ["M"],
+    "S/M/L":   ["S", "M", "L"],
+    "중형/대형": ["M", "L"],
+    "대형":     ["L"],
+    "대형/XL":  ["L", "XL"],
+    "초대형":   ["XL"],
+    "초대형/XL": ["XL"],
+}
+
+
+def normalize_size_class(val) -> list[str]:
+    if pd.isna(val):
+        return []
+    return SIZE_MAP.get(str(val).strip(), [str(val).strip()])
+
+
+# ──────────────────────────────────────────────
+# QnA
+# ──────────────────────────────────────────────
+
+QNA_FILES = [
+    ("bemypet_cat_Q&A(완료).xlsx",      "bemypet", "cat"),
+    ("bemypet_dog_Q&A(완료).xlsx",      "bemypet", "dog"),
+    ("bemypet_product_Q&A(완료).xlsx",  "bemypet", "both"),
+    ("biteme_blog_Q&A(완료).xlsx",      "biteme",  "both"),
+    ("강아지 질의응답 1000선_완료.xlsx", "manual",  "dog"),
+    ("고양이 질의응답 1000선_완료.xlsx", "manual",  "cat"),
+]
+
+
+def build_qna() -> pd.DataFrame:
+    frames = []
+    for filename, source, species in QNA_FILES:
+        df = pd.read_excel(DOMAIN_DIR / filename)
+        df["No."] = pd.to_numeric(df["No."], errors="coerce")
+        df = df.dropna(subset=["No."]).copy()
+        df["No."] = df["No."].astype(int)
+        df["source"] = source
+        df["species"] = species
+        df = df.rename(columns={
+            "No.": "no",
+            "질문 카테고리": "category",
+            "질문": "question",
+            "답변": "answer",
+            "참고사항": "notes",
+        })
+        frames.append(df[["no", "species", "source", "category", "question", "answer", "notes"]])
+        print(f"  [{filename}] {len(df)}건")
+
+    result = pd.concat(frames, ignore_index=True)
+    result["no"] = range(1, len(result) + 1)
+    return result
+
+
+# ──────────────────────────────────────────────
+# 품종 메타
+# ──────────────────────────────────────────────
+
+DOG_FILE = "강아지 300종 데이터 정보(연령_비만 메타).xlsx"
+CAT_FILE = "고양이 75종 데이타 정보(연령_비만 메타).xlsx"
+CAT_SHEET = "고양이 연령 & 비만메타"
+
+# 강아지/고양이 공통 출력 컬럼
+BREED_COLS = [
+    "no", "species", "breed_name", "breed_name_en",
+    "group", "size_class", "age_group",
+    "general_traits", "health_traits", "care_difficulty",
+    "preferred_food", "health_products", "vet_nutrition_desc", "source_ref",
+]
+
+
+def build_breed_meta() -> pd.DataFrame:
+    # ── 강아지 ──
+    dog = pd.read_excel(DOMAIN_DIR / DOG_FILE)
+    dog = dog.rename(columns={
+        "No.":                                                   "no",
+        "품종명":                                                 "breed_name",
+        "그룹":                                                   "group",
+        "영문명(English)":                                        "breed_name_en",
+        "이미지(체급)":                                           "size_class",
+        "연령대":                                                 "age_group",
+        "일반 특징":                                              "general_traits",
+        "건강 특징":                                              "health_traits",
+        "난이도":                                                 "care_difficulty",
+        "좋아하는 사료":                                           "preferred_food",
+        "건강제품":                                               "health_products",
+        "수의 영양학적 메타 디스크립션 (BCS 상세 가이드 포함)":      "vet_nutrition_desc",
+        "출처(Reference)":                                        "source_ref",
+    })
+    dog["species"] = "dog"
+    print(f"  [{DOG_FILE}] {len(dog)}행")
+
+    # ── 고양이 ──
+    cat = pd.read_excel(DOMAIN_DIR / CAT_FILE, sheet_name=CAT_SHEET)
+    cat = cat.rename(columns={
+        "No.":                                                   "no",
+        "품종명(국문)":                                           "breed_name",
+        "그룹":                                                   "group",
+        "영문명(English)":                                        "breed_name_en",
+        "체급":                                                   "size_class",
+        "연령대":                                                 "age_group",
+        "일반 특징":                                              "general_traits",
+        "건강 특징":                                              "health_traits",
+        "난이도":                                                 "care_difficulty",
+        "좋아하는 사료":                                           "preferred_food",
+        "건강제품":                                               "health_products",
+        "수의 영양학적 메타 디스크립션 (BCS 상세 가이드 포함)":      "vet_nutrition_desc",
+        "출처(Reference)":                                        "source_ref",
+    })
+    cat["species"] = "cat"
+    print(f"  [{CAT_FILE} / {CAT_SHEET}] {len(cat)}행")
+
+    result = pd.concat([dog, cat], ignore_index=True)
+
+    # no float → int
+    result["no"] = pd.to_numeric(result["no"], errors="coerce")
+    result = result.dropna(subset=["no"]).copy()
+    result["no"] = result["no"].astype(int)
+
+    # size_class 정규화 (str → list)
+    result["size_class"] = result["size_class"].apply(normalize_size_class)
+
+    return result[BREED_COLS]
+
+
+# ──────────────────────────────────────────────
+# main
+# ──────────────────────────────────────────────
+
+def main():
+    print("=== QnA 변환 ===")
+    qna = build_qna()
+    out_qna = OUTPUT_DIR / "qna.parquet"
+    qna.to_parquet(out_qna, index=False)
+    print(f"  → {out_qna}  ({len(qna)}건)")
+
+    print("\n=== 품종 메타 변환 ===")
+    breed = build_breed_meta()
+    out_breed = OUTPUT_DIR / "breed_meta.parquet"
+    breed.to_parquet(out_breed, index=False)
+    print(f"  → {out_breed}  ({len(breed)}행)")
+
+    print("\n── QnA species 분포 ──")
+    print(qna["species"].value_counts().to_string())
+    print("\n── QnA category 분포 ──")
+    print(qna["category"].value_counts().to_string())
+    print("\n── breed group 분포 ──")
+    print(breed.drop_duplicates(subset=["no", "species"]).groupby(["species", "group"]).size().to_string())
+    print("\n── breed size_class 샘플 ──")
+    print(breed[["breed_name", "age_group", "size_class"]].head(6).to_string())
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/domain/ingest_domain_qdrant.py
+++ b/scripts/domain/ingest_domain_qdrant.py
@@ -1,0 +1,274 @@
+"""
+output/domain/ Parquet → Qdrant domain_qna / breed_meta 컬렉션 적재
+
+- Dense:  intfloat/multilingual-e5-large (1024d, fastembed)
+- Sparse: Qdrant/bm25 (fastembed)
+- 청크 텍스트 설계: docs/domain/02_domain_rag_pipeline.md
+
+실행:
+  conda run -n final-project python scripts/domain/ingest_domain_qdrant.py --collection all
+
+  # 개별 컬렉션
+  conda run -n final-project python scripts/domain/ingest_domain_qdrant.py --collection qna
+  conda run -n final-project python scripts/domain/ingest_domain_qdrant.py --collection breed
+
+  # 컬렉션 재생성 (기존 데이터 삭제 후 재적재)
+  conda run -n final-project python scripts/domain/ingest_domain_qdrant.py --collection all --recreate
+
+  # 배치 크기 조정
+  conda run -n final-project python scripts/domain/ingest_domain_qdrant.py --collection all --batch 32
+"""
+
+import argparse
+import os
+from datetime import datetime
+from pathlib import Path
+
+import pandas as pd
+from qdrant_client import QdrantClient
+from qdrant_client.models import (
+    Distance,
+    HnswConfigDiff,
+    Modifier,
+    PointStruct,
+    SparseIndexParams,
+    SparseVector,
+    SparseVectorParams,
+    VectorParams,
+)
+
+# ── 환경변수 ───────────────────────────────────────────────────────────────────
+
+QDRANT_URL = os.getenv("QDRANT_URL", "http://localhost:6333")
+QDRANT_KEY = os.getenv("QDRANT_API_KEY", None)
+
+BASE_DIR   = Path(__file__).resolve().parents[2]
+DOMAIN_DIR = BASE_DIR / "output" / "domain"
+
+QNA_PARQUET   = DOMAIN_DIR / "qna.parquet"
+BREED_PARQUET = DOMAIN_DIR / "breed_meta.parquet"
+
+COL_QNA   = "domain_qna"
+COL_BREED = "breed_meta"
+
+
+# ── 청크 텍스트 빌더 ──────────────────────────────────────────────────────────
+
+def build_qna_text(row) -> str:
+    parts = [
+        f"[카테고리] {row.get('category') or ''}",
+        f"[질문] {row.get('question') or ''}",
+        f"[답변] {row.get('answer') or ''}",
+    ]
+    notes = row.get("notes")
+    if notes and str(notes).strip() and str(notes).strip().lower() != "nan":
+        parts.append(f"[참고] {notes}")
+    return "\n".join(parts).strip()
+
+
+def build_breed_text(row) -> str:
+    species_kr = "강아지" if row.get("species") == "dog" else "고양이"
+    parts = [
+        f"[품종] {row.get('breed_name') or ''} ({row.get('breed_name_en') or ''}) — {species_kr} / {row.get('group') or ''}",
+        f"[연령대] {row.get('age_group') or ''}",
+        f"[일반 특징] {row.get('general_traits') or ''}",
+        f"[건강 특징] {row.get('health_traits') or ''}",
+        f"[좋아하는 사료] {row.get('preferred_food') or ''}",
+        f"[건강제품] {row.get('health_products') or ''}",
+        f"[수의 영양학적 메타] {row.get('vet_nutrition_desc') or ''}",
+    ]
+    return "\n".join(p for p in parts if not p.endswith("— /") and not p.endswith("] ")).strip()
+
+
+# ── payload 빌더 ──────────────────────────────────────────────────────────────
+
+def build_qna_payload(row) -> dict:
+    return {
+        "no":       int(row["no"]),
+        "species":  row.get("species"),
+        "category": row.get("category"),
+        "source":   row.get("source"),
+    }
+
+
+def build_breed_payload(row) -> dict:
+    def safe_int(v):
+        try:
+            iv = int(v)
+            return iv
+        except (TypeError, ValueError):
+            return None
+
+    def safe_str(v):
+        if v is None or (isinstance(v, float) and v != v):
+            return None
+        return str(v).strip() or None
+
+    return {
+        "species":       row.get("species"),
+        "breed_name":    row.get("breed_name"),
+        "breed_name_en": row.get("breed_name_en"),
+        "group":         row.get("group"),
+        "size_class":    list(row["size_class"]) if row.get("size_class") is not None else [],
+        "age_group":     row.get("age_group"),
+        "care_difficulty": safe_int(row.get("care_difficulty")),
+        "preferred_food":  safe_str(row.get("preferred_food")),
+        "health_products": safe_str(row.get("health_products")),
+    }
+
+
+# ── Qdrant 컬렉션 생성 ────────────────────────────────────────────────────────
+
+def ensure_collection(client: QdrantClient, name: str, recreate: bool) -> None:
+    existing = {c.name for c in client.get_collections().collections}
+    if recreate and name in existing:
+        print(f"  [{name}] 삭제 후 재생성...")
+        client.delete_collection(name)
+        existing.discard(name)
+    if name not in existing:
+        client.create_collection(
+            collection_name=name,
+            vectors_config={
+                "dense": VectorParams(
+                    size=1024,
+                    distance=Distance.COSINE,
+                    hnsw_config=HnswConfigDiff(m=16, ef_construct=100),
+                )
+            },
+            sparse_vectors_config={
+                "sparse": SparseVectorParams(
+                    index=SparseIndexParams(on_disk=False),
+                    modifier=Modifier.IDF,
+                )
+            },
+        )
+        print(f"  [{name}] 컬렉션 생성 완료")
+    else:
+        print(f"  [{name}] 기존 컬렉션 사용 (upsert)")
+
+
+# ── 배치 적재 ─────────────────────────────────────────────────────────────────
+
+def ingest(
+    client: QdrantClient,
+    collection: str,
+    texts: list[str],
+    payloads: list[dict],
+    point_ids: list[int],
+    dense_model,
+    sparse_model,
+    batch_size: int,
+) -> None:
+    from tqdm import tqdm
+
+    total    = len(texts)
+    upserted = 0
+    batches  = range(0, total, batch_size)
+    pbar     = tqdm(batches, total=len(batches), unit="batch",
+                    desc=f"{collection} 임베딩+적재", dynamic_ncols=True)
+
+    for start in pbar:
+        end         = min(start + batch_size, total)
+        batch_text  = texts[start:end]
+        batch_pay   = payloads[start:end]
+        batch_ids   = point_ids[start:end]
+
+        dense_vecs  = list(dense_model.embed(batch_text))
+        sparse_vecs = list(sparse_model.embed(batch_text))
+
+        points = [
+            PointStruct(
+                id=pid,
+                vector={
+                    "dense":  dv.tolist(),
+                    "sparse": SparseVector(
+                        indices=sv.indices.tolist(),
+                        values=sv.values.tolist(),
+                    ),
+                },
+                payload=pay,
+            )
+            for pid, pay, dv, sv in zip(batch_ids, batch_pay, dense_vecs, sparse_vecs)
+        ]
+
+        client.upsert(collection_name=collection, points=points)
+        upserted += len(points)
+        pbar.set_postfix({"적재": f"{upserted:,}/{total:,}"})
+
+    info = client.get_collection(collection)
+    print(f"  [{collection}] 적재 완료: {upserted:,}개  (컬렉션 총 {info.points_count:,})")
+
+
+# ── QnA 파이프라인 ────────────────────────────────────────────────────────────
+
+def run_qna(client, dense_model, sparse_model, recreate: bool, batch_size: int) -> None:
+    print(f"\n=== domain_qna 적재 ===")
+    if not QNA_PARQUET.exists():
+        raise FileNotFoundError(f"파일 없음: {QNA_PARQUET}  (convert_domain_data.py 먼저 실행)")
+    df = pd.read_parquet(QNA_PARQUET)
+    print(f"  로드: {QNA_PARQUET}  ({len(df):,}행)")
+
+    ensure_collection(client, COL_QNA, recreate)
+
+    texts    = [build_qna_text(row) for _, row in df.iterrows()]
+    payloads = [build_qna_payload(row) for _, row in df.iterrows()]
+    # point id: no 기반 (1-indexed sequential)
+    ids      = [int(row["no"]) for _, row in df.iterrows()]
+
+    ingest(client, COL_QNA, texts, payloads, ids, dense_model, sparse_model, batch_size)
+
+
+# ── breed_meta 파이프라인 ─────────────────────────────────────────────────────
+
+def run_breed(client, dense_model, sparse_model, recreate: bool, batch_size: int) -> None:
+    print(f"\n=== breed_meta 적재 ===")
+    if not BREED_PARQUET.exists():
+        raise FileNotFoundError(f"파일 없음: {BREED_PARQUET}  (convert_domain_data.py 먼저 실행)")
+    df = pd.read_parquet(BREED_PARQUET)
+    print(f"  로드: {BREED_PARQUET}  ({len(df):,}행)")
+
+    ensure_collection(client, COL_BREED, recreate)
+
+    texts    = [build_breed_text(row) for _, row in df.iterrows()]
+    payloads = [build_breed_payload(row) for _, row in df.iterrows()]
+    # point id: 행 인덱스 기반 (0-indexed → 1-indexed)
+    ids      = list(range(1, len(df) + 1))
+
+    ingest(client, COL_BREED, texts, payloads, ids, dense_model, sparse_model, batch_size)
+
+
+# ── 메인 ──────────────────────────────────────────────────────────────────────
+
+def main(collection: str, recreate: bool, batch_size: int) -> None:
+    print(f"[ingest_domain_qdrant] 시작 — {datetime.now().strftime('%H:%M:%S')}")
+    print(f"  Qdrant: {QDRANT_URL}")
+    print(f"  collection: {collection}  recreate: {recreate}  batch: {batch_size}")
+
+    print("\n  모델 로드 중 (fastembed)...")
+    from fastembed import SparseTextEmbedding, TextEmbedding
+    dense_model  = TextEmbedding("intfloat/multilingual-e5-large")
+    sparse_model = SparseTextEmbedding("Qdrant/bm25")
+    print("  모델 로드 완료")
+
+    client = QdrantClient(url=QDRANT_URL, api_key=QDRANT_KEY)
+
+    if collection in ("qna", "all"):
+        run_qna(client, dense_model, sparse_model, recreate, batch_size)
+    if collection in ("breed", "all"):
+        run_breed(client, dense_model, sparse_model, recreate, batch_size)
+
+    print(f"\n[완료] {datetime.now().strftime('%H:%M:%S')}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="domain Parquet → Qdrant 적재")
+    parser.add_argument(
+        "--collection",
+        choices=["qna", "breed", "all"],
+        default="all",
+        help="적재할 컬렉션 (기본: all)",
+    )
+    parser.add_argument("--recreate", action="store_true", help="컬렉션 재생성 후 적재")
+    parser.add_argument("--batch", type=int, default=64, metavar="N", help="배치 크기 (기본 64)")
+    args = parser.parse_args()
+    main(collection=args.collection, recreate=args.recreate, batch_size=args.batch)

--- a/scripts/restore_postgres.sh
+++ b/scripts/restore_postgres.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# backup/*.dump → PostgreSQL 복원
+#
+# 사용법:
+#   ./scripts/restore_postgres.sh                      # 최신 덤프 자동 선택
+#   ./scripts/restore_postgres.sh backup/data_20260319.dump  # 파일 직접 지정
+#
+# 전제조건:
+#   - docker compose up -d 실행 중 (migrate 자동 적용됨)
+#   - backup/data_*.dump 존재
+
+set -euo pipefail
+
+CONTAINER="${POSTGRES_CONTAINER:-tailtalk-postgres-1}"
+PG_USER="${POSTGRES_USER:-mungnyang}"
+PG_DB="${POSTGRES_DB:-tailtalk_db}"
+BACKUP_DIR="$(cd "$(dirname "$0")/../backup" && pwd)"
+DRY_RUN=false
+
+# 인자 파싱
+POSITIONAL=()
+for arg in "$@"; do
+  case $arg in
+    --dry-run) DRY_RUN=true ;;
+    *) POSITIONAL+=("$arg") ;;
+  esac
+done
+
+# 덤프 파일 결정
+if [[ ${#POSITIONAL[@]} -ge 1 ]]; then
+  DUMP_FILE="${POSITIONAL[0]}"
+else
+  DUMP_FILE=$(ls -t "${BACKUP_DIR}"/data_*.dump 2>/dev/null | head -1)
+fi
+
+if [[ -z "$DUMP_FILE" ]]; then
+  echo "오류: 덤프 파일 없음 (${BACKUP_DIR}/data_*.dump)"
+  exit 1
+fi
+
+echo "[RESTORE] PostgreSQL ← $(basename "$DUMP_FILE")${DRY_RUN:+ (dry-run)}"
+
+# 컨테이너에 복사
+docker cp "$DUMP_FILE" "${CONTAINER}:/tmp/data_backup.dump"
+
+if [[ "$DRY_RUN" == true ]]; then
+  echo ""
+  echo "── 덤프 내용 목록 ──"
+  docker exec "${CONTAINER}" pg_restore --list /tmp/data_backup.dump
+else
+  docker exec "${CONTAINER}" pg_restore \
+    -U "$PG_USER" -d "$PG_DB" \
+    --data-only --disable-triggers \
+    /tmp/data_backup.dump
+
+  echo ""
+  docker exec "${CONTAINER}" psql -U "$PG_USER" -d "$PG_DB" \
+    -c "SELECT 'product' AS table, COUNT(*) FROM product UNION ALL SELECT 'review', COUNT(*) FROM review;"
+fi
+
+# 컨테이너 내 임시 파일 삭제
+docker exec "${CONTAINER}" rm /tmp/data_backup.dump
+
+echo ""
+echo "완료"

--- a/scripts/restore_qdrant.sh
+++ b/scripts/restore_qdrant.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# backup/qdrant/ 스냅샷 → Qdrant 컬렉션 복원
+#
+# 사용법:
+#   ./scripts/restore_qdrant.sh              # 전체 컬렉션
+#   ./scripts/restore_qdrant.sh products     # 단일 컬렉션
+#
+# 전제조건:
+#   - Qdrant 컨테이너 실행 중 (http://localhost:6333)
+#   - backup/qdrant/<collection>/*.snapshot 존재
+
+set -euo pipefail
+
+QDRANT_URL="${QDRANT_URL:-http://localhost:6333}"
+BACKUP_DIR="$(cd "$(dirname "$0")/../backup/qdrant" && pwd)"
+
+COLLECTIONS=(products domain_qna breed_meta)
+
+# 인자로 특정 컬렉션 지정 가능
+if [[ $# -ge 1 ]]; then
+  COLLECTIONS=("$@")
+fi
+
+for col in "${COLLECTIONS[@]}"; do
+  snapshot=$(ls -t "${BACKUP_DIR}/${col}"/*.snapshot 2>/dev/null | head -1)
+
+  if [[ -z "$snapshot" ]]; then
+    echo "[SKIP] ${col}: 스냅샷 없음 (${BACKUP_DIR}/${col}/)"
+    continue
+  fi
+
+  echo "[RESTORE] ${col} ← $(basename "$snapshot")"
+  curl -sf -X POST \
+    "${QDRANT_URL}/collections/${col}/snapshots/upload?priority=snapshot" \
+    -F "snapshot=@${snapshot}" | python3 -c "
+import sys, json
+r = json.load(sys.stdin)
+print('  status:', r.get('status'))
+"
+
+  points=$(curl -sf "${QDRANT_URL}/collections/${col}" \
+    | python3 -c "import sys,json; print(json.load(sys.stdin)['result']['points_count'])")
+  echo "  points_count: ${points}"
+done
+
+echo ""
+echo "완료"


### PR DESCRIPTION
## Summary

closes #142

- `scripts/domain/convert_domain_data.py`: Excel → Parquet 변환 (qna 2,411행 / breed_meta 1,125행)
- `scripts/domain/ingest_domain_qdrant.py`: Parquet → Qdrant 적재 (domain_qna, breed_meta 컬렉션)
- `scripts/restore_qdrant.sh`: 3개 컬렉션 스냅샷 복원 (최신 자동 선택)
- `scripts/restore_postgres.sh`: PostgreSQL 덤프 복원 (`--dry-run` 옵션 포함)

## Test plan

- [x] `convert_domain_data.py` 실행 → qna.parquet 2,411행 / breed_meta.parquet 1,125행 확인
- [x] `ingest_domain_qdrant.py --collection all` 실행 → Qdrant 컬렉션 points_count 확인
- [x] `restore_qdrant.sh` 실행 → 3개 컬렉션 복원 확인
- [x] `restore_postgres.sh --dry-run` 실행 → 덤프 내용 목록 출력 확인