### PR TITLE
[feat] 반려동물 등록 UI 및 예비 집사 흐름 정비 (#158)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,3 +1,5 @@
+import json
+
 from django.shortcuts import render
 
 
@@ -14,11 +16,13 @@ def _serialize_pet(pet):
     age_label = " ".join(age_parts) if age_parts else "나이 정보 없음"
     breed = pet.breed or pet.get_species_display()
 
-    def _list(val):
+    def _list(val, attr_name=None):
         if not val:
             return []
         if isinstance(val, list):
             return val
+        if attr_name and hasattr(val, "values_list"):
+            return list(val.values_list(attr_name, flat=True))
         return [v.strip() for v in val.split(",") if v.strip()]
 
     return {
@@ -35,10 +39,97 @@ def _serialize_pet(pet):
             "gender": pet.gender if hasattr(pet, "gender") else "",
             "weight": str(pet.weight_kg) if pet.weight_kg else "",
         },
-        "health_concerns": _list(getattr(pet, "health_concerns", None)),
-        "allergies": _list(getattr(pet, "allergies", None)),
-        "food_preferences": _list(getattr(pet, "food_preferences", None)),
+        "health_concerns": _list(getattr(pet, "health_concerns", None), "concern"),
+        "allergies": _list(getattr(pet, "allergies", None), "ingredient"),
+        "food_preferences": _list(getattr(pet, "food_preferences", None), "food_type"),
+        "profile_json": json.dumps(
+            {
+                "species": pet.species,
+                "breed": pet.breed or "",
+                "age": age_label,
+                "gender": pet.gender if hasattr(pet, "gender") else "",
+                "weight": str(pet.weight_kg) if pet.weight_kg else "",
+            },
+            ensure_ascii=False,
+        ),
+        "health_concerns_csv": ",".join(_list(getattr(pet, "health_concerns", None), "concern")),
+        "allergies_csv": ",".join(_list(getattr(pet, "allergies", None), "ingredient")),
+        "food_preferences_csv": ",".join(_list(getattr(pet, "food_preferences", None), "food_type")),
     }
+
+
+def _serialize_future_pet(profile):
+    if not profile:
+        return None
+
+    species_labels = {
+        "dog": "강아지",
+        "cat": "고양이",
+        "undecided": "미정",
+    }
+    housing_labels = {
+        "studio": "원룸",
+        "apartment": "아파트",
+        "house": "주택",
+        "other": "기타",
+    }
+    experience_labels = {
+        "first": "처음",
+        "experienced": "경험 있음",
+    }
+    interest_labels = {
+        "adoption": "입양 준비",
+        "breed_personality": "품종/성격",
+        "initial_cost": "초기 비용",
+        "starter_items": "필수 용품",
+        "food": "사료",
+        "health": "건강관리",
+        "training": "훈련/교육",
+    }
+
+    preferred_species = profile.get("preferred_species", "")
+    interests = [interest_labels[value] for value in profile.get("interests", []) if value in interest_labels]
+
+    future_profile = {
+        "species": preferred_species if preferred_species in {"dog", "cat"} else "",
+        "lifecycle": "future_guardian",
+        "preferred_species": preferred_species,
+        "housing_type": profile.get("housing_type", ""),
+        "experience_level": profile.get("experience_level", ""),
+        "interests": profile.get("interests", []),
+    }
+
+    if preferred_species == "dog":
+        future_summary = "강아지 준비 중"
+    elif preferred_species == "cat":
+        future_summary = "고양이 준비 중"
+    else:
+        future_summary = "입양 준비 중"
+
+    return {
+        "id": "future-profile",
+        "name": "예비 집사",
+        "species": "future",
+        "emoji": "🏠",
+        "summary": future_summary,
+        "profile": future_profile,
+        "health_concerns": [],
+        "allergies": [],
+        "food_preferences": [],
+        "profile_json": json.dumps(future_profile, ensure_ascii=False),
+        "health_concerns_csv": "",
+        "allergies_csv": "",
+        "food_preferences_csv": "",
+        "detail_lines": [
+            housing_labels.get(profile.get("housing_type", ""), ""),
+            experience_labels.get(profile.get("experience_level", ""), ""),
+            ", ".join(interests) if interests else "",
+        ],
+    }
+
+
+def _sort_member_pets(pets):
+    return sorted(pets, key=lambda pet: pet.get("species") == "future")
 
 
 def _preview_member_pets():
@@ -147,6 +238,7 @@ def chat_view(request):
     is_member_view = is_authenticated or preview_member
     is_preview_member = preview_member and not is_authenticated
     member_pets = []
