### PR TITLE
[backend] 반려동물 예방접종일 검증 추가

### DIFF
--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -86,7 +86,7 @@ class PetApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
 
-    def test_post_pets_rejects_empty_vaccination_date(self):
+    def test_post_pets_allows_empty_vaccination_date(self):
         response = self.client.post(
             "/api/pets/",
             {
@@ -98,8 +98,9 @@ class PetApiTests(TestCase):
             format="json",
         )
 
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        pet = Pet.objects.get(user=self.user, name="Bori")
+        self.assertIsNone(pet.vaccination_date)
 
     def test_post_pets_rejects_vaccination_date_before_minimum(self):
         response = self.client.post(

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -1,3 +1,4 @@
+from datetime import date, timedelta
 from decimal import Decimal
 
 from django.test import TestCase
@@ -69,6 +70,66 @@ class PetApiTests(TestCase):
         self.assertEqual(set(pet.health_concerns.values_list("concern", flat=True)), {"skin", "joint"})
         self.assertEqual(set(pet.allergies.values_list("ingredient", flat=True)), {"chicken", "beef"})
         self.assertEqual(set(pet.food_preferences.values_list("food_type", flat=True)), {"dry", "wet_can"})
+
+    def test_post_pets_rejects_invalid_vaccination_date_format(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "vaccination_date": "2026/03/01",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
+
+    def test_post_pets_rejects_empty_vaccination_date(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "vaccination_date": "",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
+
+    def test_post_pets_rejects_vaccination_date_before_minimum(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "vaccination_date": "1899-12-31",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
+
+    def test_post_pets_rejects_future_vaccination_date(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "vaccination_date": (date.today() + timedelta(days=1)).isoformat(),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "vaccination_date must be a valid date.")
 
     def test_post_pets_rejects_more_than_five_pets(self):
         for index in range(5):

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -1,0 +1,168 @@
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from users.models import User, UserProfile
+
+from .models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
+
+
+class PetApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(email="pet-owner@example.com", password="Password123!")
+        UserProfile.objects.create(user=self.user, nickname="Pet Owner")
+        self.client.force_authenticate(self.user)
+
+    def test_get_pets_returns_only_my_pets(self):
+        my_pet = Pet.objects.create(
+            user=self.user,
+            name="Nabi",
+            species="cat",
+            gender="female",
+            budget_range="5_10",
+        )
+        PetHealthConcern.objects.create(pet=my_pet, concern="skin")
+        PetAllergy.objects.create(pet=my_pet, ingredient="chicken")
+        PetFoodPreference.objects.create(pet=my_pet, food_type="dry")
+
+        other_user = User.objects.create_user(email="other@example.com", password="Password123!")
+        UserProfile.objects.create(user=other_user, nickname="Other")
+        Pet.objects.create(user=other_user, name="Bori", species="dog", gender="male", budget_range="under_5")
+
+        response = self.client.get("/api/pets/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["pets"]), 1)
+        self.assertEqual(response.data["pets"][0]["name"], "Nabi")
+        self.assertEqual(response.data["pets"][0]["health_concerns"], ["skin"])
+        self.assertEqual(response.data["pets"][0]["allergies"], ["chicken"])
+        self.assertEqual(response.data["pets"][0]["food_preferences"], ["dry"])
+
+    def test_post_pets_creates_pet_with_multi_value_fields(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "breed": "Maltese",
+                "age_years": 3,
+                "age_months": 2,
+                "weight_kg": "4.20",
+                "neutered": True,
+                "vaccination_date": "2026-03-01",
+                "budget_range": "5_10",
+                "special_notes": "likes walks",
+                "health_concerns": ["skin", "joint"],
+                "allergies": ["chicken", "beef"],
+                "food_preferences": ["dry", "wet_can"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        pet = Pet.objects.get(user=self.user, name="Bori")
+        self.assertEqual(pet.weight_kg, Decimal("4.20"))
+        self.assertEqual(set(pet.health_concerns.values_list("concern", flat=True)), {"skin", "joint"})
+        self.assertEqual(set(pet.allergies.values_list("ingredient", flat=True)), {"chicken", "beef"})
+        self.assertEqual(set(pet.food_preferences.values_list("food_type", flat=True)), {"dry", "wet_can"})
+
+    def test_post_pets_rejects_more_than_five_pets(self):
+        for index in range(5):
+            Pet.objects.create(
+                user=self.user,
+                name=f"Pet{index}",
+                species="dog",
+                gender="male",
+                budget_range="under_5",
+            )
+
+        response = self.client.post(
+            "/api/pets/",
+            {"name": "Overflow", "species": "dog", "gender": "male"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "You can register up to 5 pets.")
+
+    def test_patch_pet_updates_fields_and_replaces_multi_value_fields(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Nabi",
+            species="cat",
+            gender="female",
+            budget_range="under_5",
+        )
+        PetHealthConcern.objects.create(pet=pet, concern="skin")
+        PetAllergy.objects.create(pet=pet, ingredient="chicken")
+        PetFoodPreference.objects.create(pet=pet, food_type="dry")
+
+        response = self.client.patch(
+            f"/api/pets/{pet.pet_id}/",
+            {
+                "name": "Nabi Updated",
+                "budget_range": "10_20",
+                "health_concerns": ["joint", "digestion"],
+                "allergies": ["salmon"],
+                "food_preferences": ["wet_pouch"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        pet.refresh_from_db()
+        self.assertEqual(pet.name, "Nabi Updated")
+        self.assertEqual(pet.budget_range, "10_20")
+        self.assertEqual(set(pet.health_concerns.values_list("concern", flat=True)), {"joint", "digestion"})
+        self.assertEqual(list(pet.allergies.values_list("ingredient", flat=True)), ["salmon"])
+        self.assertEqual(list(pet.food_preferences.values_list("food_type", flat=True)), ["wet_pouch"])
+
+    def test_delete_pet_removes_pet(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Delete Me",
+            species="dog",
+            gender="male",
+            budget_range="under_5",
+        )
+
+        response = self.client.delete(f"/api/pets/{pet.pet_id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(Pet.objects.filter(pet_id=pet.pet_id).exists())
+
+    def test_post_delete_override_supports_template_form(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Delete Form",
+            species="dog",
+            gender="male",
+            budget_range="under_5",
+        )
+
+        response = self.client.post(f"/api/pets/{pet.pet_id}/", {"_method": "DELETE"})
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], "/pets/")
+        self.assertFalse(Pet.objects.filter(pet_id=pet.pet_id).exists())
+
+    def test_session_authenticated_post_delete_override_supports_template_form(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Delete Session Form",
+            species="dog",
+            gender="male",
+            budget_range="under_5",
+        )
+        self.client.force_authenticate(user=None)
+        self.client.login(email="pet-owner@example.com", password="Password123!")
+
+        response = self.client.post(f"/api/pets/{pet.pet_id}/", {"_method": "DELETE"})
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], "/pets/")
+        self.assertFalse(Pet.objects.filter(pet_id=pet.pet_id).exists())

--- a/services/django/pets/urls.py
+++ b/services/django/pets/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
-from .views import PetListView
+
+from .views import PetDetailView, PetListView
 
 urlpatterns = [
     path("", PetListView.as_view(), name="pet-list"),
+    path("<uuid:pet_id>/", PetDetailView.as_view(), name="pet-detail"),
 ]

--- a/services/django/pets/views.py
+++ b/services/django/pets/views.py
@@ -70,7 +70,7 @@ def _parse_boolean(value):
 
 def _parse_vaccination_date(value):
     if value in (None, ""):
-        raise ValueError("vaccination_date must be a valid date.")
+        return None
 
     if not isinstance(value, str):
         raise ValueError("vaccination_date must be a valid date.")

--- a/services/django/pets/views.py
+++ b/services/django/pets/views.py
@@ -1,3 +1,4 @@
+from datetime import date
 from decimal import Decimal, InvalidOperation
 
 from django.shortcuts import get_object_or_404
@@ -65,6 +66,24 @@ def _parse_boolean(value):
     if normalized in {"0", "false", "no", "off"}:
         return False
     raise ValueError("neutered must be a boolean.")
+
+
+def _parse_vaccination_date(value):
+    if value in (None, ""):
+        raise ValueError("vaccination_date must be a valid date.")
+
+    if not isinstance(value, str):
+        raise ValueError("vaccination_date must be a valid date.")
+
+    try:
+        parsed = date.fromisoformat(value)
+    except ValueError as exc:
+        raise ValueError("vaccination_date must be a valid date.") from exc
+
+    if parsed < date(1900, 1, 1) or parsed > date.today():
+        raise ValueError("vaccination_date must be a valid date.")
+
+    return parsed
 
 
 def _get_list_value(request, field_name):
@@ -151,7 +170,7 @@ def _apply_pet_payload(pet, request, *, partial):
         "age_months": lambda value: _parse_integer(value, "age_months"),
         "weight_kg": lambda value: _parse_decimal(value, "weight_kg"),
         "neutered": _parse_boolean,
-        "vaccination_date": lambda value: value or None,
+        "vaccination_date": _parse_vaccination_date,
         "budget_range": lambda value: str(value).strip(),
         "special_notes": lambda value: str(value).strip() or None,
     }

--- a/services/django/pets/views.py
+++ b/services/django/pets/views.py
@@ -1,7 +1,263 @@
-from rest_framework.views import APIView
+from decimal import Decimal, InvalidOperation
+
+from django.shortcuts import get_object_or_404
+from django.http import HttpResponseRedirect
+from django.urls import reverse
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
+
+from .models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
+
+
+def serialize_pet(pet):
+    return {
+        "pet_id": str(pet.pet_id),
+        "name": pet.name,
+        "species": pet.species,
+        "breed": pet.breed,
+        "gender": pet.gender,
+        "age_years": pet.age_years,
+        "age_months": pet.age_months,
+        "weight_kg": str(pet.weight_kg) if pet.weight_kg is not None else None,
+        "neutered": pet.neutered,
+        "vaccination_date": pet.vaccination_date.isoformat() if pet.vaccination_date else None,
+        "budget_range": pet.budget_range,
+        "special_notes": pet.special_notes,
+        "health_concerns": [item.concern for item in pet.health_concerns.order_by("concern")],
+        "allergies": [item.ingredient for item in pet.allergies.order_by("ingredient")],
+        "food_preferences": [item.food_type for item in pet.food_preferences.order_by("food_type")],
+        "created_at": pet.created_at,
+        "updated_at": pet.updated_at,
+    }
+
+
+def _parse_integer(value, field_name):
+    if value in (None, ""):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an integer.") from exc
+
+
+def _parse_decimal(value, field_name):
+    if value in (None, ""):
+        return None
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be a decimal number.") from exc
+
+
+def _parse_boolean(value):
+    if value in (None, ""):
+        return None
+    if isinstance(value, bool):
+        return value
+
+    normalized = str(value).strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"0", "false", "no", "off"}:
+        return False
+    raise ValueError("neutered must be a boolean.")
+
+
+def _get_list_value(request, field_name):
+    if hasattr(request.data, "getlist"):
+        values = request.data.getlist(field_name)
+        if len(values) > 1:
+            return values
+
+    value = request.data.get(field_name)
+    if value is None:
+        return None
+    if isinstance(value, list):
+        return value
+    return [value]
+
+
+def _parse_allergies(raw_values):
+    if raw_values is None:
+        return None
+
+    if len(raw_values) == 1 and isinstance(raw_values[0], str) and "," in raw_values[0]:
+        raw_values = raw_values[0].split(",")
+
+    cleaned = []
+    for value in raw_values:
+        ingredient = str(value).strip()
+        if ingredient and ingredient not in cleaned:
+            cleaned.append(ingredient)
+    return cleaned
+
+
+def _parse_choice_list(raw_values, valid_values, field_name):
+    if raw_values is None:
+        return None
+
+    cleaned = []
+    for value in raw_values:
+        choice = str(value).strip()
+        if choice not in valid_values:
+            raise ValueError(f"{field_name} contains an invalid value: {choice}")
+        if choice not in cleaned:
+            cleaned.append(choice)
+    return cleaned
+
+
+def _replace_related_items(model, pet, field_name, attr_name, values):
+    model.objects.filter(pet=pet).delete()
+    if values is None:
+        return
+    for value in values:
+        model.objects.create(pet=pet, **{field_name: value})
+
+
+def _apply_pet_payload(pet, request, *, partial):
+    required_fields = ["name", "species", "gender"]
+    if not partial:
+        missing = [field for field in required_fields if request.data.get(field) in (None, "")]
+        if missing:
+            raise ValueError(f"Missing required fields: {', '.join(missing)}")
+
+    if "name" in request.data:
+        name = str(request.data.get("name", "")).strip()
+        if not name:
+            raise ValueError("name is required.")
+        pet.name = name
+
+    if "species" in request.data:
+        species = request.data.get("species")
+        valid_species = {choice for choice, _ in Pet.SPECIES_CHOICES}
+        if species not in valid_species:
+            raise ValueError("species must be one of: cat, dog.")
+        pet.species = species
+
+    if "gender" in request.data:
+        gender = request.data.get("gender")
+        valid_genders = {choice for choice, _ in Pet.GENDER_CHOICES}
+        if gender not in valid_genders:
+            raise ValueError("gender must be one of: male, female.")
+        pet.gender = gender
+
+    scalar_fields = {
+        "breed": lambda value: str(value).strip() or None,
+        "age_years": lambda value: _parse_integer(value, "age_years"),
+        "age_months": lambda value: _parse_integer(value, "age_months"),
+        "weight_kg": lambda value: _parse_decimal(value, "weight_kg"),
+        "neutered": _parse_boolean,
+        "vaccination_date": lambda value: value or None,
+        "budget_range": lambda value: str(value).strip(),
+        "special_notes": lambda value: str(value).strip() or None,
+    }
+
+    for field, parser in scalar_fields.items():
+        if field in request.data:
+            setattr(pet, field, parser(request.data.get(field)))
+
+    valid_health_concerns = {choice for choice, _ in PetHealthConcern.CONCERN_CHOICES}
+    valid_food_preferences = {choice for choice, _ in PetFoodPreference.FOOD_TYPE_CHOICES}
+
+    return {
+        "health_concerns": _parse_choice_list(
+            _get_list_value(request, "health_concerns"),
+            valid_health_concerns,
+            "health_concerns",
+        ),
+        "allergies": _parse_allergies(_get_list_value(request, "allergies")),
+        "food_preferences": _parse_choice_list(
+            _get_list_value(request, "food_preferences"),
+            valid_food_preferences,
+            "food_preferences",
+        ),
+    }
 
 
 class PetListView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
     def get(self, request):
-        return Response({"message": "TODO"})
+        pets = (
+            Pet.objects.filter(user=request.user)
+            .prefetch_related("health_concerns", "allergies", "food_preferences")
+            .order_by("created_at")
+        )
+        return Response({"pets": [serialize_pet(pet) for pet in pets]})
+
+    def post(self, request):
+        if request.user.pets.count() >= 5:
+            return Response({"detail": "You can register up to 5 pets."}, status=status.HTTP_400_BAD_REQUEST)
+
+        pet = Pet(user=request.user, budget_range="")
+        try:
+            related_payload = _apply_pet_payload(pet, request, partial=False)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        pet.save()
+        _replace_related_items(PetHealthConcern, pet, "concern", "health_concerns", related_payload["health_concerns"])
+        _replace_related_items(PetAllergy, pet, "ingredient", "allergies", related_payload["allergies"])
+        _replace_related_items(
+            PetFoodPreference,
+            pet,
+            "food_type",
+            "food_preferences",
+            related_payload["food_preferences"],
+        )
+        pet.refresh_from_db()
+        return Response({"pet": serialize_pet(pet)}, status=status.HTTP_201_CREATED)
+
+
+class PetDetailView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def _delete_pet(self, request, pet_id, *, redirect_to_list=False):
+        pet = get_object_or_404(Pet, pet_id=pet_id, user=request.user)
+        pet.delete()
+        if redirect_to_list:
+            return HttpResponseRedirect(reverse("pet_list"))
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+    def patch(self, request, pet_id):
+        pet = get_object_or_404(
+            Pet.objects.prefetch_related("health_concerns", "allergies", "food_preferences"),
+            pet_id=pet_id,
+            user=request.user,
+        )
+        try:
+            related_payload = _apply_pet_payload(pet, request, partial=True)
+        except ValueError as exc:
+            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+        pet.save()
+
+        if related_payload["health_concerns"] is not None:
+            _replace_related_items(PetHealthConcern, pet, "concern", "health_concerns", related_payload["health_concerns"])
+        if related_payload["allergies"] is not None:
+            _replace_related_items(PetAllergy, pet, "ingredient", "allergies", related_payload["allergies"])
+        if related_payload["food_preferences"] is not None:
+            _replace_related_items(
+                PetFoodPreference,
+                pet,
+                "food_type",
+                "food_preferences",
+                related_payload["food_preferences"],
+            )
+
+        pet.refresh_from_db()
+        return Response({"pet": serialize_pet(pet)})
+
+    def delete(self, request, pet_id):
+        return self._delete_pet(request, pet_id)
+
+    def post(self, request, pet_id):
+        if request.data.get("_method", "").upper() == "DELETE":
+            return self._delete_pet(request, pet_id, redirect_to_list=True)
+        return Response({"detail": "Method not allowed."}, status=status.HTTP_405_METHOD_NOT_ALLOWED)

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -33,13 +33,13 @@
       />
 
       <div class="absolute left-[106px] top-[114px] flex h-[48px] w-[188px] items-center justify-between">
-        <a href="/auth/social/kakao/?remember=on" data-social-link aria-label="카카오 로그인">
+        <a href="/auth/kakao/start/?remember=on" data-social-link aria-label="카카오 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
         </a>
-        <a href="/auth/social/naver/?remember=on" data-social-link aria-label="네이버 로그인">
+        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
         </a>
-        <a href="/auth/social/google/?remember=on" data-social-link aria-label="구글 로그인">
+        <a href="/auth/google/start/?remember=on" data-social-link aria-label="구글 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
         </a>
       </div>

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -49,7 +49,7 @@
 
       <div class="text-[18px] font-bold text-[#2d3748]">1. 프로필 관리</div>
 
-      <!-- 프로필 이미지 -->
+      <!-- 프로필 이미지 업로드는 현재 비활성화.
       <div class="mt-6 flex flex-col items-center">
         <div class="relative flex h-[72px] w-[72px] items-center justify-center rounded-full bg-[#cbd5e0] text-[12px] text-[#4a5568]">
           IMG
@@ -57,6 +57,7 @@
         </div>
         <div class="mt-3 text-[12px] text-[#718096]">클릭하여 이미지 업로드</div>
       </div>
+      -->
 
       <!-- 닉네임 / 연락처 -->
       <div class="mt-6 grid grid-cols-1 gap-4 md:grid-cols-2">

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -33,13 +33,13 @@
       />
 
       <div class="absolute left-[106px] top-[114px] flex h-[48px] w-[188px] items-center justify-between">
-        <a href="/auth/social/kakao/?remember=on" data-social-link aria-label="카카오 로그인">
+        <a href="/auth/kakao/start/?remember=on" data-social-link aria-label="카카오 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/d22d7edf-9f92-417d-8172-d0122cb9956e" />
         </a>
-        <a href="/auth/social/naver/?remember=on" data-social-link aria-label="네이버 로그인">
+        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/7cfb3bd5-c1d7-42df-8155-0281c422f977" />
         </a>
-        <a href="/auth/social/google/?remember=on" data-social-link aria-label="구글 로그인">
+        <a href="/auth/google/start/?remember=on" data-social-link aria-label="구글 로그인">
           <img alt="" class="h-[40px] w-[40px]" src="https://www.figma.com/api/mcp/asset/579f7bd6-15db-47cc-995e-1510a459db1d" />
         </a>
       </div>

--- a/services/django/users/auth_urls.py
+++ b/services/django/users/auth_urls.py
@@ -4,16 +4,10 @@ from .views import (
     AuthLoginView,
     AuthLogoutView,
     AuthWithdrawView,
-    SocialLoginCallbackView,
-    SocialLoginView,
-    SocialProviderListView,
 )
 
 urlpatterns = [
     path("login/", AuthLoginView.as_view(), name="auth-login"),
     path("logout/", AuthLogoutView.as_view(), name="auth-logout"),
     path("withdraw/", AuthWithdrawView.as_view(), name="auth-withdraw"),
-    path("providers/", SocialProviderListView.as_view(), name="social-provider-list"),
-    path("social/<str:provider>/", SocialLoginView.as_view(), name="social-login"),
-    path("social/<str:provider>/callback/", SocialLoginCallbackView.as_view(), name="social-login-callback-api"),
 ]

--- a/services/django/users/page_urls.py
+++ b/services/django/users/page_urls.py
@@ -7,8 +7,6 @@ urlpatterns = [
     path("signup/", page_views.signup_view, name="signup"),
     path("logout/", page_views.logout_view, name="logout"),
     path("profile/", page_views.profile_view, name="profile"),
-    path("auth/social/<str:provider>/", page_views.social_login_start_view, name="social-login-start"),
-    path("auth/social/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback"),
-    path("auth/<str:provider>/start/", page_views.social_login_start_view, name="social-login-start-legacy"),
-    path("auth/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback-legacy"),
+    path("auth/<str:provider>/start/", page_views.social_login_start_view, name="social-login-start"),
+    path("auth/<str:provider>/callback/", page_views.social_login_callback_view, name="social-login-callback"),
 ]

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -1,17 +1,13 @@
-import tempfile
-from pathlib import Path
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 from django.urls import reverse
-from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from products.models import Product
 from users.models import SocialAccount, User, UserProfile
-from users.oauth import SocialUserProfile
 from users.social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
     SOCIAL_AUTH_REFRESH_SESSION_KEY,
@@ -45,125 +41,12 @@ TEST_SOCIAL_PROVIDERS = {
 
 
 @override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)
-class SocialLoginViewTests(TestCase):
-    def setUp(self):
-        self.client = APIClient()
-
-    @patch("users.views.OAuthProviderClient.exchange_code")
-    def test_social_login_creates_user_and_tokens(self, exchange_code_mock):
-        exchange_code_mock.return_value = SocialUserProfile(
-            provider="google",
-            provider_user_id="google-user-1",
-            email="user@example.com",
-            nickname="TailTalk User",
-            profile_image_url="https://example.com/avatar.png",
-            extra_data={"sub": "google-user-1"},
-        )
-
-        response = self.client.post(
-            "/api/auth/social/google/",
-            {
-                "code": "oauth-code",
-                "redirect_uri": "http://localhost:3000/auth/google/callback",
-            },
-            format="json",
-        )
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data["user"]["email"], "user@example.com")
-        self.assertTrue(response.data["is_new_user"])
-        self.assertIn("access", response.data)
-        self.assertIn("refresh", response.data)
-        self.assertTrue(User.objects.filter(email="user@example.com").exists())
-        self.assertTrue(
-            SocialAccount.objects.filter(provider="google", provider_user_id="google-user-1").exists()
-        )
-
-    @patch("users.views.OAuthProviderClient.exchange_code")
-    def test_social_login_links_existing_user_by_email(self, exchange_code_mock):
-        user = User.objects.create_user(email="existing@example.com")
-        UserProfile.objects.create(user=user, nickname="Existing User")
-
-        exchange_code_mock.return_value = SocialUserProfile(
-            provider="kakao",
-            provider_user_id="kakao-user-1",
-            email="existing@example.com",
-            nickname="Updated User",
-            profile_image_url="https://example.com/new-avatar.png",
-            extra_data={"id": "kakao-user-1"},
-        )
-
-        response = self.client.post(
-            "/api/auth/social/kakao/",
-            {
-                "code": "oauth-code",
-                "redirect_uri": "http://localhost:3000/auth/kakao/callback",
-            },
-            format="json",
-        )
-
-        user.refresh_from_db()
-        self.assertEqual(response.status_code, 200)
-        self.assertFalse(response.data["is_new_user"])
-        self.assertEqual(user.profile.nickname, "Updated User")
-        self.assertEqual(user.profile.profile_image_url, "https://example.com/new-avatar.png")
-        self.assertEqual(SocialAccount.objects.count(), 1)
-
-    def test_provider_list_returns_authorization_urls_for_configured_providers(self):
-        response = self.client.get("/api/auth/providers/?redirect_uri=http://localhost:3000/auth/callback")
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(len(response.data["providers"]), 3)
-        for provider in response.data["providers"]:
-            self.assertTrue(provider["configured"])
-            self.assertIn("authorization_url", provider)
-            self.assertIn("state", provider)
-
-    @patch("users.views.build_authorization_url")
-    def test_social_login_get_returns_authorization_url(self, build_authorization_url_mock):
-        build_authorization_url_mock.return_value = "https://accounts.google.com/o/oauth2/auth?state=test"
-
-        response = self.client.get("/api/auth/social/google/?remember=on")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["provider"], "google")
-        self.assertIn("authorization_url", response.data)
-        self.assertIn("callback_url", response.data)
-
-    @patch("users.views.complete_social_login")
-    def test_social_login_callback_returns_tokens_and_logs_in_session(self, complete_social_login_mock):
-        user = User.objects.create_user(email="callback@example.com")
-        UserProfile.objects.create(user=user, nickname="Callback User")
-        complete_social_login_mock.return_value = SocialLoginResult(
-            user=user,
-            backend_path="social_core.backends.google.GoogleOAuth2",
-            provider="google",
-            is_new_user=False,
-        )
-
-        session = self.client.session
-        session["tailtalk_social_oauth_remember"] = True
-        session.save()
-
-        response = self.client.get("/api/auth/social/google/callback/?code=test-code&state=test-state")
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertIn("access", response.data)
-        self.assertIn("refresh", response.data)
-        self.assertEqual(response.data["user"]["email"], "callback@example.com")
-
-        session = self.client.session
-        self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)
-        self.assertIn(SOCIAL_AUTH_REFRESH_SESSION_KEY, session)
-
-
-@override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)
 class SocialLoginPageViewTests(TestCase):
     @patch("users.page_views.build_authorization_url")
     def test_social_login_start_redirects_to_provider(self, build_authorization_url_mock):
         build_authorization_url_mock.return_value = "https://nid.naver.com/oauth2.0/authorize?state=test"
 
-        response = self.client.get("/auth/social/naver/?remember=on")
+        response = self.client.get("/auth/naver/start/?remember=on")
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response["Location"], "https://nid.naver.com/oauth2.0/authorize?state=test")
@@ -183,7 +66,7 @@ class SocialLoginPageViewTests(TestCase):
         session["tailtalk_social_oauth_remember"] = False
         session.save()
 
-        response = self.client.get("/auth/social/kakao/callback/?code=test-code&state=test-state")
+        response = self.client.get("/auth/kakao/callback/?code=test-code&state=test-state")
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response["Location"], f"{reverse('profile')}?setup=1")
@@ -274,37 +157,6 @@ class UserProfileApiTests(TestCase):
         self.assertEqual(self.user.profile.nickname, "Updated User")
         self.assertEqual(self.user.profile.phone, "01012341234")
         self.assertTrue(self.user.profile.marketing_consent)
-
-    def test_patch_me_uploads_profile_image_to_local_media(self):
-        with tempfile.TemporaryDirectory() as media_root:
-            with override_settings(MEDIA_ROOT=media_root, MEDIA_URL="/media/"):
-                upload = SimpleUploadedFile("avatar.png", b"fake-image", content_type="image/png")
-
-                response = self.client.patch("/api/users/me/", {"profile_image": upload})
-
-                self.assertEqual(response.status_code, status.HTTP_200_OK)
-                self.user.refresh_from_db()
-                self.assertTrue(self.user.profile.profile_image_url.startswith("/media/profile-images/"))
-
-                relative_path = self.user.profile.profile_image_url.removeprefix("/media/")
-                self.assertTrue((Path(media_root) / relative_path).exists())
-
-    @override_settings(
-        AWS_S3_BUCKET_NAME="tailtalk-bucket",
-        AWS_S3_REGION_NAME="ap-northeast-2",
-    )
-    @patch("users.views.boto3.client")
-    def test_patch_me_uploads_profile_image_to_s3_when_configured(self, boto3_client_mock):
-        s3_client = boto3_client_mock.return_value
-        upload = SimpleUploadedFile("avatar.png", b"fake-image", content_type="image/png")
-
-        response = self.client.patch("/api/users/me/", {"profile_image": upload})
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.user.refresh_from_db()
-        self.assertIn("tailtalk-bucket", self.user.profile.profile_image_url)
-        s3_client.upload_fileobj.assert_called_once()
-
 
 class UserPreferenceApiTests(TestCase):
     def setUp(self):

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -18,7 +18,6 @@ from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthExcept
 from products.models import Product
 
 from .models import SocialAccount, User, UserPreference, UserProfile, UserUsedProduct
-from .oauth import OAuthProviderClient, SocialAuthError
 from .social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
     SOCIAL_AUTH_REFRESH_SESSION_KEY,
@@ -151,44 +150,46 @@ def serialize_used_product(used_product):
     }
 
 