+    registered_pet_count = 0
     recommended_products = [
         {
             "name": "닥터독 하이포알러지 연어 사료",
@@ -297,10 +389,17 @@ def chat_view(request):
         sessions = list(
             request.user.chat_sessions.order_by("-created_at").values("session_id", "title", "created_at")[:50]
         )
+        registered_pet_count = request.user.pets.count()
         member_pets = [_serialize_pet(pet) for pet in request.user.pets.order_by("created_at")[:5]]
+
+    future_pet = _serialize_future_pet(request.session.get("future_pet_profile"))
+    if future_pet:
+        member_pets.append(future_pet)
+        member_pets = _sort_member_pets(member_pets)
 
     if preview_member and not member_pets:
         member_pets = _preview_member_pets()
+        registered_pet_count = len(member_pets)
 
     if preview_member and not sessions:
         sessions = _preview_sessions()
@@ -317,6 +416,7 @@ def chat_view(request):
             "is_member_view": is_member_view,
             "is_preview_member": is_preview_member,
             "member_pets": member_pets,
+            "can_add_pet": is_member_view and registered_pet_count < 5,
             "active_pet_id": active_pet_id,
             "active_pet": active_pet,
             "recommended_products": recommended_products,

--- a/services/django/pets/page_urls.py
+++ b/services/django/pets/page_urls.py
@@ -4,6 +4,8 @@ from . import page_views
 urlpatterns = [
     path("pets/", page_views.pet_list, name="pet_list"),
     path("pets/add/", page_views.pet_add, name="pet_add"),
+    path("pets/add/future/", page_views.pet_add_future, name="pet_add_future"),
+    path("pets/future/delete/", page_views.pet_delete_future, name="pet_delete_future"),
     path("pets/add/details/", page_views.pet_add_details, name="pet_add_details"),
     path("pets/add/health/", page_views.pet_add_health, name="pet_add_health"),
     path("pets/preview/<str:pet_id>/edit/", page_views.preview_pet_edit, name="preview_pet_edit"),

--- a/services/django/pets/page_views.py
+++ b/services/django/pets/page_views.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from .models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 
@@ -15,6 +16,25 @@ FOOD_OPTIONS = [
     ("dry", "건식"),
     ("wet_can", "습식"),
     ("raw", "혼합/자연식"),
+]
+FUTURE_HOUSING_OPTIONS = [
+    ("studio", "원룸"),
+    ("apartment", "아파트"),
+    ("house", "주택"),
+    ("other", "기타"),
+]
+FUTURE_EXPERIENCE_OPTIONS = [
+    ("first", "처음"),
+    ("experienced", "경험 있음"),
+]
+FUTURE_INTEREST_OPTIONS = [
+    ("adoption", "입양 준비"),
+    ("breed_personality", "품종/성격"),
+    ("initial_cost", "초기 비용"),
+    ("starter_items", "필수 용품"),
+    ("food", "사료"),
+    ("health", "건강관리"),
+    ("training", "훈련/교육"),
 ]
 BUDGET_OPTIONS = [
     ("under_5", "5만 원 미만"),
@@ -172,19 +192,128 @@ def _pet_step3_data(pet):
     }
 
 
+def _future_pet_list_item(profile):
+    if not profile:
+        return None
+
+    housing_labels = {
+        "studio": "원룸",
+        "apartment": "아파트",
+        "house": "주택",
+        "other": "기타",
+    }
+    experience_labels = {
+        "first": "처음",
+        "experienced": "경험 있음",
+    }
+
+    preferred_species = profile.get("preferred_species", "")
+    if preferred_species == "dog":
+        summary = "강아지 준비 중"
+    elif preferred_species == "cat":
+        summary = "고양이 준비 중"
+    else:
+        summary = "입양 준비 중"
+
+    return {
+        "pet_id": "future-profile",
+        "name": "예비 집사",
+        "species": "future",
+        "emoji": "🏠",
+        "summary": summary,
+        "detail": " · ".join(
+            value
+            for value in [
+                housing_labels.get(profile.get("housing_type", ""), ""),
+                experience_labels.get(profile.get("experience_level", ""), ""),
+            ]
+            if value
+        )
+        or "입양 준비 상담 프로필",
+        "is_future_profile": True,
+    }
+
+
+def _sort_pet_list_items(pets):
+    def _species_of(pet):
+        return pet.get("species", "") if isinstance(pet, dict) else getattr(pet, "species", "")
+
+    def _created_at_of(pet):
+        return pet.get("created_at") if isinstance(pet, dict) else getattr(pet, "created_at", None)
+
+    return sorted(
+        pets,
+        key=lambda pet: (
+            _species_of(pet) == "future",
+            _created_at_of(pet),
+        ),
+    )
+
+
 def pet_list(request):
     is_preview_list = request.GET.get("preview") == "filled"
+    future_pet = None
     if is_preview_list:
         pets = _preview_pets()
+        actual_pet_count = len(pets)
     elif getattr(request.user, "is_authenticated", False):
-        pets = Pet.objects.filter(user=request.user)
+        pets = list(Pet.objects.filter(user=request.user))
+        actual_pet_count = len(pets)
+        future_pet = _future_pet_list_item(request.session.get("future_pet_profile"))
+        if future_pet:
+            pets.append(future_pet)
+        pets = _sort_pet_list_items(pets)
     else:
         pets = []
-    return render(request, "pets/list.html", {"pets": pets, "is_preview_list": is_preview_list})
+        actual_pet_count = 0
+    return render(
+        request,
+        "pets/list.html",
+        {
+            "pets": pets,
+            "is_preview_list": is_preview_list,
+            "actual_pet_count": actual_pet_count,
+            "has_future_pet": bool(future_pet),
+        },
+    )
 
 
 def pet_add(request):
     return render(request, "pets/add_step1.html", {"species_options": SPECIES_OPTIONS})
+
+
+def pet_add_future(request):
+    if request.method == "POST":
+        request.session["future_pet_profile"] = {
+            "preferred_species": request.POST.get("preferred_species", "").strip(),
+            "housing_type": request.POST.get("housing_type", "").strip(),
+            "experience_level": request.POST.get("experience_level", "").strip(),
+            "interests": request.POST.getlist("interests"),
+        }
+        return redirect(f"{reverse('chat')}?pet=future-profile")
+
+    future_profile = {
+        "preferred_species": "",
+        "housing_type": "",
+        "experience_level": "",
+        "interests": [],
+    } | request.session.get("future_pet_profile", {})
+    return render(
+        request,
+        "pets/add_future.html",
+        {
+            "future_profile": future_profile,
+            "housing_options": FUTURE_HOUSING_OPTIONS,
+            "experience_options": FUTURE_EXPERIENCE_OPTIONS,
+            "interest_options": FUTURE_INTEREST_OPTIONS,
+        },
+    )
+
+
+def pet_delete_future(request):
+    if request.method == "POST":
+        request.session.pop("future_pet_profile", None)
+    return redirect("pet_list")
 
 
 def pet_add_details(request):

--- a/services/django/static/css/main.css
+++ b/services/django/static/css/main.css
@@ -71,6 +71,10 @@ input:disabled {
 
 .auth-legacy-remember {
   position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 7px;
   border: 0;
   background: transparent;
   padding: 0;
@@ -88,15 +92,19 @@ input:disabled {
 }
 
 .auth-legacy-remember-text {
-  position: absolute;
-  left: 36px;
-  top: 6px;
-  font-size: 13px;
-  line-height: 1;
-  letter-spacing: -0.01em;
-  color: #4a5568;
+  display: block;
   white-space: nowrap;
+  font-size: 15px;
+  line-height: 18px;
+  letter-spacing: -0.01em;
+  color: #5f6b7a;
+  transform: translate(0, 4px);
   z-index: 2;
+}
+
+.auth-legacy-remember .auth-legacy-checkbox {
+  flex: 0 0 18px;
+  white-space: nowrap;
 }
 
 @media (max-width: 430px) {

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -326,8 +326,12 @@
           <img alt="로그아웃" class="block h-full w-full"
                src="https://www.figma.com/api/mcp/asset/859bd012-3121-4646-8578-a808af8cfaf3" />
         </a>
-        <img alt="설정" class="absolute bottom-[30.9px] left-[237px] h-[19.1px] w-[18.68px]"
-             src="https://www.figma.com/api/mcp/asset/792ac734-a1f1-4756-b214-34070a46371f" />
+        <div class="absolute bottom-[30.9px] left-[237px] flex h-[19.1px] w-[18.68px] items-center justify-center text-[#718096]" aria-label="설정">
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="3.2"></circle>
+            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          </svg>
+        </div>
         {% else %}
         <img alt="" class="absolute inset-0 h-full w-full"
              src="https://www.figma.com/api/mcp/asset/ad58345b-5dd6-4c4d-9add-d9ce93ab4236" />
@@ -345,8 +349,12 @@
           <p class="whitespace-nowrap">맞춤형 반려동물 케어와 대화 기록 저장을 위해</p>
           <p class="mt-[2px] whitespace-nowrap">로그인을 진행해 주세요</p>
         </div>
-        <img alt="설정" class="absolute bottom-[31px] right-[24px] h-[19.1px] w-[18.68px]"
-             src="https://www.figma.com/api/mcp/asset/07028074-58d6-4ef3-b1b8-303b3868d92b" />
+        <div class="absolute bottom-[31px] right-[24px] flex h-[19.1px] w-[18.68px] items-center justify-center text-[#718096]" aria-label="설정">
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="3.2"></circle>
+            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          </svg>
+        </div>
         {% endif %}
       </div>
 
@@ -367,8 +375,12 @@
                src="https://www.figma.com/api/mcp/asset/d6bb3b36-3d28-4b12-874c-412da87095c8" />
         </button>
         {% endif %}
-        <img alt="설정" class="absolute bottom-[28.45px] left-1/2 h-[19.1px] w-[18.68px] -translate-x-1/2"
-             src="https://www.figma.com/api/mcp/asset/4eec41a1-b8c0-4611-9d1a-adc716d51753" />
+        <div class="absolute bottom-[28.45px] left-1/2 flex h-[19.1px] w-[18.68px] -translate-x-1/2 items-center justify-center text-[#718096]" aria-label="설정">
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="12" cy="12" r="3.2"></circle>
+            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          </svg>
+        </div>
       </div>
     </aside>
 

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -205,8 +205,8 @@
           <div class="pr-[8px]">
             <p class="text-[13px] font-bold leading-none text-[#2d3748]">상담 기준 반려동물</p>
             <p class="mt-[8px] max-w-[198px] break-keep text-[11px] leading-[1.65] text-[#718096]">
-              선택한 반려동물 정보를 기준으로
-              답변과 추천이 맞춰집니다
+              선택한 반려동물 정보를 기준으로<br>
+              답변과 추천이 제공됩니다
             </p>
           </div>
 
@@ -233,7 +233,7 @@
               </div>
             </button>
 
-            {% if member_pets %}
+            {% if member_pets or can_add_pet %}
             <div id="petDropdownMenu"
                  class="pointer-events-none absolute left-0 right-0 top-[calc(100%+8px)] z-20 overflow-hidden rounded-[14px] border border-[#dbe7f5] bg-white opacity-0 shadow-[0_14px_30px_rgba(45,55,72,0.10)] transition-all duration-200">
               <div class="max-h-[248px] overflow-y-auto p-[6px]">
@@ -243,6 +243,10 @@
                         data-pet-name="선택 안 함"
                         data-pet-summary="일반 상담으로 진행"
                         data-pet-emoji="○"
+                        data-pet-profile=""
+                        data-pet-health-concerns=""
+                        data-pet-allergies=""
+                        data-pet-food-preferences=""
                         onclick="selectPet(this)">
                   <div class="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#f8fafc] text-[16px]">
                     ○
@@ -259,10 +263,10 @@
                         data-pet-name="{{ pet.name }}"
                         data-pet-summary="{{ pet.summary }}"
                         data-pet-emoji="{{ pet.emoji }}"
-                        data-pet-profile='{{ pet.profile|default:"{}" }}'
-                        data-pet-health-concerns='{{ pet.health_concerns|default:"[]"|join:"," }}'
-                        data-pet-allergies='{{ pet.allergies|default:"[]"|join:"," }}'
-                        data-pet-food-preferences='{{ pet.food_preferences|default:"[]"|join:"," }}'
+                        data-pet-profile='{{ pet.profile_json|default:"" }}'
+                        data-pet-health-concerns='{{ pet.health_concerns_csv|default:"" }}'
+                        data-pet-allergies='{{ pet.allergies_csv|default:"" }}'
+                        data-pet-food-preferences='{{ pet.food_preferences_csv|default:"" }}'
                         onclick="selectPet(this)">
                   <div class="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#f8fafc] text-[17px]">
                     {{ pet.emoji }}
@@ -273,11 +277,20 @@
                   </div>
                 </button>
                 {% endfor %}
+                {% if can_add_pet %}
+                <div class="mx-[10px] my-[6px] h-px bg-[#edf2f7]"></div>
+                <a href="/pets/add/"
+                   class="flex w-full items-center gap-[10px] rounded-[10px] px-[10px] py-[9px] text-left transition-colors duration-150 hover:bg-[#f8fbff]">
+                  <div class="flex h-[30px] w-[30px] shrink-0 items-center justify-center rounded-full bg-[#eff8ff] text-[18px] font-semibold text-[#3182ce]">
+                    +
+                  </div>
+                  <div class="min-w-0 flex-1">
+                    <p class="truncate text-[12px] font-bold leading-none text-[#2d3748]">반려동물 추가</p>
+                    <p class="mt-[5px] truncate text-[11px] leading-none text-[#718096]">새 반려동물 등록하기</p>
+                  </div>
+                </a>
+                {% endif %}
               </div>
-            </div>
-            {% else %}
-            <div class="mt-[8px] rounded-[12px] border border-dashed border-[#cbd5e0] px-[10px] py-[12px] text-center text-[11px] leading-[1.5] text-[#718096]">
-              등록된 반려동물이 없습니다
             </div>
             {% endif %}
           </div>
@@ -303,11 +316,6 @@
                         aria-label="삭제" onclick="event.stopPropagation(); openDeleteModal('{{ session.session_id }}')">🗑️</button>
               </div>
             </div>
-          </div>
-          {% empty %}
-          <div class="rounded-[16px] border border-dashed border-[#cbd5e0] px-[18px] py-[16px] text-center text-[12px] leading-[1.6] text-[#718096]">
-            <p>아직 저장된 대화가 없습니다</p>
-            <p>새 대화를 시작해 주세요</p>
           </div>
           {% endfor %}
         </div>
@@ -730,6 +738,7 @@
   var pendingDeleteId = null;
   var isPetDropdownOpen = false;
   var activeSessionId = null;
+  var activePetId = '{{ active_pet_id|escapejs }}';
   var draftSessionCount = 0;
   var promoIndex = 0;
   var promoTimer = null;
@@ -1548,6 +1557,13 @@
   closePetDropdown();
   updateChatSectionState(false);
   updateSessionItemStyles();
+
+  if (activePetId) {
+    var initialPet = document.querySelector('[data-pet-id="' + activePetId + '"]');
+    if (initialPet) {
+      selectPet(initialPet);
+    }
+  }
 
   function revealPage() {
     if (!pageGate) return;

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -197,8 +197,11 @@
         </button>
         <button type="button" onclick="closeSidebar()"
                 class="absolute left-[242px] top-[32px] h-[16px] w-[24px]" aria-label="사이드바 닫기">
-          <img alt="" class="block h-full w-full"
-               src="https://www.figma.com/api/mcp/asset/5f81f82e-a391-4ba4-b447-0ac855e07b12" />
+          <svg viewBox="0 0 24 16" class="block h-full w-full text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 3H19"></path>
+            <path d="M5 8H19"></path>
+            <path d="M5 13H19"></path>
+          </svg>
         </button>
 
         <div class="absolute left-[20px] top-[88px] w-[240px] rounded-[18px] border border-[#dbe7f5] bg-white px-[14px] py-[14px] shadow-[0_10px_24px_rgba(45,55,72,0.06)]">
@@ -320,16 +323,13 @@
           {% endfor %}
         </div>
 
-        <img alt="" class="absolute bottom-[69.5px] left-[20.5px] h-px w-[240px]"
-             src="https://www.figma.com/api/mcp/asset/29c2734e-0f52-4f9b-80bf-a8e97d42dbc0" />
-        <a href="{% if is_preview_member %}#{% else %}/logout/{% endif %}" class="absolute bottom-[34.26px] left-[25.07px] h-[12.96px] w-[50.37px]" {% if is_preview_member %}onclick="return false"{% endif %}>
-          <img alt="로그아웃" class="block h-full w-full"
-               src="https://www.figma.com/api/mcp/asset/859bd012-3121-4646-8578-a808af8cfaf3" />
+        <div class="absolute bottom-[69.5px] left-[20.5px] h-px w-[240px] bg-[#d9e4f0]"></div>
+        <a href="{% if is_preview_member %}#{% else %}/logout/{% endif %}" class="absolute bottom-[30px] left-[24px] text-[13px] font-semibold text-[#ef4444]" {% if is_preview_member %}onclick="return false"{% endif %}>
+          로그아웃
         </a>
         <div class="absolute bottom-[30.9px] left-[237px] flex h-[19.1px] w-[18.68px] items-center justify-center text-[#718096]" aria-label="설정">
-          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="3.2"></circle>
-            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.213 1.277c.066.394.335.723.707.878.22.092.435.193.646.304.36.19.8.198 1.15.02l1.14-.57a1.125 1.125 0 0 1 1.422.42l1.296 2.244c.275.476.17 1.08-.248 1.433l-1.003.847a1.125 1.125 0 0 0-.36 1.094c.022.24.033.482.033.726 0 .244-.011.486-.034.726-.037.41.104.813.36 1.094l1.004.847c.418.353.522.957.247 1.433l-1.296 2.244a1.125 1.125 0 0 1-1.421.42l-1.141-.57a1.125 1.125 0 0 0-1.15.02c-.211.111-.426.212-.646.304-.372.155-.64.484-.707.878l-.213 1.277a1.125 1.125 0 0 1-1.11.94h-2.592a1.125 1.125 0 0 1-1.11-.94l-.213-1.277a1.125 1.125 0 0 0-.707-.878 8.208 8.208 0 0 1-.646-.304 1.125 1.125 0 0 0-1.15-.02l-1.14.57a1.125 1.125 0 0 1-1.422-.42L2.72 16.2a1.125 1.125 0 0 1 .247-1.433l1.004-.847c.256-.281.397-.684.36-1.094A7.78 7.78 0 0 1 4.296 12c0-.244.011-.486.034-.726a1.125 1.125 0 0 0-.36-1.094l-1.004-.847a1.125 1.125 0 0 1-.247-1.433L4.015 5.656a1.125 1.125 0 0 1 1.421-.42l1.141.57c.35.178.79.17 1.15-.02.211-.111.426-.212.646-.304.372-.155.64-.484.707-.878l.213-1.277ZM12 15.375A3.375 3.375 0 1 0 12 8.625a3.375 3.375 0 0 0 0 6.75Z" clip-rule="evenodd"></path>
           </svg>
         </div>
         {% else %}
@@ -337,8 +337,11 @@
              src="https://www.figma.com/api/mcp/asset/ad58345b-5dd6-4c4d-9add-d9ce93ab4236" />
         <button type="button" onclick="closeSidebar()"
                 class="absolute right-[15px] top-[31px] h-[16px] w-[24px]" aria-label="사이드바 닫기">
-          <img alt="" class="block h-full w-full"
-               src="https://www.figma.com/api/mcp/asset/915378dd-f8b9-43fe-9cf7-1933a9312d51" />
+          <svg viewBox="0 0 24 16" class="block h-full w-full text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 3H19"></path>
+            <path d="M5 8H19"></path>
+            <path d="M5 13H19"></path>
+          </svg>
         </button>
         <a href="/login/" class="absolute left-[16px] top-[20px] flex h-[37px] w-[207px] items-center justify-center">
           <img alt="" class="absolute inset-0 h-full w-full"
@@ -350,9 +353,8 @@
           <p class="mt-[2px] whitespace-nowrap">로그인을 진행해 주세요</p>
         </div>
         <div class="absolute bottom-[31px] right-[24px] flex h-[19.1px] w-[18.68px] items-center justify-center text-[#718096]" aria-label="설정">
-          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="3.2"></circle>
-            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.213 1.277c.066.394.335.723.707.878.22.092.435.193.646.304.36.19.8.198 1.15.02l1.14-.57a1.125 1.125 0 0 1 1.422.42l1.296 2.244c.275.476.17 1.08-.248 1.433l-1.003.847a1.125 1.125 0 0 0-.36 1.094c.022.24.033.482.033.726 0 .244-.011.486-.034.726-.037.41.104.813.36 1.094l1.004.847c.418.353.522.957.247 1.433l-1.296 2.244a1.125 1.125 0 0 1-1.421.42l-1.141-.57a1.125 1.125 0 0 0-1.15.02c-.211.111-.426.212-.646.304-.372.155-.64.484-.707.878l-.213 1.277a1.125 1.125 0 0 1-1.11.94h-2.592a1.125 1.125 0 0 1-1.11-.94l-.213-1.277a1.125 1.125 0 0 0-.707-.878 8.208 8.208 0 0 1-.646-.304 1.125 1.125 0 0 0-1.15-.02l-1.14.57a1.125 1.125 0 0 1-1.422-.42L2.72 16.2a1.125 1.125 0 0 1 .247-1.433l1.004-.847c.256-.281.397-.684.36-1.094A7.78 7.78 0 0 1 4.296 12c0-.244.011-.486.034-.726a1.125 1.125 0 0 0-.36-1.094l-1.004-.847a1.125 1.125 0 0 1-.247-1.433L4.015 5.656a1.125 1.125 0 0 1 1.421-.42l1.141.57c.35.178.79.17 1.15-.02.211-.111.426-.212.646-.304.372-.155.64-.484.707-.878l.213-1.277ZM12 15.375A3.375 3.375 0 1 0 12 8.625a3.375 3.375 0 0 0 0 6.75Z" clip-rule="evenodd"></path>
           </svg>
         </div>
         {% endif %}
@@ -363,22 +365,26 @@
         <button type="button" onclick="openSidebar()"
                 class="absolute left-1/2 top-[31px] h-[16px] w-[24px] -translate-x-1/2"
                 aria-label="사이드바 열기">
-          <img alt="" class="block h-full w-full"
-               src="https://www.figma.com/api/mcp/asset/8aa9f692-3df6-4a17-a9e8-f713d7d1a1ee" />
+          <svg viewBox="0 0 24 16" class="block h-full w-full text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" aria-hidden="true">
+            <path d="M5 3H19"></path>
+            <path d="M5 8H19"></path>
+            <path d="M5 13H19"></path>
+          </svg>
         </button>
         {% if is_member_view %}
         <button type="button"
-           class="absolute left-1/2 top-[93.19px] flex h-[14.81px] w-[14.81px] -translate-x-1/2 items-center justify-center"
+           class="absolute left-1/2 top-[90px] flex h-[20px] w-[20px] -translate-x-1/2 items-center justify-center"
            aria-label="새 대화 시작"
            onclick="resetChatState(false)">
-          <img alt="" class="block h-full w-full"
-               src="https://www.figma.com/api/mcp/asset/d6bb3b36-3d28-4b12-874c-412da87095c8" />
+          <svg viewBox="0 0 20 20" class="block h-full w-full text-[#3182ce]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M13.8 3.2l3 3-8.7 8.7-3.8.8.8-3.8 8.7-8.7Z"></path>
+            <path d="M11.9 5.1l3 3"></path>
+          </svg>
         </button>
         {% endif %}
         <div class="absolute bottom-[28.45px] left-1/2 flex h-[19.1px] w-[18.68px] -translate-x-1/2 items-center justify-center text-[#718096]" aria-label="설정">
-          <svg viewBox="0 0 24 24" class="h-full w-full" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <circle cx="12" cy="12" r="3.2"></circle>
-            <path d="M19.4 15a1 1 0 0 0 .2 1.1l.1.1a1.9 1.9 0 0 1-2.7 2.7l-.1-.1a1 1 0 0 0-1.1-.2 1 1 0 0 0-.6.9V20a1.9 1.9 0 0 1-3.8 0v-.2a1 1 0 0 0-.6-.9 1 1 0 0 0-1.1.2l-.1.1a1.9 1.9 0 1 1-2.7-2.7l.1-.1a1 1 0 0 0 .2-1.1 1 1 0 0 0-.9-.6H4a1.9 1.9 0 0 1 0-3.8h.2a1 1 0 0 0 .9-.6 1 1 0 0 0-.2-1.1l-.1-.1a1.9 1.9 0 1 1 2.7-2.7l.1.1a1 1 0 0 0 1.1.2 1 1 0 0 0 .6-.9V4a1.9 1.9 0 1 1 3.8 0v.2a1 1 0 0 0 .6.9 1 1 0 0 0 1.1-.2l.1-.1a1.9 1.9 0 0 1 2.7 2.7l-.1.1a1 1 0 0 0-.2 1.1 1 1 0 0 0 .9.6h.2a1.9 1.9 0 0 1 0 3.8h-.2a1 1 0 0 0-.9.6z"></path>
+          <svg viewBox="0 0 24 24" class="h-full w-full" fill="currentColor" aria-hidden="true">
+            <path fill-rule="evenodd" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.592c.55 0 1.02.398 1.11.94l.213 1.277c.066.394.335.723.707.878.22.092.435.193.646.304.36.19.8.198 1.15.02l1.14-.57a1.125 1.125 0 0 1 1.422.42l1.296 2.244c.275.476.17 1.08-.248 1.433l-1.003.847a1.125 1.125 0 0 0-.36 1.094c.022.24.033.482.033.726 0 .244-.011.486-.034.726-.037.41.104.813.36 1.094l1.004.847c.418.353.522.957.247 1.433l-1.296 2.244a1.125 1.125 0 0 1-1.421.42l-1.141-.57a1.125 1.125 0 0 0-1.15.02c-.211.111-.426.212-.646.304-.372.155-.64.484-.707.878l-.213 1.277a1.125 1.125 0 0 1-1.11.94h-2.592a1.125 1.125 0 0 1-1.11-.94l-.213-1.277a1.125 1.125 0 0 0-.707-.878 8.208 8.208 0 0 1-.646-.304 1.125 1.125 0 0 0-1.15-.02l-1.14.57a1.125 1.125 0 0 1-1.422-.42L2.72 16.2a1.125 1.125 0 0 1 .247-1.433l1.004-.847c.256-.281.397-.684.36-1.094A7.78 7.78 0 0 1 4.296 12c0-.244.011-.486.034-.726a1.125 1.125 0 0 0-.36-1.094l-1.004-.847a1.125 1.125 0 0 1-.247-1.433L4.015 5.656a1.125 1.125 0 0 1 1.421-.42l1.141.57c.35.178.79.17 1.15-.02.211-.111.426-.212.646-.304.372-.155.64-.484.707-.878l.213-1.277ZM12 15.375A3.375 3.375 0 1 0 12 8.625a3.375 3.375 0 0 0 0 6.75Z" clip-rule="evenodd"></path>
           </svg>
         </div>
       </div>
@@ -1143,16 +1149,8 @@
     }
 
     if (closeDrawer) {
-      if (composerStage) composerStage.classList.add('no-transition');
-      if (productPanel) productPanel.classList.add('no-transition');
-      if (chatEmptyState) chatEmptyState.classList.add('no-transition');
-      closeSidebar(true);
+      closeSidebar();
       performReset();
-      window.setTimeout(function () {
-        if (composerStage) composerStage.classList.remove('no-transition');
-        if (productPanel) productPanel.classList.remove('no-transition');
-        if (chatEmptyState) chatEmptyState.classList.remove('no-transition');
-      }, 20);
       return;
     }
 

--- a/services/django/templates/pets/add_future.html
+++ b/services/django/templates/pets/add_future.html
@@ -1,0 +1,186 @@
+{% extends "base.html" %}
+{% block title %}예비 집사 등록 — TailTalk{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
+    <a href="/chat/" class="absolute left-4 top-4 text-[22px] font-bold leading-none text-[#2d3748] md:left-8 md:top-8 md:text-[26px]" aria-label="메인으로 이동">
+      <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+    </a>
+
+    <div class="flex w-full max-w-[720px] flex-col rounded-[18px] border border-[#e2e8f0] bg-white px-5 pb-6 pt-0 shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
+      <div class="grid grid-cols-2 gap-[10px]">
+        <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
+        <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
+      </div>
+      <div class="mt-[20px] text-[14px] font-bold leading-none text-[#3182ce]">STEP 2 / 2</div>
+      <div class="mt-[14px] flex items-center gap-[8px] text-[16px] font-bold leading-none text-[#2d3748] md:text-[18px]">
+        <span class="text-[18px] md:text-[20px]">🏠</span>
+        <span>예비 집사 정보</span>
+      </div>
+      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">
+        정보를 입력하면 챗봇 상담과 추천에 반영할 수 있어요
+      </p>
+
+      <form method="post" class="mt-[28px]">
+        {% csrf_token %}
+
+        <div class="grid grid-cols-1 gap-x-[28px] gap-y-[20px] md:grid-cols-2 md:gap-y-[24px]">
+          <div class="space-y-[10px] md:col-span-2">
+            <div class="text-[14px] font-bold leading-none text-[#4a5568]">
+              희망 반려동물 <span class="text-[#e53e3e]">(필수)</span>
+            </div>
+            <div class="flex gap-[6px]">
+              <button type="button" data-group="preferred_species" data-value="dog" class="future-toggle flex h-[42px] flex-1 items-center justify-center rounded-[10px] border text-[14px] leading-none transition-colors">
+                강아지
+              </button>
+              <button type="button" data-group="preferred_species" data-value="cat" class="future-toggle flex h-[42px] flex-1 items-center justify-center rounded-[10px] border text-[14px] leading-none transition-colors">
+                고양이
+              </button>
+              <button type="button" data-group="preferred_species" data-value="undecided" class="future-toggle flex h-[42px] flex-1 items-center justify-center rounded-[10px] border text-[14px] leading-none transition-colors">
+                미정
+              </button>
+            </div>
+            <input type="hidden" name="preferred_species" id="preferredSpeciesInput" value="{{ future_profile.preferred_species|default:'' }}" />
+            <p id="preferredSpeciesStatus" class="min-h-[8px] text-right text-[12px]"></p>
+          </div>
+
+          <div class="space-y-[10px]">
+            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">
+              주거 형태 <span class="text-[#a0aec0]">(선택)</span>
+            </label>
+            <select name="housing_type" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[14px] leading-none text-[#2d3748] outline-none transition-colors focus:border-[#90cdf4]">
+              <option value="">선택해주세요</option>
+              {% for value, label in housing_options %}
+              <option value="{{ value }}" {% if future_profile.housing_type == value %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="space-y-[10px]">
+            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">
+              양육 경험 <span class="text-[#a0aec0]">(선택)</span>
+            </label>
+            <select name="experience_level" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[14px] leading-none text-[#2d3748] outline-none transition-colors focus:border-[#90cdf4]">
+              <option value="">선택해주세요</option>
+              {% for value, label in experience_options %}
+              <option value="{{ value }}" {% if future_profile.experience_level == value %}selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </div>
+
+          <div class="space-y-[10px] md:col-span-2">
+            <div class="text-[14px] font-bold leading-none text-[#4a5568]">
+              관심사 <span class="text-[#a0aec0]">(선택)</span>
+            </div>
+            <div class="flex flex-wrap gap-[8px]">
+              {% for value, label in interest_options %}
+              <label class="interest-option flex h-[38px] cursor-pointer items-center justify-center rounded-[10px] border px-[16px] text-[13px] {% if value in future_profile.interests|default:'' %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
+                <input type="checkbox" class="hidden interest-checkbox" name="interests" value="{{ value }}" {% if value in future_profile.interests|default:'' %}checked{% endif %} />
+                {{ label }}
+              </label>
+              {% endfor %}
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-[28px] flex flex-col-reverse gap-[10px] md:flex-row md:items-end md:gap-[14px]">
+          <a href="/pets/add/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[128px]">
+            이전으로
+          </a>
+          <button id="futureSubmitButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#cbd5e0] text-[16px] font-bold leading-none text-white transition-colors">
+            입력 완료
+          </button>
+        </div>
+      </form>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    var preferredSpeciesInput = document.getElementById('preferredSpeciesInput');
+    var preferredSpeciesStatus = document.getElementById('preferredSpeciesStatus');
+    var submitButton = document.getElementById('futureSubmitButton');
+    var toggles = Array.from(document.querySelectorAll('.future-toggle'));
+    var form = submitButton ? submitButton.closest('form') : null;
+
+    function paintToggle(button, active) {
+      button.style.borderColor = active ? '#3182ce' : '#e2e8f0';
+      button.style.backgroundColor = active ? '#ebf8ff' : 'white';
+      button.style.color = active ? '#3182ce' : '#4a5568';
+      button.style.fontWeight = active ? '700' : '400';
+    }
+
+    function syncPreferredSpecies() {
+      toggles.forEach(function (button) {
+        paintToggle(button, button.getAttribute('data-value') === preferredSpeciesInput.value);
+      });
+    }
+
+    function syncSubmitButton() {
+      var ready = !!preferredSpeciesInput.value;
+      submitButton.disabled = !ready;
+      submitButton.style.backgroundColor = ready ? '#3182ce' : '#cbd5e0';
+      submitButton.style.cursor = ready ? 'pointer' : 'default';
+    }
+
+    function syncSelectable(className, inputClass, activeClass, inactiveClass) {
+      var labels = Array.from(document.querySelectorAll(className));
+      labels.forEach(function (label) {
+        var checkbox = label.querySelector(inputClass);
+        function paint() {
+          label.className = label.className.replace(activeClass, '').replace(inactiveClass, '').trim();
+          label.className += ' ' + (checkbox.checked ? activeClass : inactiveClass);
+        }
+        label.addEventListener('click', function () {
+          setTimeout(paint, 0);
+        });
+        paint();
+      });
+    }
+
+    function clearError(statusNode) {
+      if (!statusNode) return;
+      statusNode.textContent = '';
+    }
+
+    toggles.forEach(function (button) {
+      button.addEventListener('click', function () {
+        preferredSpeciesInput.value = button.getAttribute('data-value') || '';
+        clearError(preferredSpeciesStatus);
+        syncPreferredSpecies();
+        syncSubmitButton();
+      });
+    });
+
+    if (form) {
+      form.addEventListener('submit', function (event) {
+        var valid = true;
+        clearError(preferredSpeciesStatus);
+
+        if (!preferredSpeciesInput.value) {
+          preferredSpeciesStatus.textContent = '희망 반려동물 종류를 선택해 주세요';
+          preferredSpeciesStatus.style.color = '#e53e3e';
+          valid = false;
+        }
+
+        if (!valid) {
+          event.preventDefault();
+        }
+      });
+    }
+
+    syncSelectable(
+      '.interest-option',
+      '.interest-checkbox',
+      'border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]',
+      'border-[#e2e8f0] bg-white text-[#4a5568]'
+    );
+    syncPreferredSpecies();
+    syncSubmitButton();
+  })();
+</script>
+{% endblock %}

--- a/services/django/templates/pets/add_step1.html
+++ b/services/django/templates/pets/add_step1.html
@@ -59,9 +59,8 @@
       });
 
       var hasSelection = !!selectedSpecies;
-      var canProceed = hasSelection && selectedSpecies !== 'future';
       nextButton.disabled = !hasSelection;
-      nextButton.style.backgroundColor = canProceed ? '#3182ce' : '#cbd5e0';
+      nextButton.style.backgroundColor = hasSelection ? '#3182ce' : '#cbd5e0';
       nextButton.style.cursor = hasSelection ? 'pointer' : 'default';
     }
 
@@ -73,7 +72,11 @@
     });
 
     nextButton.addEventListener('click', function () {
-      if (!selectedSpecies || selectedSpecies === 'future') return;
+      if (!selectedSpecies) return;
+      if (selectedSpecies === 'future') {
+        window.location.href = '/pets/add/future/';
+        return;
+      }
       window.location.href = '/pets/add/details/?type=' + selectedSpecies;
     });
   })();

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -23,24 +23,29 @@
           {% if species == "cat" %}고양이 기본 정보{% elif species == "future" %}예비 집사 기본 정보{% else %}강아지 기본 정보{% endif %}
         </span>
       </div>
-      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">정확한 맞춤형 케어를 위해 빈칸을 채워주세요</p>
+      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">정보를 입력하면 챗봇 상담과 추천에 반영할 수 있어요</p>
 
-      <form method="post" class="contents" action="{% if is_preview_edit %}/pets/preview/{{ pet.pet_id }}/edit/{% elif is_edit %}/pets/{{ pet.pet_id }}/edit/{% else %}/pets/add/health/{% endif %}">
+      <form method="post" class="contents" novalidate action="{% if is_preview_edit %}/pets/preview/{{ pet.pet_id }}/edit/{% elif is_edit %}/pets/{{ pet.pet_id }}/edit/{% else %}/pets/add/health/{% endif %}">
         {% csrf_token %}
         <input type="hidden" name="species" value="{{ species }}" />
 
-        <div class="mt-[30px] grid grid-cols-1 gap-x-[28px] gap-y-[20px] md:grid-cols-2 md:gap-y-[24px]">
-          <div class="space-y-[10px]">
+        <div class="mt-[30px] grid gap-x-[28px] gap-y-[24px] {% if is_edit %}grid-cols-2{% else %}grid-cols-1 sm:grid-cols-2{% endif %} {% if is_edit %}gap-y-[28px]{% else %}sm:gap-y-[28px]{% endif %}">
+          <div class="space-y-[12px]">
             <label class="block text-[14px] font-bold leading-none text-[#4a5568]">이름 <span class="text-[#e53e3e]">(필수)</span></label>
-            <input id="nameInput" name="name" value="{{ pet.name|default:'' }}" placeholder="반려동물의 이름을 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" required />
+            <input id="nameInput" name="name" value="{{ pet.name|default:'' }}" maxlength="12" placeholder="반려동물의 이름을 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+            <p id="nameStatus" class="hidden text-right text-[12px]"></p>
           </div>
 
-          <div class="space-y-[10px]">
-            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">품종 <span class="text-[#a0aec0]">(선택)</span></label>
-            <input id="breedInput" name="breed" value="{{ pet.breed|default:'' }}" placeholder="{% if species == 'cat' %}품종을 검색해주세요 (예: 코리안숏헤어){% else %}품종을 검색해주세요 (예: 말티즈){% endif %}" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+          <div class="space-y-[12px]">
+            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">품종 <span class="text-[#e53e3e]">(필수)</span></label>
+            <div class="relative">
+              <input id="breedInput" name="breed" value="{{ pet.breed|default:'' }}" autocomplete="off" placeholder="{% if species == 'cat' %}품종을 검색해주세요 (예: 벵갈, ㅂㄱ){% else %}품종을 검색해주세요 (예: 말티즈, ㅁㅌㅈ){% endif %}" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+              <div id="breedSuggestions" class="pointer-events-none absolute left-0 right-0 top-[calc(100%+8px)] z-10 hidden max-h-[220px] overflow-y-auto rounded-[12px] border border-[#dbe7f5] bg-white p-[6px] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.10)] transition-all duration-150"></div>
+            </div>
+            <p id="breedStatus" class="hidden text-right text-[12px]"></p>
           </div>
 
-          <div class="space-y-[10px]">
+          <div class="space-y-[12px]">
             <div class="text-[14px] font-bold leading-none text-[#4a5568]">성별 <span class="text-[#e53e3e]">(필수)</span></div>
             <div class="mt-2 flex gap-[6px]">
               <button type="button" id="genderMale" class="flex h-[42px] flex-1 items-center justify-center rounded-[10px] border text-[14px] leading-none transition-colors {% if pet.gender == 'female' %}border-[#e2e8f0] bg-white font-normal text-[#4a5568]{% else %}border-[#3182ce] bg-[#ebf8ff] font-bold text-[#3182ce]{% endif %}">수컷 (남아)</button>
@@ -49,8 +54,8 @@
             </div>
           </div>
 
-          <div class="space-y-[10px]">
-            <div class="text-[14px] font-bold leading-none text-[#4a5568]">나이 <span class="text-[#e53e3e]">(필수, 월령 포함)</span></div>
+          <div class="space-y-[12px]">
+            <div class="text-[14px] font-bold leading-none text-[#4a5568]">나이 <span class="text-[#e53e3e]">(필수)</span></div>
             <div class="flex flex-wrap items-center gap-[10px]">
               <select id="ageYearsInput" name="age_years" class="h-[42px] w-[96px] rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-center text-[14px] leading-none text-[#2d3748] outline-none transition-colors focus:border-[#90cdf4] md:w-[104px]">
                 {% for option in age_year_options %}
@@ -65,17 +70,18 @@
               </select>
               <span class="text-[14px] leading-none text-[#4a5568]">개월</span>
             </div>
+            <p id="ageStatus" class="hidden text-right text-[12px]"></p>
           </div>
 
-          <div class="space-y-[10px]">
-            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">체중 <span class="text-[#a0aec0]">(선택)</span></label>
+          <div class="space-y-[12px]">
+            <label class="block text-[14px] font-bold leading-none text-[#4a5568]">몸무게 <span class="text-[#a0aec0]">(선택)</span></label>
             <div class="relative">
-              <input id="weightInput" name="weight_kg" value="{{ pet.weight_kg|default:'' }}" placeholder="체중 입력" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] pr-10 text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+              <input id="weightInput" name="weight_kg" value="{{ pet.weight_kg|default:'' }}" maxlength="3" placeholder="몸무게를 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] pr-10 text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
               <span class="absolute right-[12px] top-1/2 -translate-y-1/2 text-[14px] leading-none text-[#4a5568]">kg</span>
             </div>
           </div>
 
-          <div class="space-y-[10px]">
+          <div class="space-y-[12px]">
             <div class="text-[14px] font-bold leading-none text-[#4a5568]">중성화 여부 <span class="text-[#a0aec0]">(선택)</span></div>
             <div class="flex gap-[6px]">
               <button type="button" id="neuteredYes" class="flex h-[42px] flex-1 items-center justify-center rounded-[10px] border text-[14px] leading-none transition-colors {% if pet.neutered == True %}border-[#3182ce] bg-[#ebf8ff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white font-normal text-[#4a5568]{% endif %}">예</button>
@@ -85,13 +91,13 @@
           </div>
         </div>
 
-        <div class="mt-[28px] flex flex-col-reverse gap-[10px] pt-[8px] md:mt-auto md:flex-row md:items-end md:gap-[14px] md:pt-[40px]">
+        <div class="mt-[20px] flex flex-col-reverse gap-[10px] pt-[4px] md:mt-auto md:flex-row md:items-end md:gap-[14px] md:pt-[24px]">
           {% if is_edit %}
-          <a href="/pets/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">이전으로</a>
-          <button type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음 단계로 (건강/식이 입력)</button>
+          <a href="/pets/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">취소</a>
+          <button id="nextButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음으로</button>
           {% else %}
           <a href="/pets/add/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">이전으로</a>
-          <button id="nextButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음 단계로 (건강/식이 입력)</button>
+          <button id="nextButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음으로</button>
           {% endif %}
         </div>
       </form>
@@ -103,6 +109,8 @@
 {% block scripts %}
 <script>
   (function () {
+    var form = document.querySelector('form[action]');
+    var species = '{{ species|escapejs }}';
     var genderInput = document.getElementById('genderInput');
     var neuteredInput = document.getElementById('neuteredInput');
     var genderMale = document.getElementById('genderMale');
@@ -110,10 +118,24 @@
     var neuteredYes = document.getElementById('neuteredYes');
     var neuteredNo = document.getElementById('neuteredNo');
     var nameInput = document.getElementById('nameInput');
+    var nameStatus = document.getElementById('nameStatus');
     var ageYearsInput = document.getElementById('ageYearsInput');
     var ageMonthsInput = document.getElementById('ageMonthsInput');
+    var ageStatus = document.getElementById('ageStatus');
+    var breedInput = document.getElementById('breedInput');
+    var breedStatus = document.getElementById('breedStatus');
+    var breedSuggestions = document.getElementById('breedSuggestions');
     var weightInput = document.getElementById('weightInput');
     var nextButton = document.getElementById('nextButton');
+    var currentBreedItems = [];
+    var highlightedBreedIndex = -1;
+    var isNameComposing = false;
+    var allowedNamePattern = /[^가-힣A-Za-z0-9\s]/g;
+    var breedData = {
+      dog: ['말티즈', '푸들', '포메라니안', '비숑 프리제', '시바견', '웰시 코기', '리트리버', '치와와', '불독', '요크셔테리어'],
+      cat: ['코리안 숏헤어', '브리티시 숏헤어', '러시안 블루', '스코티시 폴드', '페르시안', '샴', '먼치킨', '랙돌', '노르웨이 숲', '벵갈'],
+    };
+    var CHOSEONG = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
 
     function paintToggle(button, active) {
       button.style.borderColor = active ? '#3182ce' : '#e2e8f0';
@@ -123,7 +145,148 @@
     }
 
     function keepWeight(input) {
-      input.value = input.value.replace(/[^0-9.]/g, '');
+      var digits = input.value.replace(/\D/g, '').slice(0, 3);
+      digits = digits.replace(/^0+(?=\d)/, '');
+      if (/^0+$/.test(digits)) {
+        digits = '';
+      }
+      input.value = digits;
+    }
+
+    function normalizeNameSpacing(value) {
+      return (value || '')
+        .replace(/\s+/g, ' ')
+        .replace(/^\s+/, '');
+    }
+
+    function sanitizeNameInput() {
+      var sanitized = normalizeNameSpacing(nameInput.value).replace(allowedNamePattern, '').slice(0, 12);
+      if (nameInput.value !== sanitized) {
+        nameInput.value = sanitized;
+      }
+    }
+
+    function isValidName(value) {
+      return /^[A-Za-z0-9가-힣\s]+$/.test(value || '');
+    }
+
+    function clearError(node) {
+      if (!node) return;
+      node.textContent = '';
+      node.classList.add('hidden');
+    }
+
+    function showError(node, message) {
+      if (!node) return;
+      node.textContent = message;
+      node.style.color = '#e53e3e';
+      node.classList.remove('hidden');
+    }
+
+    function normalizeText(value) {
+      return (value || '').toLowerCase().replace(/\s+/g, '');
+    }
+
+    function sanitizeBreedInput(value) {
+      return (value || '')
+        .replace(/[^A-Za-z가-힣ㄱ-ㅎ\s]/g, '')
+        .replace(/\s+/g, ' ')
+        .replace(/^\s+/, '');
+    }
+
+    function toChoseong(value) {
+      return Array.from(value || '').map(function (char) {
+        var code = char.charCodeAt(0) - 44032;
+        if (code < 0 || code > 11171) return char;
+        return CHOSEONG[Math.floor(code / 588)] || char;
+      }).join('');
+    }
+
+    function isChoseongQuery(value) {
+      return /^[ㄱ-ㅎ]+$/.test(value || '');
+    }
+
+    function getBreedOptions() {
+      return breedData[species] || [];
+    }
+
+    function closeBreedSuggestions() {
+      if (!breedSuggestions) return;
+      currentBreedItems = [];
+      highlightedBreedIndex = -1;
+      breedSuggestions.classList.add('hidden');
+      breedSuggestions.classList.remove('pointer-events-auto');
+      breedSuggestions.classList.add('pointer-events-none');
+      breedSuggestions.style.opacity = '0';
+      breedSuggestions.style.transform = 'translateY(-6px)';
+    }
+
+    function applyBreed(value) {
+      if (!breedInput) return;
+      breedInput.value = value;
+      closeBreedSuggestions();
+      breedInput.focus();
+    }
+
+    function paintBreedSuggestionState() {
+      if (!breedSuggestions) return;
+      Array.from(breedSuggestions.querySelectorAll('button')).forEach(function (button, index) {
+        if (index === highlightedBreedIndex) {
+          button.classList.add('bg-[#f8fbff]', 'text-[#3182ce]');
+        } else {
+          button.classList.remove('bg-[#f8fbff]', 'text-[#3182ce]');
+        }
+      });
+    }
+
+    function openBreedSuggestions(items) {
+      if (!breedSuggestions) return;
+      if (!items.length) {
+        closeBreedSuggestions();
+        return;
+      }
+      currentBreedItems = items.slice();
+      highlightedBreedIndex = -1;
+      breedSuggestions.innerHTML = '';
+      items.forEach(function (item) {
+        var button = document.createElement('button');
+        button.type = 'button';
+        button.className = 'flex w-full items-center rounded-[8px] px-[10px] py-[9px] text-left text-[13px] leading-none text-[#2d3748] transition-colors duration-150 hover:bg-[#f8fbff]';
+        button.textContent = item;
+        button.addEventListener('mouseenter', function () {
+          highlightedBreedIndex = items.indexOf(item);
+          paintBreedSuggestionState();
+        });
+        button.addEventListener('mousedown', function (event) {
+          event.preventDefault();
+          applyBreed(item);
+        });
+        breedSuggestions.appendChild(button);
+      });
+      breedSuggestions.classList.remove('hidden', 'pointer-events-none');
+      breedSuggestions.classList.add('pointer-events-auto');
+      breedSuggestions.style.opacity = '1';
+      breedSuggestions.style.transform = 'translateY(0)';
+      paintBreedSuggestionState();
+    }
+
+    function updateBreedSuggestions() {
+      if (!breedInput) return;
+      var keyword = breedInput.value.trim();
+      var options = getBreedOptions();
+      if (!keyword) {
+        closeBreedSuggestions();
+        return;
+      }
+      var normalizedKeyword = normalizeText(keyword);
+      var filtered = options.filter(function (item) {
+        var normalizedItem = normalizeText(item);
+        if (isChoseongQuery(normalizedKeyword)) {
+          return toChoseong(normalizedItem).indexOf(normalizedKeyword) === 0;
+        }
+        return normalizedItem.indexOf(normalizedKeyword) !== -1;
+      }).slice(0, 8);
+      openBreedSuggestions(filtered);
     }
 
     function syncNextButton() {
@@ -131,7 +294,7 @@
       var years = Number(ageYearsInput.value || '0');
       var months = Number(ageMonthsInput.value || '0');
       var hasMinimumAge = years > 0 || months > 0;
-      var ready = nameInput.value.trim() && hasMinimumAge;
+      var ready = nameInput.value.trim() && breedInput.value.trim() && hasMinimumAge;
       nextButton.disabled = !ready;
       nextButton.style.backgroundColor = ready ? '#3182ce' : '#cbd5e0';
       nextButton.style.cursor = ready ? 'pointer' : 'default';
@@ -151,17 +314,135 @@
 
     genderMale.addEventListener('click', function () { syncGender('male'); });
     genderFemale.addEventListener('click', function () { syncGender('female'); });
-    neuteredYes.addEventListener('click', function () { syncNeutered('yes'); });
-    neuteredNo.addEventListener('click', function () { syncNeutered('no'); });
+    neuteredYes.addEventListener('click', function () {
+      syncNeutered(neuteredInput.value === 'yes' ? '' : 'yes');
+    });
+    neuteredNo.addEventListener('click', function () {
+      syncNeutered(neuteredInput.value === 'no' ? '' : 'no');
+    });
     ageYearsInput.addEventListener('change', syncNextButton);
     ageMonthsInput.addEventListener('change', syncNextButton);
     weightInput.addEventListener('input', function () {
       keepWeight(weightInput);
     });
-    nameInput.addEventListener('input', syncNextButton);
+    nameInput.addEventListener('input', function () {
+      if (!isNameComposing) {
+        sanitizeNameInput();
+      }
+      clearError(nameStatus);
+      syncNextButton();
+    });
+    nameInput.addEventListener('compositionstart', function () {
+      isNameComposing = true;
+    });
+    nameInput.addEventListener('compositionend', function () {
+      isNameComposing = false;
+      sanitizeNameInput();
+      clearError(nameStatus);
+      syncNextButton();
+    });
+    nameInput.addEventListener('blur', function () {
+      sanitizeNameInput();
+      nameInput.value = nameInput.value.trim();
+      syncNextButton();
+    });
+    ageYearsInput.addEventListener('change', function () {
+      clearError(ageStatus);
+      syncNextButton();
+    });
+    ageMonthsInput.addEventListener('change', function () {
+      clearError(ageStatus);
+      syncNextButton();
+    });
+
+    if (breedInput) {
+      breedInput.addEventListener('focus', updateBreedSuggestions);
+      breedInput.addEventListener('input', function () {
+        breedInput.value = sanitizeBreedInput(breedInput.value);
+        clearError(breedStatus);
+        updateBreedSuggestions();
+        syncNextButton();
+      });
+      breedInput.addEventListener('keydown', function (event) {
+        var isOpen = breedSuggestions && !breedSuggestions.classList.contains('hidden') && currentBreedItems.length;
+        if (event.key === 'ArrowDown') {
+          if (!isOpen) {
+            updateBreedSuggestions();
+            isOpen = breedSuggestions && !breedSuggestions.classList.contains('hidden') && currentBreedItems.length;
+          }
+          if (!isOpen) return;
+          event.preventDefault();
+          highlightedBreedIndex = highlightedBreedIndex < currentBreedItems.length - 1 ? highlightedBreedIndex + 1 : 0;
+          paintBreedSuggestionState();
+          return;
+        }
+        if (event.key === 'ArrowUp' && isOpen) {
+          event.preventDefault();
+          highlightedBreedIndex = highlightedBreedIndex > 0 ? highlightedBreedIndex - 1 : currentBreedItems.length - 1;
+          paintBreedSuggestionState();
+          return;
+        }
+        if (event.key === 'Enter' && isOpen && highlightedBreedIndex >= 0) {
+          event.preventDefault();
+          applyBreed(currentBreedItems[highlightedBreedIndex]);
+          return;
+        }
+        if (event.key === 'Escape' && isOpen) {
+          event.preventDefault();
+          closeBreedSuggestions();
+        }
+      });
+      breedInput.addEventListener('blur', function () {
+        breedInput.value = sanitizeBreedInput(breedInput.value).trim();
+        syncNextButton();
+      });
+      breedInput.addEventListener('blur', function () {
+        window.setTimeout(closeBreedSuggestions, 120);
+      });
+    }
+
+    document.addEventListener('mousedown', function (event) {
+      if (!breedSuggestions || !breedInput) return;
+      if (breedSuggestions.contains(event.target) || breedInput.contains(event.target)) return;
+      closeBreedSuggestions();
+    });
+
+    if (form) {
+      form.addEventListener('submit', function (event) {
+        var valid = true;
+        sanitizeNameInput();
+        var cleanedName = nameInput.value.trim();
+        var years = Number(ageYearsInput.value || '0');
+        var months = Number(ageMonthsInput.value || '0');
+
+        clearError(nameStatus);
+        clearError(breedStatus);
+        clearError(ageStatus);
+
+        nameInput.value = cleanedName;
+
+        if (!cleanedName) {
+          valid = false;
+        }
+
+        if (!breedInput.value.trim()) {
+          valid = false;
+        }
+
+        if (!(years > 0 || months > 0)) {
+          valid = false;
+        }
+
+        if (!valid) {
+          event.preventDefault();
+        }
+      });
+    }
 
     syncGender(genderInput.value || 'male');
     syncNeutered(neuteredInput.value || '');
+    sanitizeNameInput();
+    nameInput.value = nameInput.value.trim();
     syncNextButton();
   })();
 </script>

--- a/services/django/templates/pets/add_step3.html
+++ b/services/django/templates/pets/add_step3.html
@@ -23,7 +23,7 @@
           {% if species == "cat" %}고양이 건강/식이 정보{% elif species == "future" %}예비 집사 건강/식이 정보{% else %}강아지 건강/식이 정보{% endif %}
         </span>
       </div>
-      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">정확한 사료와 영양제 추천을 위해 빈칸을 채워주세요</p>
+      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">건강과 식이 정보를 입력하면 맞춤 추천에 반영할 수 있어요</p>
 
       <form method="post" action="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/health/{% elif is_edit %}/pets/{{ pet_id }}/edit/health/{% else %}/pets/add/health/{% endif %}" class="mt-[18px]">
         {% csrf_token %}
@@ -37,31 +37,9 @@
         <input type="hidden" name="weight_kg" value="{{ step2_data.weight_kg }}" />
         <input type="hidden" name="neutered" value="{{ step2_data.neutered }}" />
         <input type="hidden" name="allergies" id="allergiesInput" value="{{ step3_data.allergies }}" />
+        <input type="hidden" name="special_notes" value="{{ step3_data.special_notes }}" />
 
         <div class="grid grid-cols-1 gap-x-[28px] gap-y-[18px] md:grid-cols-2">
-          <div>
-            <label class="mb-[8px] block text-[14px] font-bold text-[#4a5568]">
-              마지막 접종일 <span class="text-[#a0aec0]">(선택)</span>
-            </label>
-            <div class="relative">
-              <input type="date" name="vaccination_date" value="{{ step3_data.vaccination_date }}" class="h-[42px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] text-[#2d3748] outline-none focus:border-[#90cdf4]" />
-            </div>
-          </div>
-
-          <div>
-            <div class="mb-[8px] text-[14px] font-bold text-[#4a5568]">
-              선호 사료 형태 <span class="text-[#a0aec0]">(다중 선택 가능)</span>
-            </div>
-            <div class="flex flex-wrap gap-[8px]">
-              {% for value, label in food_options %}
-              <label class="food-option flex h-[42px] flex-1 cursor-pointer items-center justify-center rounded-[8px] border text-[14px] {% if value in step3_data.food_preferences %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
-                <input type="checkbox" class="hidden food-checkbox" name="food_preferences" value="{{ value }}" {% if value in step3_data.food_preferences %}checked{% endif %} />
-                {{ label }}
-              </label>
-              {% endfor %}
-            </div>
-          </div>
-
           <div class="md:col-span-2">
             <div class="mb-[8px] text-[14px] font-bold text-[#4a5568]">
               건강 관심사 <span class="text-[#a0aec0]">(다중 선택 가능)</span>
@@ -76,12 +54,62 @@
             </div>
           </div>
 
-          <div>
+          <div class="md:col-span-2">
+            <div class="mb-[8px] text-[14px] font-bold text-[#4a5568]">
+              선호 사료 형태 <span class="text-[#a0aec0]">(다중 선택 가능)</span>
+            </div>
+            <div class="flex flex-wrap gap-[8px]">
+              {% for value, label in food_options %}
+              <label class="food-option flex h-[42px] flex-1 cursor-pointer items-center justify-center rounded-[8px] border text-[14px] {% if value in step3_data.food_preferences %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
+                <input type="checkbox" class="hidden food-checkbox" name="food_preferences" value="{{ value }}" {% if value in step3_data.food_preferences %}checked{% endif %} />
+                {{ label }}
+              </label>
+              {% endfor %}
+            </div>
+          </div>
+
+          <div class="md:col-span-2">
             <label class="mb-[8px] block text-[14px] font-bold text-[#4a5568]">
               알레르기 태그 <span class="text-[#a0aec0]">(선택)</span>
             </label>
             <input id="allergyTextInput" type="text" placeholder="알레르기 성분 입력 후 Enter (예: 닭고기)" class="h-[42px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] text-[13px] text-[#2d3748] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
             <div id="allergyTags" class="mt-[8px] flex flex-wrap gap-[6px]"></div>
+          </div>
+
+          <div>
+            <label class="mb-[8px] block text-[14px] font-bold text-[#4a5568]">
+              마지막 접종일 <span class="text-[#a0aec0]">(선택)</span>
+            </label>
+            <div class="relative">
+              <input
+                type="text"
+                id="vaccinationDateInput"
+                name="vaccination_date"
+                value="{{ step3_data.vaccination_date }}"
+                inputmode="numeric"
+                maxlength="10"
+                placeholder="YYYY-MM-DD"
+                class="h-[42px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] pr-[52px] text-[14px] text-[#2d3748] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]"
+              />
+              <input
+                type="date"
+                id="vaccinationDatePicker"
+                value="{{ step3_data.vaccination_date }}"
+                min="2000-01-01"
+                tabindex="-1"
+                aria-hidden="true"
+                class="pointer-events-none absolute right-[10px] top-1/2 h-[1px] w-[1px] -translate-y-1/2 opacity-0"
+              />
+              <button
+                type="button"
+                id="vaccinationDatePickerButton"
+                class="absolute right-[10px] top-1/2 flex h-[28px] w-[28px] -translate-y-1/2 items-center justify-center rounded-[6px] text-[16px] text-[#718096] transition-colors hover:bg-[#edf2f7]"
+                aria-label="캘린더 열기"
+              >
+                <span aria-hidden="true">📅</span>
+              </button>
+            </div>
+            <p id="vaccinationDateStatus" class="mt-[6px] min-h-[16px] text-right text-[12px]"></p>
           </div>
 
           <div>
@@ -95,17 +123,10 @@
               {% endfor %}
             </select>
           </div>
-
-          <div class="md:col-span-2">
-            <label class="mb-[8px] block text-[14px] font-bold text-[#4a5568]">
-              특이사항 <span class="text-[#a0aec0]">(선택)</span>
-            </label>
-            <textarea name="special_notes" class="h-[88px] w-full resize-none rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] py-[12px] text-[13px] text-[#2d3748] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]" placeholder="약 복용 여부, 기저질환 등 기타 특이사항을 자유롭게 적어주세요.">{{ step3_data.special_notes }}</textarea>
-          </div>
         </div>
 
         <div class="mt-[28px] flex flex-col-reverse gap-[10px] md:flex-row md:items-end md:gap-[14px]">
-          <button type="button" onclick="history.back()" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] md:w-[128px]">이전으로</button>
+          <a href="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/{% elif is_edit %}/pets/{{ pet_id }}/edit/{% else %}/pets/add/health/?species={{ step2_data.species|urlencode }}&name={{ step2_data.name|urlencode }}&breed={{ step2_data.breed|urlencode }}&gender={{ step2_data.gender|urlencode }}&age_years={{ step2_data.age_years|urlencode }}&age_months={{ step2_data.age_months|urlencode }}&weight_kg={{ step2_data.weight_kg|urlencode }}&neutered={{ step2_data.neutered|urlencode }}{% endif %}" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] md:w-[128px]">이전으로</a>
           <button type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white">{% if is_edit %}수정 완료{% else %}등록 완료{% endif %}</button>
         </div>
       </form>
@@ -139,6 +160,152 @@
     var allergiesHidden = document.getElementById('allergiesInput');
     var tagsContainer = document.getElementById('allergyTags');
     var tags = allergiesHidden.value ? allergiesHidden.value.split(',').map(function (item) { return item.trim(); }).filter(Boolean) : [];
+    var vaccinationDateInput = document.getElementById('vaccinationDateInput');
+    var vaccinationDatePicker = document.getElementById('vaccinationDatePicker');
+    var vaccinationDatePickerButton = document.getElementById('vaccinationDatePickerButton');
+    var vaccinationDateStatus = document.getElementById('vaccinationDateStatus');
+
+    function clearStatus(node) {
+      if (!node) return;
+      node.textContent = '';
+      node.style.color = '';
+    }
+
+    function showStatus(node, message) {
+      if (!node) return;
+      node.textContent = message;
+      node.style.color = '#e53e3e';
+    }
+
+    function normalizeVaccinationDate(value) {
+      var digits = (value || '').replace(/\D/g, '').slice(0, 8);
+      if (digits.length <= 4) return digits;
+      if (digits.length <= 6) return digits.slice(0, 4) + '-' + digits.slice(4);
+      return digits.slice(0, 4) + '-' + digits.slice(4, 6) + '-' + digits.slice(6);
+    }
+
+    function getTodayParts() {
+      var today = new Date();
+      return {
+        year: today.getFullYear(),
+        month: today.getMonth() + 1,
+        day: today.getDate(),
+        iso: today.getFullYear() + '-' + String(today.getMonth() + 1).padStart(2, '0') + '-' + String(today.getDate()).padStart(2, '0'),
+      };
+    }
+
+    function clampVaccinationDigits(rawValue) {
+      var digits = (rawValue || '').replace(/\D/g, '').slice(0, 8);
+      var today = getTodayParts();
+
+      if (digits.length >= 4) {
+        var year = Number(digits.slice(0, 4));
+        if (year < 2000) {
+          digits = '2000' + digits.slice(4);
+        } else if (year > today.year) {
+          digits = String(today.year) + digits.slice(4);
+        }
+      }
+
+      if (digits.length >= 6) {
+        var month = Number(digits.slice(4, 6));
+        if (month < 1) month = 1;
+        if (month > 12) month = 12;
+        digits = digits.slice(0, 4) + String(month).padStart(2, '0') + digits.slice(6);
+      }
+
+      if (digits.length >= 8) {
+        var clampedYear = Number(digits.slice(0, 4));
+        var clampedMonth = Number(digits.slice(4, 6));
+        var day = Number(digits.slice(6, 8));
+        var maxDay = new Date(clampedYear, clampedMonth, 0).getDate();
+        if (day < 1) day = 1;
+        if (day > maxDay) day = maxDay;
+
+        if (clampedYear === today.year) {
+          if (clampedMonth > today.month) {
+            clampedMonth = today.month;
+            day = today.day;
+          } else if (clampedMonth === today.month && day > today.day) {
+            day = today.day;
+          }
+        }
+
+        digits =
+          digits.slice(0, 4) +
+          String(clampedMonth).padStart(2, '0') +
+          String(day).padStart(2, '0');
+      }
+
+      return digits;
+    }
+
+    function isValidVaccinationDate(value) {
+      if (!value) return true;
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) return false;
+      var parts = value.split('-');
+      var year = Number(parts[0]);
+      var month = Number(parts[1]);
+      var day = Number(parts[2]);
+      var date = new Date(year, month - 1, day);
+      return (
+        date.getFullYear() === year &&
+        date.getMonth() === month - 1 &&
+        date.getDate() === day
+      );
+    }
+
+    function isVaccinationDateInRange(value) {
+      if (!value) return true;
+      var min = '2000-01-01';
+      var max = getTodayParts().iso;
+      return value >= min && value <= max;
+    }
+
+    function syncVaccinationPickerBounds() {
+      if (!vaccinationDatePicker) return;
+      vaccinationDatePicker.min = '2000-01-01';
+      vaccinationDatePicker.max = getTodayParts().iso;
+    }
+
+    if (vaccinationDateInput) {
+      vaccinationDateInput.addEventListener('input', function () {
+        vaccinationDateInput.value = normalizeVaccinationDate(clampVaccinationDigits(vaccinationDateInput.value));
+        clearStatus(vaccinationDateStatus);
+      });
+
+      vaccinationDateInput.addEventListener('blur', function () {
+        vaccinationDateInput.value = normalizeVaccinationDate(clampVaccinationDigits(vaccinationDateInput.value));
+        if (!isValidVaccinationDate(vaccinationDateInput.value)) {
+          showStatus(vaccinationDateStatus, '날짜는 YYYY-MM-DD 형식으로 입력해 주세요');
+          return;
+        }
+        if (!isVaccinationDateInRange(vaccinationDateInput.value)) {
+          showStatus(vaccinationDateStatus, '날짜는 2000-01-01부터 오늘까지만 입력할 수 있어요');
+          return;
+        }
+        clearStatus(vaccinationDateStatus);
+        if (vaccinationDatePicker && vaccinationDateInput.value) {
+          vaccinationDatePicker.value = vaccinationDateInput.value;
+        }
+      });
+    }
+
+    if (vaccinationDatePickerButton && vaccinationDatePicker) {
+      vaccinationDatePickerButton.addEventListener('click', function () {
+        if (typeof vaccinationDatePicker.showPicker === 'function') {
+          vaccinationDatePicker.showPicker();
+          return;
+        }
+        vaccinationDatePicker.click();
+      });
+
+      vaccinationDatePicker.addEventListener('change', function () {
+        if (!vaccinationDateInput) return;
+        vaccinationDateInput.value = vaccinationDatePicker.value;
+        clearStatus(vaccinationDateStatus);
+      });
+    }
 
     function syncTags() {
       allergiesHidden.value = tags.join(',');
@@ -166,6 +333,24 @@
       syncTags();
     });
 
+    var form = document.querySelector('form');
+    if (form) {
+      form.addEventListener('submit', function (event) {
+        if (!vaccinationDateInput) return;
+        vaccinationDateInput.value = normalizeVaccinationDate(clampVaccinationDigits(vaccinationDateInput.value));
+        if (!isValidVaccinationDate(vaccinationDateInput.value)) {
+          event.preventDefault();
+          showStatus(vaccinationDateStatus, '날짜는 YYYY-MM-DD 형식으로 입력해 주세요');
+          return;
+        }
+        if (!isVaccinationDateInRange(vaccinationDateInput.value)) {
+          event.preventDefault();
+          showStatus(vaccinationDateStatus, '날짜는 2000-01-01부터 오늘까지만 입력할 수 있어요');
+        }
+      });
+    }
+
+    syncVaccinationPickerBounds();
     syncTags();
   })();
 </script>

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -55,10 +55,10 @@
       <div>
         <h1 class="text-[24px] font-bold text-[#2d3748]">반려동물 정보</h1>
         <p class="mt-2 text-[14px] text-[#718096]">
-          등록된 반려동물 정보를 수정하거나 새로운 반려동물을 추가할 수 있습니다
+          등록된 반려동물 정보와 예비 집사 프로필을 함께 관리할 수 있습니다
         </p>
       </div>