-def upload_profile_image(file_obj):
-    extension = os.path.splitext(file_obj.name)[1].lower() or ".bin"
-    content_type = getattr(file_obj, "content_type", None) or "application/octet-stream"
-    key = f"profile-images/{uuid.uuid4()}{extension}"
-
-    if not settings.AWS_S3_BUCKET_NAME:
-        media_root = Path(settings.MEDIA_ROOT)
-        destination = media_root / key
-        destination.parent.mkdir(parents=True, exist_ok=True)
-
-        with destination.open("wb+") as output:
-            for chunk in file_obj.chunks():
-                output.write(chunk)
-
-        return f"{settings.MEDIA_URL.rstrip('/')}/{key}"
-
-    client_kwargs = {}
-    if settings.AWS_S3_REGION_NAME:
-        client_kwargs["region_name"] = settings.AWS_S3_REGION_NAME
-    if settings.AWS_S3_ENDPOINT_URL:
-        client_kwargs["endpoint_url"] = settings.AWS_S3_ENDPOINT_URL
-
-    s3 = boto3.client("s3", **client_kwargs)
-    s3.upload_fileobj(
-        file_obj,
-        settings.AWS_S3_BUCKET_NAME,
-        key,
-        ExtraArgs={"ContentType": content_type},
-    )
-
-    if settings.AWS_S3_CUSTOM_DOMAIN:
-        return f"https://{settings.AWS_S3_CUSTOM_DOMAIN}/{key}"
-
-    if settings.AWS_S3_ENDPOINT_URL:
-        return f"{settings.AWS_S3_ENDPOINT_URL.rstrip('/')}/{settings.AWS_S3_BUCKET_NAME}/{key}"
-
-    region = settings.AWS_S3_REGION_NAME or "us-east-1"
-    return f"https://{settings.AWS_S3_BUCKET_NAME}.s3.{region}.amazonaws.com/{key}"
+# Profile image upload is intentionally disabled for now.
+# Keep the helper here so the previous local/S3 flow can be restored quickly.
+# def upload_profile_image(file_obj):
+#     extension = os.path.splitext(file_obj.name)[1].lower() or ".bin"
+#     content_type = getattr(file_obj, "content_type", None) or "application/octet-stream"
+#     key = f"profile-images/{uuid.uuid4()}{extension}"
+#
+#     if not settings.AWS_S3_BUCKET_NAME:
+#         media_root = Path(settings.MEDIA_ROOT)
+#         destination = media_root / key
+#         destination.parent.mkdir(parents=True, exist_ok=True)
+#
+#         with destination.open("wb+") as output:
+#             for chunk in file_obj.chunks():
+#                 output.write(chunk)
+#
+#         return f"{settings.MEDIA_URL.rstrip('/')}/{key}"
+#
+#     client_kwargs = {}
+#     if settings.AWS_S3_REGION_NAME:
+#         client_kwargs["region_name"] = settings.AWS_S3_REGION_NAME
+#     if settings.AWS_S3_ENDPOINT_URL:
+#         client_kwargs["endpoint_url"] = settings.AWS_S3_ENDPOINT_URL
+#
+#     s3 = boto3.client("s3", **client_kwargs)
+#     s3.upload_fileobj(
+#         file_obj,
+#         settings.AWS_S3_BUCKET_NAME,
+#         key,
+#         ExtraArgs={"ContentType": content_type},
+#     )
+#
+#     if settings.AWS_S3_CUSTOM_DOMAIN:
+#         return f"https://{settings.AWS_S3_CUSTOM_DOMAIN}/{key}"
+#
+#     if settings.AWS_S3_ENDPOINT_URL:
+#         return f"{settings.AWS_S3_ENDPOINT_URL.rstrip('/')}/{settings.AWS_S3_BUCKET_NAME}/{key}"
+#
+#     region = settings.AWS_S3_REGION_NAME or "us-east-1"
+#     return f"https://{settings.AWS_S3_BUCKET_NAME}.s3.{region}.amazonaws.com/{key}"
 
 
 class RegisterView(APIView):