-      <div class="text-[14px] font-bold text-[#3182ce]">등록 현황: {{ pets|length }} / 5</div>
+      <div class="text-[14px] font-bold text-[#3182ce]">반려동물 등록 현황: {{ actual_pet_count }} / 5</div>
     </div>
 
     <div class="mt-5 h-px w-full bg-[#edf2f7]"></div>
@@ -68,20 +68,41 @@
       <div class="pet-card flex items-center gap-5 rounded-[14px] border border-[#e2e8f0] bg-white px-4 py-4 shadow-[0_1px_2px_rgba(45,55,72,0.02)] {% if pets|length >= 3 and not forloop.first %}mt-4{% endif %}"
            data-pet-id="{{ pet.pet_id }}">
         <div class="flex h-[56px] w-[56px] items-center justify-center rounded-full bg-[#edf2f7] text-[24px]">
-          {% if pet.species == "cat" %}🐱{% else %}🐶{% endif %}
+          {% if pet.species == "future" %}🏠{% elif pet.species == "cat" %}🐱{% else %}🐶{% endif %}
         </div>
         <div class="min-w-0 flex-1">
           <div class="text-[18px] font-bold text-[#2d3748]">
+            {% if pet.species == "future" %}
+            {{ pet.name }}
+            {% else %}
             {{ pet.name }} ({{ pet.get_species_display }})
+            {% endif %}
           </div>
           <div class="mt-1 text-[14px] text-[#718096]">
+            {% if pet.species == "future" %}
+            {{ pet.summary }}
+            {% else %}
             {{ pet.age_years }}년 {{ pet.age_months }}개월
             · {{ pet.get_gender_display }}
             {% if pet.breed %} · {{ pet.breed }}{% endif %}
+            {% endif %}
           </div>
         </div>
         <div class="flex items-center gap-3">
-          {% if is_preview_list %}
+          {% if pet.species == "future" %}
+          <a href="/pets/add/future/"
+             class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568] transition-colors hover:bg-[#e2e8f0]">
+            수정
+          </a>
+          <form id="deletePetForm-{{ pet.pet_id }}" method="post" action="/pets/future/delete/" style="display:contents">
+            {% csrf_token %}
+            <button type="button"
+                    class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] border border-[#feb2b2] bg-white text-[14px] font-bold text-[#e53e3e] transition-colors hover:bg-[#fff5f5]"
+                    onclick="openPetDeleteModal('{{ pet.pet_id }}', false)">
+              삭제
+            </button>
+          </form>
+          {% elif is_preview_list %}
           <a href="/pets/preview/{{ pet.pet_id }}/edit/"
                   class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">
             수정
@@ -100,7 +121,7 @@
             {% csrf_token %}
             <input type="hidden" name="_method" value="DELETE" />
             <button type="button"
-                    class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] border border-[#feb2b2] bg-white text-[14px] font-bold text-[#e53e3e] transition-colors hover:bg-[#fff5f5]">
+                    class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] border border-[#feb2b2] bg-white text-[14px] font-bold text-[#e53e3e] transition-colors hover:bg-[#fff5f5]"
                     onclick="openPetDeleteModal('{{ pet.pet_id }}', false)">
               삭제
             </button>
@@ -113,7 +134,7 @@
       {% endfor %}
     </div>
 
-    {% if pets|length < 5 %}
+    {% if actual_pet_count < 5 %}
     <a href="/pets/add/"
        class="mt-4 flex h-[44px] w-full items-center justify-center rounded-[12px] border border-dashed border-[#90cdf4] bg-[#f8fbff] text-[16px] font-bold text-[#3182ce] transition-colors hover:bg-[#eef7ff]">
       + 새로운 반려동물 추가하기

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -45,25 +45,24 @@
       </div>
       <button
         type="button"
-        class="auth-legacy-remember absolute left-[126px] top-[186px] h-[26px] w-[148px]"
-        style="display:flex; align-items:center; justify-content:flex-start; gap:10px; padding:0; border:0; background:transparent;"
+        class="auth-legacy-remember absolute left-[140px] top-[186px] h-[26px] w-[148px]"
         id="rememberToggle"
         aria-pressed="true"
       >
-        <span class="auth-legacy-checkbox" aria-hidden="true" style="position:relative; width:18px; height:18px; flex:0 0 18px;">
+        <span class="auth-legacy-checkbox" aria-hidden="true" style="position:relative; width:16px; height:16px; display:block;">
           <img
             alt=""
-            class="absolute left-0 top-0 h-[18px] w-[18px]"
+            class="absolute left-0 top-0 h-[16px] w-[16px]"
             src="https://www.figma.com/api/mcp/asset/d87cedfa-0ee2-4f61-8bfd-ac58c6a6fb43"
           />
           <img
             alt=""
-            class="absolute left-[5px] top-[6px] h-[6px] w-[8px]"
+            class="absolute left-[4px] top-[5px] h-[6px] w-[8px]"
             id="rememberCheck"
             src="https://www.figma.com/api/mcp/asset/c1ccc9d0-f595-41ef-8f5c-668456e9975d"
           />
         </span>
-        <span class="auth-legacy-remember-text" style="display:block; white-space:nowrap; line-height:1; margin-top:1px;">로그인 상태 유지</span>
+        <span class="auth-legacy-remember-text">로그인 상태 유지</span>
       </button>
     </div>
   </div>

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -79,20 +79,20 @@
       <div class="mt-4">
         <div class="mb-2 text-[14px] font-bold text-[#4a5568]">주소 <span class="text-[12px] font-medium text-[#a0aec0]">(선택)</span></div>
         <div class="flex gap-3">
-          <input name="zipcode" id="zipcodeInput" placeholder="우편번호"
-                 class="h-[36px] w-[140px] rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
+          <input name="zipcode" id="zipcodeInput" placeholder="우편번호" readonly
+                 class="h-[36px] w-[140px] rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
           <button type="button" id="postcodeButton"
                   class="h-[36px] w-[110px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">우편번호 찾기</button>
         </div>
-        <input name="address_main" id="addressMainInput" placeholder="기본 주소"
-               class="mt-3 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
+        <input name="address_main" id="addressMainInput" placeholder="기본 주소" readonly
+               class="mt-3 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
         <input name="address_detail" id="addressDetailInput" placeholder="상세 주소"
                class="mt-3 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
-        <p id="addressStatus" class="mt-2 min-h-[18px] text-right text-[12px]"></p>
+        <p id="addressStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
       </div>
 
       <!-- 알림 설정 -->
-      <div class="mt-6">
+      <div class="mt-4">
         <div class="flex w-full max-w-[195px] items-center gap-2 rounded-[10px] border border-[#e2e8f0] px-3 py-2">
           <span class="text-[13px] font-medium leading-none text-[#4a5568]">마케팅 푸시 동의</span>
           <div class="ml-auto flex h-[20px] items-center">

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -45,25 +45,24 @@
       </div>
       <button
         type="button"
-        class="auth-legacy-remember absolute left-[126px] top-[186px] h-[26px] w-[148px]"
-        style="display:flex; align-items:center; justify-content:flex-start; gap:10px; padding:0; border:0; background:transparent;"
+        class="auth-legacy-remember absolute left-[140px] top-[186px] h-[26px] w-[148px]"
         id="rememberToggle"
         aria-pressed="true"
       >
-        <span class="auth-legacy-checkbox" aria-hidden="true" style="position:relative; width:18px; height:18px; flex:0 0 18px;">
+        <span class="auth-legacy-checkbox" aria-hidden="true" style="position:relative; width:16px; height:16px; display:block;">
           <img
             alt=""
-            class="absolute left-0 top-0 h-[18px] w-[18px]"
+            class="absolute left-0 top-0 h-[16px] w-[16px]"
             src="https://www.figma.com/api/mcp/asset/d87cedfa-0ee2-4f61-8bfd-ac58c6a6fb43"
           />
           <img
             alt=""
-            class="absolute left-[5px] top-[6px] h-[6px] w-[8px]"
+            class="absolute left-[4px] top-[5px] h-[6px] w-[8px]"
             id="rememberCheck"
             src="https://www.figma.com/api/mcp/asset/c1ccc9d0-f595-41ef-8f5c-668456e9975d"
           />
         </span>
-        <span class="auth-legacy-remember-text" style="display:block; white-space:nowrap; line-height:1; margin-top:1px;">로그인 상태 유지</span>
+        <span class="auth-legacy-remember-text">로그인 상태 유지</span>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## 요약
Django MVT 전환 이후 반려동물 등록 UI와 예비 집사 흐름을 정리했습니다.

## 변경 사항
- Django Template 기준 반려동물 등록 단계 UI를 정비했습니다.
- `/pets/add/` 흐름의 단계별 입력 구조와 액션 배치를 현재 MVT 구조에 맞게 정리했습니다.
- 건강/식이 정보(step3)에서 핵심 입력 항목 우선순위를 조정했습니다.
- 마지막 접종일 입력을 `YYYY-MM-DD` 직접 입력 + 캘린더 선택 방식으로 개선했습니다.
- 마지막 접종일에 형식/범위 검증을 추가했습니다.
- 예비 집사 프로필을 반려동물과 공존 가능하도록 정리했습니다.
- 반려동물 정보 페이지와 채팅 드롭다운에서 예비 집사를 함께 노출하도록 반영했습니다.
- 예비 집사는 실제 반려동물 아래에 오도록 정렬을 고정했습니다.
- 반려동물 추가 후 예비 집사 세션이 사라지던 문제를 수정했습니다.

## 관련 이슈
- Refs #128
- Closes #158

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- `/pets/add/` 단계별 이동과 저장 동작
- `step3` 마지막 접종일 직접 입력 검증
- 반려동물 정보 페이지와 채팅 드롭다운에서 예비 집사 노출 및 정렬 순서

## 테스트
- `python manage.py test`
- 반려동물 신규 등록 저장 확인
- 반려동물 수정 저장 확인
- 예비 집사 등록 후 반려동물 추가 시 공존 여부 확인
- 반려동물 정보 페이지와 채팅 드롭다운에서 노출/정렬 확인