@@ -286,126 +287,6 @@ class AuthWithdrawView(APIView):
         return Response(status=status.HTTP_204_NO_CONTENT)
 
 
-class SocialProviderListView(APIView):
-    permission_classes = [AllowAny]
-
-    def get(self, request):
-        redirect_uri = request.query_params.get("redirect_uri")
-        response_data = []
-
-        for provider in settings.SOCIAL_AUTH_PROVIDERS:
-            provider_data = {
-                "provider": provider,
-                "configured": self._is_provider_configured(provider),
-            }
-            if redirect_uri and provider_data["configured"]:
-                client = OAuthProviderClient(provider)
-                provider_data.update(client.build_authorization_url(redirect_uri=redirect_uri))
-            response_data.append(provider_data)
-
-        return Response({"providers": response_data})
-
-    def _is_provider_configured(self, provider: str) -> bool:
-        provider_config = settings.SOCIAL_AUTH_PROVIDERS.get(provider, {})
-        return bool(provider_config.get("client_id") and provider_config.get("client_secret"))
-
-
-class SocialLoginView(APIView):
-    permission_classes = [AllowAny]
-
-    def get(self, request, provider):
-        remember = request.query_params.get("remember") == "on"
-        redirect_uri = build_callback_url(request, "social-login-callback-api", provider)
-
-        try:
-            authorization_url = build_authorization_url(
-                request=request,
-                provider=provider,
-                redirect_uri=redirect_uri,
-            )
-        except SocialAuthServiceError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-
-        request.session[SOCIAL_AUTH_REMEMBER_SESSION_KEY] = remember
-        return Response(
-            {
-                "provider": provider,
-                "authorization_url": authorization_url,
-                "callback_url": redirect_uri,
-            }
-        )
-
-    def post(self, request, provider):
-        code = request.data.get("code")
-        redirect_uri = request.data.get("redirect_uri")
-        state = request.data.get("state")
-
-        if not code or not redirect_uri:
-            return Response(
-                {"detail": "code and redirect_uri are required."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        try:
-            profile = OAuthProviderClient(provider).exchange_code(
-                code=code,
-                redirect_uri=redirect_uri,
-                state=state,
-            )
-            user, is_new_user = get_or_create_social_user(profile)
-        except SocialAuthError as exc:
-            return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-
-        tokens = issue_user_tokens(user)
-        return Response(
-            {
-                "provider": provider,
-                **tokens,
-                "is_new_user": is_new_user,
-                "user": serialize_user(user),
-            }
-        )
-
-
-class SocialLoginCallbackView(APIView):
-    permission_classes = [AllowAny]
-
-    def get(self, request, provider):
-        redirect_uri = build_callback_url(request, "social-login-callback-api", provider)
-
-        try:
-            result = complete_social_login(
-                request=request,
-                provider=provider,
-                redirect_uri=redirect_uri,
-            )
-        except (AuthCanceled, AuthConnectionError, AuthMissingParameter, AuthForbidden, AuthException, SocialAuthServiceError) as exc:
-            return Response(
-                {"detail": f"{provider} OAuth failed: {exc}"},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-
-        user = result.user
-        user.backend = result.backend_path
-        login(request, user)
-        if not request.session.get(SOCIAL_AUTH_REMEMBER_SESSION_KEY):
-            request.session.set_expiry(0)
-
-        tokens = issue_user_tokens(user)
-        request.session[SOCIAL_AUTH_ACCESS_SESSION_KEY] = tokens["access"]
-        request.session[SOCIAL_AUTH_REFRESH_SESSION_KEY] = tokens["refresh"]
-        request.session.pop(SOCIAL_AUTH_REMEMBER_SESSION_KEY, None)
-
-        return Response(
-            {
-                "provider": result.provider,
-                **tokens,
-                "is_new_user": result.is_new_user,
-                "user": serialize_user(user),
-            }
-        )
-
-
 class UserMeView(APIView):
     permission_classes = [IsAuthenticated]
 
@@ -441,13 +322,14 @@ class UserMeView(APIView):
                 profile.marketing_consent = marketing_consent
                 dirty_fields.append("marketing_consent")
 
-        profile_image = request.FILES.get("profile_image")
-        if profile_image is not None:
-            try:
-                profile.profile_image_url = upload_profile_image(profile_image)
-            except ValueError as exc:
-                return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
-            dirty_fields.append("profile_image_url")
+        # Profile image upload is intentionally disabled for now.
+        # profile_image = request.FILES.get("profile_image")
+        # if profile_image is not None:
+        #     try:
+        #         profile.profile_image_url = upload_profile_image(profile_image)
+        #     except ValueError as exc:
+        #         return Response({"detail": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+        #     dirty_fields.append("profile_image_url")
 
         if dirty_fields:
             profile.save(update_fields=[*dirty_fields, "updated_at"])


### PR DESCRIPTION
## 요약
반려동물 프로필 API를 구현하고, OAuth 로그인 흐름을 Django Session 기반 `social_django` 경로로 정리했습니다.

## 변경 사항
- `GET /api/pets/`, `POST /api/pets/`, `PATCH /api/pets/{pet_id}/`, `DELETE /api/pets/{pet_id}/` 구현
- 반려동물 등록 최대 5마리 제한 추가
- `health_concerns`, `allergies`, `food_preferences` 다중값 저장/수정 처리 구현
- 템플릿 삭제 폼(`POST + _method=DELETE`)도 `/pets/` 목록으로 리다이렉트되도록 지원
- 반려동물 API 테스트 추가
- OAuth 경로를 Django Session 기반 브라우저 흐름으로 통일
- `/api/auth/providers`, `/api/auth/social/<provider>/...` 커스텀 OAuth API 제거
- 로그인/회원가입 화면의 소셜 로그인 진입 경로를 `/auth/<provider>/start/`로 통일
- 프로필 이미지 업로드는 현재 비활성화 상태로 주석 처리 유지

## 관련 이슈
closes #46
ref #43

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- OAuth provider 콘솔의 redirect URI가 현재 기준 `http://localhost/auth/<provider>/callback/` 으로 맞춰져 있는지 확인 부탁드립니다.

---

## 추가 변경 사항
- 반려동물 API의 `vaccination_date`를 백엔드에서 검증하도록 추가했습니다.
- `YYYY-MM-DD` 실제 날짜만 허용하고, `1900-01-01` 미만/미래 날짜/잘못된 형식은 모두 `400 Bad Request`로 처리합니다.
- 빈 값은 허용하며, 빈 문자열 또는 미입력은 `null`로 저장됩니다.
- 에러 메시지는 `vaccination_date must be a valid date.` 로 통일했습니다.
- 회귀 방지를 위해 invalid/empty/min/future 케이스 테스트를 보강했습니다.

## 추가 검증
- `python services/django/manage.py test pets.tests`
- 결과: `11 tests`, 모두 통과
