### PR TITLE
feat(chat): add django proxy and session messaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 *.py[cod]
 *.pyo
 .venv/
+.venv-pdf/
 venv/
 env/
 *.egg-info/
@@ -55,6 +56,7 @@ services/django/media/
 
 # Crawling output (로컬 데이터, S3 업로드 전)
 output/
+tmp/pdfs/
 
 # DB 백업 (팀 공유 드라이브로 배포)
 backup/
@@ -64,6 +66,7 @@ backup/
 
 # Issues / internal notes (로컬 전용)
 docs/issues/
+docs/shqkel/
 
 # 발표 자료 (로컬 전용)
 docs/presentation/

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -28,6 +28,8 @@ services:
       DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
       DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-localhost}
       APP_BASE_URL: ${APP_BASE_URL:-}
+      FASTAPI_INTERNAL_CHAT_URL: ${FASTAPI_INTERNAL_CHAT_URL:-http://fastapi:8001/api/chat/}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
       POSTGRES_DB: ${POSTGRES_DB}
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
@@ -74,6 +76,7 @@ services:
       QDRANT_HOST: ${QDRANT_HOST:-qdrant}
       QDRANT_PORT: ${QDRANT_PORT:-6333}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
     expose:
       - "8001"
     depends_on:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -13,7 +13,7 @@ http {
 
         # FastAPI — 챗봇 / 추천
         location /api/chat/ {
-            proxy_pass http://fastapi;
+            proxy_pass http://django;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             # SSE 스트리밍 지원

--- a/services/django/chat/api_views.py
+++ b/services/django/chat/api_views.py
@@ -1,0 +1,179 @@
+import json
+
+import httpx
+from django.conf import settings
+from django.http import JsonResponse, StreamingHttpResponse
+from django.views.decorators.http import require_http_methods
+
+
+def _chat_base_url():
+    return settings.FASTAPI_INTERNAL_CHAT_URL.rstrip("/")
+
+
+def _internal_headers(user_id, include_content_type=True):
+    headers = {
+        "X-Internal-Service-Token": settings.INTERNAL_SERVICE_TOKEN,
+        "X-User-Id": str(user_id),
+    }
+    if include_content_type:
+        headers["Content-Type"] = "application/json"
+    return headers
+
+
+def _read_json_body(request):
+    if not request.body:
+        return {}
+    try:
+        return json.loads(request.body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        raise ValueError("유효한 JSON 요청이 필요합니다.")
+
+
+def _proxy_json(method, url, user_id, payload=None):
+    headers = _internal_headers(user_id, include_content_type=payload is not None)
+    with httpx.Client(timeout=30.0) as client:
+        response = client.request(method, url, headers=headers, json=payload)
+
+    try:
+        data = response.json()
+    except ValueError:
+        data = {"detail": response.text.strip() or "요청 처리에 실패했습니다."}
+
+    return JsonResponse(data, status=response.status_code, safe=not isinstance(data, list))
+
+
+def _stream_fastapi_response(url, payload, user_id):
+    headers = _internal_headers(user_id)
+
+    with httpx.Client(timeout=None) as client:
+        with client.stream("POST", url, headers=headers, json=payload) as response:
+            if response.status_code != 200:
+                detail = "채팅 요청 처리에 실패했습니다."
+                try:
+                    detail = response.json().get("detail", detail)
+                except Exception:
+                    text = response.text.strip()
+                    if text:
+                        detail = text
+                yield f"data: {json.dumps({'type': 'error', 'message': detail}, ensure_ascii=False)}\n\n"
+                return
+
+            for chunk in response.iter_bytes():
+                if chunk:
+                    yield chunk
+
+
+def _require_authenticated(request):
+    if request.user.is_authenticated:
+        return None
+    return JsonResponse({"detail": "로그인이 필요합니다."}, status=401)
+
+
+@require_http_methods(["POST"])
+def chat_proxy_view(request):
+    unauthorized = _require_authenticated(request)
+    if unauthorized:
+        return unauthorized
+
+    try:
+        payload = _read_json_body(request)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
+
+    message = (payload.get("message") or "").strip()
+    if not message:
+        return JsonResponse({"detail": "message is required."}, status=400)
+
+    safe_payload = {
+        "message": message,
+        "thread_id": payload.get("thread_id") or "default",
+        "pet_profile": payload.get("pet_profile"),
+        "health_concerns": payload.get("health_concerns") or [],
+        "allergies": payload.get("allergies") or [],
+        "food_preferences": payload.get("food_preferences") or [],
+    }
+
+    return StreamingHttpResponse(
+        _stream_fastapi_response(_chat_base_url() + "/", safe_payload, request.user.id),
+        content_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@require_http_methods(["GET", "POST"])
+def sessions_proxy_view(request):
+    unauthorized = _require_authenticated(request)
+    if unauthorized:
+        return unauthorized
+
+    url = _chat_base_url() + "/sessions/"
+    if request.method == "GET":
+        return _proxy_json("GET", url, request.user.id)
+
+    try:
+        payload = _read_json_body(request)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
+
+    safe_payload = {
+        "title": payload.get("title"),
+        "target_pet_id": payload.get("target_pet_id"),
+    }
+    return _proxy_json("POST", url, request.user.id, payload=safe_payload)
+
+
+@require_http_methods(["PATCH", "DELETE"])
+def session_detail_proxy_view(request, session_id):
+    unauthorized = _require_authenticated(request)
+    if unauthorized:
+        return unauthorized
+
+    url = f"{_chat_base_url()}/sessions/{session_id}/"
+    if request.method == "DELETE":
+        return _proxy_json("DELETE", url, request.user.id)
+
+    try:
+        payload = _read_json_body(request)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
+
+    return _proxy_json("PATCH", url, request.user.id, payload={"title": payload.get("title")})
+
+
+@require_http_methods(["GET", "POST"])
+def session_messages_proxy_view(request, session_id):
+    unauthorized = _require_authenticated(request)
+    if unauthorized:
+        return unauthorized
+
+    url = f"{_chat_base_url()}/sessions/{session_id}/messages/"
+    if request.method == "GET":
+        return _proxy_json("GET", url, request.user.id)
+
+    try:
+        payload = _read_json_body(request)
+    except ValueError as exc:
+        return JsonResponse({"detail": str(exc)}, status=400)
+
+    message = (payload.get("message") or "").strip()
+    if not message:
+        return JsonResponse({"detail": "message is required."}, status=400)
+
+    safe_payload = {
+        "message": message,
+        "pet_profile": payload.get("pet_profile"),
+        "health_concerns": payload.get("health_concerns") or [],
+        "allergies": payload.get("allergies") or [],
+        "food_preferences": payload.get("food_preferences") or [],
+    }
+    return StreamingHttpResponse(
+        _stream_fastapi_response(url, safe_payload, request.user.id),
+        content_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )

--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,6 +1,7 @@
 import json
 
 from django.shortcuts import render
+from django.views.decorators.csrf import ensure_csrf_cookie
 
 
 def _format_price(value):
@@ -24,7 +25,6 @@ def _serialize_pet(pet):
         if attr_name and hasattr(val, "values_list"):
             return list(val.values_list(attr_name, flat=True))
         return [v.strip() for v in val.split(",") if v.strip()]
-
     return {
         "id": str(pet.pet_id),
         "name": pet.name,
@@ -231,12 +231,14 @@ def _preview_session_threads():
     }
 
 
+@ensure_csrf_cookie
 def chat_view(request):
     sessions = []
     preview_member = request.GET.get("preview") == "member"
     is_authenticated = request.user.is_authenticated
     is_member_view = is_authenticated or preview_member
     is_preview_member = preview_member and not is_authenticated
+    chat_enabled = is_authenticated
     member_pets = []
     registered_pet_count = 0
     recommended_products = [
@@ -387,10 +389,11 @@ def chat_view(request):
     ]
     if is_authenticated:
         sessions = list(
-            request.user.chat_sessions.order_by("-created_at").values("session_id", "title", "created_at")[:50]
+            request.user.chat_sessions.order_by("-updated_at", "-created_at").values("session_id", "title", "created_at", "updated_at")[:50]
         )
         registered_pet_count = request.user.pets.count()
-        member_pets = [_serialize_pet(pet) for pet in request.user.pets.order_by("created_at")[:5]]
+        pets = request.user.pets.prefetch_related("health_concerns", "allergies", "food_preferences").order_by("created_at")[:5]
+        member_pets = [_serialize_pet(pet) for pet in pets]
 
     future_pet = _serialize_future_pet(request.session.get("future_pet_profile"))
     if future_pet:
@@ -415,6 +418,7 @@ def chat_view(request):
             "sessions": sessions,
             "is_member_view": is_member_view,
             "is_preview_member": is_preview_member,
+            "chat_enabled": chat_enabled,
             "member_pets": member_pets,
             "can_add_pet": is_member_view and registered_pet_count < 5,
             "active_pet_id": active_pet_id,

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -1,0 +1,260 @@
+from unittest.mock import patch
+
+from django.conf import settings
+from django.test import TestCase
+from django.urls import reverse
+
+from pets.models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
+from users.models import User, UserProfile
+
+
+class ChatPageTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="chat-owner@example.com",
+            password="Password123!",
+        )
+        UserProfile.objects.create(user=self.user, nickname="Chat Owner")
+        self.client.force_login(self.user)
+
+    def test_chat_page_renders_related_pet_fields(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Nabi",
+            species="cat",
+            gender="female",
+            budget_range="5_10",
+        )
+        PetHealthConcern.objects.create(pet=pet, concern="skin")
+        PetAllergy.objects.create(pet=pet, ingredient="chicken")
+        PetFoodPreference.objects.create(pet=pet, food_type="dry")
+
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(response.context["member_pets"]), 1)
+        serialized_pet = response.context["member_pets"][0]
+        self.assertEqual(serialized_pet["health_concerns"], ["skin"])
+        self.assertEqual(serialized_pet["allergies"], ["chicken"])
+        self.assertEqual(serialized_pet["food_preferences"], ["dry"])
+
+
+class _FakeStreamResponse:
+    def __init__(self, chunks, status_code=200):
+        self._chunks = chunks
+        self.status_code = status_code
+        self.text = ""
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def iter_bytes(self):
+        for chunk in self._chunks:
+            yield chunk
+
+    def json(self):
+        return {"detail": "error"}
+
+
+class _FakeJsonResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.text = ""
+
+    def json(self):
+        return self._payload
+
+
+class _FakeHttpxClient:
+    last_request = None
+    last_stream_request = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, method, url, headers=None, json=None):
+        self.__class__.last_request = {
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "json": json,
+        }
+        if method == "GET" and url.endswith("/sessions/"):
+            return _FakeJsonResponse(
+                {
+                    "sessions": [
+                        {
+                            "session_id": "11111111-1111-1111-1111-111111111111",
+                            "title": "기존 세션",
+                            "display_date": "26/03/23",
+                        }
+                    ],
+                    "groups": [
+                        {
+                            "key": "today",
+                            "label": "오늘",
+                            "sessions": [
+                                {
+                                    "session_id": "11111111-1111-1111-1111-111111111111",
+                                    "title": "기존 세션",
+                                    "display_date": "26/03/23",
+                                }
+                            ],
+                        }
+                    ],
+                }
+            )
+        if method == "GET" and url.endswith("/messages/"):
+            return _FakeJsonResponse(
+                {
+                    "session_id": "11111111-1111-1111-1111-111111111111",
+                    "messages": [
+                        {
+                            "message_id": "22222222-2222-2222-2222-222222222222",
+                            "role": "user",
+                            "content": "hello",
+                            "created_at": "2026-03-23T10:00:00+09:00",
+                        }
+                    ],
+                    "history_trimmed": False,
+                }
+            )
+        if method == "POST" and url.endswith("/sessions/"):
+            return _FakeJsonResponse(
+                {
+                    "session_id": "33333333-3333-3333-3333-333333333333",
+                    "title": json.get("title"),
+                    "target_pet_id": json.get("target_pet_id"),
+                    "display_date": "26/03/23",
+                },
+                status_code=201,
+            )
+        if method == "PATCH":
+            return _FakeJsonResponse(
+                {
+                    "session_id": "11111111-1111-1111-1111-111111111111",
+                    "title": json.get("title"),
+                    "display_date": "26/03/23",
+                }
+            )
+        if method == "DELETE":
+            return _FakeJsonResponse({"deleted": True})
+        return _FakeJsonResponse({"detail": "ok"})
+
+    def stream(self, method, url, headers=None, json=None):
+        self.__class__.last_stream_request = {
+            "method": method,
+            "url": url,
+            "headers": headers,
+            "json": json,
+        }
+        return _FakeStreamResponse(
+            [
+                b'data: {"type":"token","content":"hello"}\n\n',
+                b'data: {"type":"done"}\n\n',
+            ]
+        )
+
+
+class ChatProxyTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(
+            email="chat-proxy@example.com",
+            password="Password123!",
+        )
+        UserProfile.objects.create(user=self.user, nickname="ChatProxy")
+
+    def test_chat_proxy_requires_authentication(self):
+        response = self.client.post(
+            "/api/chat/",
+            data='{"message":"hello"}',
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 401)
+
+    @patch("chat.api_views.httpx.Client", _FakeHttpxClient)
+    def test_chat_proxy_streams_fastapi_response_with_internal_auth_headers(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            "/api/chat/",
+            data='{"message":"hello","thread_id":"thread-1","pet_profile":{"species":"cat"}}',
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+        payload = b"".join(response.streaming_content).decode("utf-8")
+        self.assertIn('"type":"token"', payload)
+        self.assertEqual(_FakeHttpxClient.last_stream_request["url"], settings.FASTAPI_INTERNAL_CHAT_URL)
+        self.assertEqual(
+            _FakeHttpxClient.last_stream_request["headers"]["X-Internal-Service-Token"],
+            settings.INTERNAL_SERVICE_TOKEN,
+        )
+        self.assertEqual(_FakeHttpxClient.last_stream_request["headers"]["X-User-Id"], str(self.user.id))
+        self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["thread_id"], "thread-1")
+
+    @patch("chat.api_views.httpx.Client", _FakeHttpxClient)
+    def test_sessions_proxy_supports_list_create_update_delete_and_message_load(self):
+        self.client.force_login(self.user)
+
+        list_response = self.client.get("/api/chat/sessions/")
+        self.assertEqual(list_response.status_code, 200)
+        self.assertEqual(list_response.json()["groups"][0]["key"], "today")
+        self.assertEqual(_FakeHttpxClient.last_request["url"], settings.FASTAPI_INTERNAL_CHAT_URL.rstrip("/") + "/sessions/")
+
+        create_response = self.client.post(
+            "/api/chat/sessions/",
+            data='{"title":"신규 세션","target_pet_id":"44444444-4444-4444-4444-444444444444"}',
+            content_type="application/json",
+        )
+        self.assertEqual(create_response.status_code, 201)
+        self.assertEqual(create_response.json()["title"], "신규 세션")
+        self.assertEqual(_FakeHttpxClient.last_request["json"]["target_pet_id"], "44444444-4444-4444-4444-444444444444")
+
+        patch_response = self.client.patch(
+            "/api/chat/sessions/11111111-1111-1111-1111-111111111111/",
+            data='{"title":"수정 제목"}',
+            content_type="application/json",
+        )
+        self.assertEqual(patch_response.status_code, 200)
+        self.assertEqual(patch_response.json()["title"], "수정 제목")
+
+        messages_response = self.client.get("/api/chat/sessions/11111111-1111-1111-1111-111111111111/messages/")
+        self.assertEqual(messages_response.status_code, 200)
+        self.assertEqual(messages_response.json()["messages"][0]["content"], "hello")
+
+        delete_response = self.client.delete("/api/chat/sessions/11111111-1111-1111-1111-111111111111/")
+        self.assertEqual(delete_response.status_code, 200)
+        self.assertTrue(delete_response.json()["deleted"])
+
+    @patch("chat.api_views.httpx.Client", _FakeHttpxClient)
+    def test_session_messages_proxy_streams_to_fastapi(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            "/api/chat/sessions/11111111-1111-1111-1111-111111111111/messages/",
+            data='{"message":"hello","pet_profile":{"species":"cat"}}',
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["Content-Type"], "text/event-stream")
+        payload = b"".join(response.streaming_content).decode("utf-8")
+        self.assertIn('"type":"done"', payload)
+        self.assertEqual(
+            _FakeHttpxClient.last_stream_request["url"],
+            settings.FASTAPI_INTERNAL_CHAT_URL.rstrip("/") + "/sessions/11111111-1111-1111-1111-111111111111/messages/",
+        )
+        self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["message"], "hello")

--- a/services/django/chat/urls.py
+++ b/services/django/chat/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from . import api_views
+
+urlpatterns = [
+    path("", api_views.chat_proxy_view, name="chat-proxy"),
+    path("sessions/", api_views.sessions_proxy_view, name="chat-sessions-proxy"),
+    path("sessions/<uuid:session_id>/", api_views.session_detail_proxy_view, name="chat-session-detail-proxy"),
+    path("sessions/<uuid:session_id>/messages/", api_views.session_messages_proxy_view, name="chat-session-messages-proxy"),
+]

--- a/services/django/config/settings.py
+++ b/services/django/config/settings.py
@@ -184,6 +184,8 @@ STATIC_ROOT = BASE_DIR / "staticfiles"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 APP_BASE_URL = config("APP_BASE_URL", default="")
+FASTAPI_INTERNAL_CHAT_URL = config("FASTAPI_INTERNAL_CHAT_URL", default="http://fastapi:8001/api/chat/")
+INTERNAL_SERVICE_TOKEN = config("INTERNAL_SERVICE_TOKEN", default="dev-internal-token")
 
 AWS_S3_BUCKET_NAME = config("AWS_S3_BUCKET_NAME", default="")
 AWS_S3_REGION_NAME = config("AWS_S3_REGION_NAME", default="")

--- a/services/django/config/urls.py
+++ b/services/django/config/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("api/auth/", include("users.auth_urls")),
 
     # ── API — Resources ───────────────────────────────────────────────────────
+    path("api/chat/", include("chat.urls")),
     path("api/users/", include("users.urls")),
     path("api/pets/", include("pets.urls")),
     path("api/orders/", include("orders.urls")),

--- a/services/django/requirements.txt
+++ b/services/django/requirements.txt
@@ -13,3 +13,4 @@ pandas==2.2.3
 pyarrow==19.0.1
 python-dotenv==1.1.0
 tqdm==4.67.1
+httpx==0.28.1

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -409,7 +409,7 @@
               <div class="text-[32px] font-bold leading-[1.2] text-[#1a202c]">
                 <span class="text-[#3182ce]">Tail</span><span>Talk 와 함께하는 스마트한 집사 생활 </span>
               </div>
-              {% if is_member_view %}
+              {% if chat_enabled %}
               <div class="mt-[24px] flex flex-wrap items-center justify-center gap-[12px]">
                 <button type="button" onclick="fillMessage('가수분해 사료란?')"
                         class="flex h-[36px] items-center justify-center rounded-full border border-[#3182ce] bg-white px-[18px] text-[13px] font-bold text-[#3182ce] shadow-[0_1px_2px_rgba(49,130,206,0.08)]">
@@ -438,7 +438,7 @@
             <div id="composerWrap"
                  class="relative overflow-hidden rounded-full border border-[#e2e8f0] bg-white shadow-[0_8px_20px_rgba(45,55,72,0.06)]"
                  style="height: 61px">
-              {% if is_member_view %}
+              {% if chat_enabled %}
               <div class="absolute bottom-[10.5px] left-[10.5px] h-[40px] w-[40px]">
                 <img alt="" class="absolute inset-0 h-full w-full"
                      src="https://www.figma.com/api/mcp/asset/bf9036d0-fa6a-4951-8bf1-87121fd476c3" />
@@ -751,20 +751,164 @@
   var chatHistoryList = document.getElementById('chatHistoryList');
   var sessionThreadsNode = document.getElementById('sessionThreadsData');
   var sessionThreads = sessionThreadsNode ? JSON.parse(sessionThreadsNode.textContent) : {};
+  var csrfToken = getCookie('csrftoken');
 
   var isOpen = false;
   var pendingDeleteId = null;
   var isPetDropdownOpen = false;
   var activeSessionId = null;
-  var activePetId = '{{ active_pet_id|escapejs }}';
-  var draftSessionCount = 0;
   var promoIndex = 0;
   var promoTimer = null;
+  var activePetId = '{{ active_pet_id|escapejs }}';
   // 선택된 펫 프로필 (FastAPI 요청에 사용)
   var activePetProfile = null;
   var activePetHealthConcerns = [];
   var activePetAllergies = [];
   var activePetFoodPreferences = [];
+
+  function getCookie(name) {
+    var cookieValue = null;
+    if (!document.cookie) return cookieValue;
+    document.cookie.split(';').forEach(function (cookie) {
+      var trimmed = cookie.trim();
+      if (trimmed.startsWith(name + '=')) {
+        cookieValue = decodeURIComponent(trimmed.slice(name.length + 1));
+      }
+    });
+    return cookieValue;
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function ensureSessionState(sessionId) {
+    if (!sessionThreads[sessionId]) {
+      sessionThreads[sessionId] = { messages: [], loaded: false };
+    }
+    if (!Array.isArray(sessionThreads[sessionId].messages)) {
+      sessionThreads[sessionId].messages = [];
+    }
+    if (typeof sessionThreads[sessionId].loaded === 'undefined') {
+      sessionThreads[sessionId].loaded = sessionThreads[sessionId].messages.length > 0;
+    }
+    return sessionThreads[sessionId];
+  }
+
+  function readJsonResponse(res) {
+    return res.text().then(function (text) {
+      if (!text) return {};
+      try {
+        return JSON.parse(text);
+      } catch (e) {
+        return { detail: text };
+      }
+    });
+  }
+
+  function ensureSessionItem(session) {
+    if (!chatHistoryList || !session || !session.session_id) return null;
+
+    var sessionId = session.session_id;
+    var existing = chatHistoryList.querySelector('[data-id="' + CSS.escape(sessionId) + '"]');
+    var emptyStateCard = chatHistoryList.querySelector('.border-dashed');
+    if (emptyStateCard) emptyStateCard.remove();
+
+    if (!existing) {
+      existing = document.createElement('div');
+      existing.className = 'chat-history-item relative h-[40px] w-[250px] cursor-pointer rounded-[8px] transition-colors duration-150 text-left';
+      existing.setAttribute('data-id', sessionId);
+      existing.innerHTML = ''
+        + '<img alt="" class="history-bg absolute inset-0 h-[40px] w-[250px] transition-opacity duration-150" src="https://www.figma.com/api/mcp/asset/6630cc6d-cbd9-471a-8587-bd6e56070487" />'
+        + '<span class="history-title absolute left-[10.5px] right-[66px] top-[11.8px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold leading-none text-[#2d3748]"></span>'
+        + '<div class="absolute right-[10px] top-[11px] h-[18px] w-[62px]">'
+        + '  <span class="history-date absolute right-0 top-[1px] w-full whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]"></span>'
+        + '  <div class="history-actions absolute right-0 top-0 hidden flex items-center justify-end gap-[7px]">'
+        + '    <button type="button" class="flex h-[18px] w-[18px] items-center justify-center text-[12px]" aria-label="수정">✏️</button>'
+        + '    <button type="button" class="flex h-[18px] w-[18px] items-center justify-center text-[12px]" aria-label="삭제">🗑️</button>'
+        + '  </div>'
+        + '</div>';
+      chatHistoryList.insertBefore(existing, chatHistoryList.firstChild);
+
+      var actions = existing.querySelector('.history-actions');
+      if (actions) {
+        var editBtn = actions.querySelector('button[aria-label="수정"]');
+        var deleteBtn = actions.querySelector('button[aria-label="삭제"]');
+        if (editBtn) {
+          editBtn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            editHistory(editBtn);
+          });
+        }
+        if (deleteBtn) {
+          deleteBtn.addEventListener('click', function (e) {
+            e.stopPropagation();
+            openDeleteModal(sessionId);
+          });
+        }
+      }
+      bindHistoryItemInteractions(existing);
+    } else {
+      chatHistoryList.insertBefore(existing, chatHistoryList.firstChild);
+    }
+
+    var titleNode = existing.querySelector('.history-title');
+    var dateNode = existing.querySelector('.history-date');
+    if (titleNode) titleNode.textContent = session.title || '새 대화';
+    if (dateNode) dateNode.textContent = session.display_date || '오늘';
+
+    ensureSessionState(sessionId);
+    return existing;
+  }
+
+  function createSessionForMessage(message) {
+    var derivedTitle = message.length > 18 ? message.slice(0, 18) + '...' : message;
+    return fetch('/api/chat/sessions/', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': csrfToken || '',
+      },
+      body: JSON.stringify({
+        title: derivedTitle,
+        target_pet_id: activePetId || null,
+      }),
+    }).then(function (res) {
+      return readJsonResponse(res).then(function (data) {
+        if (!res.ok) {
+          throw new Error((data && data.detail) || '세션 생성에 실패했습니다.');
+        }
+        ensureSessionItem(data);
+        activeSessionId = data.session_id;
+        return data;
+      });
+    });
+  }
+
+  function loadSessionMessages(sessionId) {
+    var session = ensureSessionState(sessionId);
+    if (session.loaded) {
+      return Promise.resolve(session.messages);
+    }
+
+    return fetch('/api/chat/sessions/' + sessionId + '/messages/').then(function (res) {
+      return readJsonResponse(res).then(function (data) {
+        if (!res.ok) {
+          throw new Error((data && data.detail) || '대화 기록을 불러오지 못했습니다.');
+        }
+        session.messages = (data.messages || []).map(function (message) {
+          return { role: message.role, text: message.content };
+        });
+        session.loaded = true;
+        return session.messages;
+      });
+    });
+  }
 
   function applyLayout() {
     if (!sidebar || !workspaceShell || !sidebarOpen || !sidebarColl || !overlay) return;
@@ -877,6 +1021,7 @@
     activePetHealthConcerns = hc ? hc.split(',').filter(Boolean) : [];
     activePetAllergies = al ? al.split(',').filter(Boolean) : [];
     activePetFoodPreferences = fp ? fp.split(',').filter(Boolean) : [];
+    activePetId = nextId;
 
     petDropdownName.textContent = nextName;
     petDropdownSummary.textContent = nextSummary;
@@ -995,7 +1140,7 @@
   function renderSessionThread(sessionId) {
     if (!chatMessages || !chatThread || !chatEmptyState) return;
 
-    var session = sessionThreads[sessionId];
+    var session = ensureSessionState(sessionId);
     chatMessages.innerHTML = '';
     chatEmptyState.classList.remove('is-fading-in');
     chatEmptyState.classList.add('hidden');
@@ -1016,65 +1161,16 @@
 
   function activateSession(sessionId) {
     activeSessionId = sessionId;
-    renderSessionThread(sessionId);
     updateSessionItemStyles();
     openProductPanel();
     switchProductTab('recommended');
-  }
-
-  function createDraftSession(title) {
-    if (!chatHistoryList) return null;
-
-    draftSessionCount += 1;
-    var sessionId = 'draft-session-' + Date.now() + '-' + draftSessionCount;
-    var item = document.createElement('div');
-    item.className = 'chat-history-item relative h-[40px] w-[250px] cursor-pointer rounded-[8px] transition-colors duration-150 text-left';
-    item.setAttribute('data-id', sessionId);
-    item.onclick = function () {
-      activateSession(sessionId);
-    };
-    item.innerHTML = ''
-      + '<img alt="" class="history-bg absolute inset-0 h-[40px] w-[250px] transition-opacity duration-150" src="https://www.figma.com/api/mcp/asset/6630cc6d-cbd9-471a-8587-bd6e56070487" />'
-      + '<span class="history-title absolute left-[10.5px] right-[66px] top-[11.8px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold leading-none text-[#2d3748]">' + title + '</span>'
-      + '<div class="absolute right-[10px] top-[11px] h-[18px] w-[62px]">'
-      + '  <span class="history-date absolute right-0 top-[1px] w-full whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]">오늘</span>'
-      + '  <div class="history-actions absolute right-0 top-0 hidden flex items-center justify-end gap-[7px]"></div>'
-      + '</div>';
-
-    var actions = item.querySelector('.history-actions');
-    if (actions) {
-      var editBtn = document.createElement('button');
-      editBtn.type = 'button';
-      editBtn.className = 'flex h-[18px] w-[18px] items-center justify-center text-[12px]';
-      editBtn.setAttribute('aria-label', '수정');
-      editBtn.textContent = '✏️';
-      editBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        editHistory(editBtn);
-      });
-
-      var deleteBtn = document.createElement('button');
-      deleteBtn.type = 'button';
-      deleteBtn.className = 'flex h-[18px] w-[18px] items-center justify-center text-[12px]';
-      deleteBtn.setAttribute('aria-label', '삭제');
-      deleteBtn.textContent = '🗑️';
-      deleteBtn.addEventListener('click', function (e) {
-        e.stopPropagation();
-        openDeleteModal(sessionId);
-      });
-
-      actions.appendChild(editBtn);
-      actions.appendChild(deleteBtn);
-    }
-
-    var emptyStateCard = chatHistoryList.querySelector('.border-dashed');
-    if (emptyStateCard) {
-      emptyStateCard.remove();
-    }
-    chatHistoryList.insertBefore(item, chatHistoryList.firstChild);
-    bindHistoryItemInteractions(item);
-    sessionThreads[sessionId] = { messages: [] };
-    return sessionId;
+    loadSessionMessages(sessionId).then(function () {
+      if (activeSessionId === sessionId) {
+        renderSessionThread(sessionId);
+      }
+    }).catch(function (error) {
+      window.alert(error.message || '대화 기록을 불러오지 못했습니다.');
+    });
   }
 
   function openProductPanel() {
@@ -1162,89 +1258,108 @@
     var msg = messageInput.value.trim();
     if (!msg) return;
 
-    if (!activeSessionId) {
-      var derivedTitle = msg.length > 18 ? msg.slice(0, 18) + '...' : msg;
-      activeSessionId = createDraftSession(derivedTitle) || activeSessionId;
-    }
+    var ensureSessionPromise = activeSessionId
+      ? Promise.resolve({ session_id: activeSessionId })
+      : createSessionForMessage(msg);
 
-    if (!sessionThreads[activeSessionId]) {
-      sessionThreads[activeSessionId] = { messages: [] };
-    }
+    ensureSessionPromise.then(function (sessionData) {
+      var sessionId = sessionData.session_id;
+      activeSessionId = sessionId;
+      var sessionState = ensureSessionState(sessionId);
 
-    if (chatEmptyState) chatEmptyState.classList.add('hidden');
-    if (chatThread) chatThread.classList.remove('hidden');
+      if (chatEmptyState) chatEmptyState.classList.add('hidden');
+      if (chatThread) chatThread.classList.remove('hidden');
 
-    appendMessage('user', msg);
-    sessionThreads[activeSessionId].messages.push({ role: 'user', text: msg });
+      appendMessage('user', msg);
+      sessionState.messages.push({ role: 'user', text: msg });
+      sessionState.loaded = true;
 
-    updateChatSectionState(true);
-    updateSessionItemStyles();
+      updateChatSectionState(true);
+      updateSessionItemStyles();
 
-    messageInput.value = '';
-    updateComposerState(messageInput);
-    scrollToBottom();
+      messageInput.value = '';
+      updateComposerState(messageInput);
+      scrollToBottom();
 
-    // FastAPI SSE 스트리밍 호출
-    var assistantEl = appendMessage('assistant', '');
-    var assistantText = '';
+      var assistantEl = appendMessage('assistant', '');
+      var assistantText = '';
 
-    fetch('/api/chat/', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        message: msg,
-        thread_id: activeSessionId || 'default',
-        pet_profile: activePetProfile,
-        health_concerns: activePetHealthConcerns,
-        allergies: activePetAllergies,
-        food_preferences: activePetFoodPreferences,
-      }),
-    }).then(function (res) {
-      var reader = res.body.getReader();
-      var decoder = new TextDecoder();
-      var buf = '';
-
-      function read() {
-        reader.read().then(function (result) {
-          if (result.done) return;
-          buf += decoder.decode(result.value, { stream: true });
-          var lines = buf.split('\n\n');
-          buf = lines.pop();
-          lines.forEach(function (line) {
-            if (!line.startsWith('data: ')) return;
-            try {
-              var evt = JSON.parse(line.slice(6));
-              if (evt.type === 'token') {
-                assistantText += evt.content;
-                if (assistantEl) {
-                  var p = assistantEl.querySelector('.assistant-text');
-                  if (p) p.textContent = assistantText;
-                }
-                scrollToBottom();
-              } else if (evt.type === 'products' && evt.cards && evt.cards.length) {
-                openProductPanel();
-                switchProductTab('recommended');
-                renderProductCards(evt.cards);
-              } else if (evt.type === 'done') {
-                sessionThreads[activeSessionId].messages.push({ role: 'assistant', text: assistantText });
-              } else if (evt.type === 'error') {
-                assistantText = '죄송합니다, 오류가 발생했습니다.';
-                if (assistantEl) {
-                  var p = assistantEl.querySelector('.assistant-text');
-                  if (p) p.textContent = assistantText;
-                }
-              }
-            } catch(e) {}
+      fetch('/api/chat/sessions/' + sessionId + '/messages/', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken || '',
+        },
+        body: JSON.stringify({
+          message: msg,
+          pet_profile: activePetProfile,
+          health_concerns: activePetHealthConcerns,
+          allergies: activePetAllergies,
+          food_preferences: activePetFoodPreferences,
+        }),
+      }).then(function (res) {
+        if (!res.ok) {
+          return readJsonResponse(res).then(function (data) {
+            var message = (data && data.detail) || '죄송합니다, 오류가 발생했습니다.';
+            if (assistantEl) {
+              var errorText = assistantEl.querySelector('.assistant-text');
+              if (errorText) errorText.textContent = message;
+            }
           });
-          read();
-        });
-      }
-      read();
-    }).catch(function () {
-      if (assistantEl) {
-        var p = assistantEl.querySelector('.assistant-text');
-        if (p) p.textContent = '서버 연결에 실패했습니다.';
-      }
+        }
+
+        if (!res.body) {
+          throw new Error('Empty response body');
+        }
+
+        var reader = res.body.getReader();
+        var decoder = new TextDecoder();
+        var buf = '';
+
+        function read() {
+          reader.read().then(function (result) {
+            if (result.done) return;
+            buf += decoder.decode(result.value, { stream: true });
+            var lines = buf.split('\n\n');
+            buf = lines.pop();
+            lines.forEach(function (line) {
+              if (!line.startsWith('data: ')) return;
+              try {
+                var evt = JSON.parse(line.slice(6));
+                if (evt.type === 'token') {
+                  assistantText += evt.content;
+                  if (assistantEl) {
+                    var p = assistantEl.querySelector('.assistant-text');
+                    if (p) p.textContent = assistantText;
+                  }
+                  scrollToBottom();
+                } else if (evt.type === 'products' && evt.cards && evt.cards.length) {
+                  openProductPanel();
+                  switchProductTab('recommended');
+                  renderProductCards(evt.cards);
+                } else if (evt.type === 'done') {
+                  ensureSessionState(sessionId).messages.push({ role: 'assistant', text: assistantText });
+                } else if (evt.type === 'error') {
+                  assistantText = evt.message || '죄송합니다, 오류가 발생했습니다.';
+                  if (assistantEl) {
+                    var errorNode = assistantEl.querySelector('.assistant-text');
+                    if (errorNode) errorNode.textContent = assistantText;
+                  }
+                }
+              } catch(e) {}
+            });
+            read();
+          });
+        }
+        read();
+      }).catch(function () {
+        if (assistantEl) {
+          var p = assistantEl.querySelector('.assistant-text');
+          if (p) p.textContent = '서버 연결에 실패했습니다.';
+        }
+      });
+    }).catch(function (error) {
+      window.alert(error.message || '세션 생성에 실패했습니다.');
     });
   };
 
@@ -1467,12 +1582,22 @@
       {% endif %}
       fetch('/api/chat/sessions/' + pendingDeleteId + '/', {
         method: 'DELETE',
-        headers: { 'X-CSRFToken': '{{ csrf_token }}' },
-      }).then(function () {
-        var target = document.querySelector('[data-id="' + pendingDeleteId + '"]');
-        if (target) target.remove();
-        deleteModal.classList.remove('is-open');
-        pendingDeleteId = null;
+        headers: { 'X-CSRFToken': csrfToken || '' },
+      }).then(function (res) {
+        return readJsonResponse(res).then(function (data) {
+          if (!res.ok) {
+            throw new Error((data && data.detail) || '대화 기록 삭제에 실패했습니다.');
+          }
+          var deletedId = pendingDeleteId;
+          var target = document.querySelector('[data-id="' + deletedId + '"]');
+          if (target) target.remove();
+          delete sessionThreads[deletedId];
+          if (activeSessionId === deletedId) {
+            resetChatState(false);
+          }
+          deleteModal.classList.remove('is-open');
+          pendingDeleteId = null;
+        });
       }).catch(function () {
         window.alert('대화 기록 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
       });
@@ -1531,6 +1656,29 @@
       span.className = 'history-title absolute left-[10.5px] right-[66px] top-[11.8px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold leading-none text-[#2d3748]';
       span.textContent = newTitle;
       input.replaceWith(span);
+
+      {% if not is_preview_member %}
+      if (newTitle !== current) {
+        fetch('/api/chat/sessions/' + item.getAttribute('data-id') + '/', {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-CSRFToken': csrfToken || '',
+          },
+          body: JSON.stringify({ title: newTitle }),
+        }).then(function (res) {
+          return readJsonResponse(res).then(function (data) {
+            if (!res.ok) {
+              span.textContent = current;
+              throw new Error((data && data.detail) || '제목 수정에 실패했습니다.');
+            }
+            if (data && data.title) span.textContent = data.title;
+          });
+        }).catch(function () {
+          window.alert('제목 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        });
+      }
+      {% endif %}
     }
 
     input.addEventListener('blur', done);
@@ -1554,6 +1702,7 @@
 
   renderPromoSlide();
   updateCartTotal();
+  Object.keys(sessionThreads).forEach(ensureSessionState);
 
   if (promoCarouselGroup) {
     promoCarouselGroup.addEventListener('mouseenter', stopPromoAutoSlide);
@@ -1564,6 +1713,10 @@
   switchProductTab('recommended');
   hideProductPanel();
   applyLayout();
+  if (activePetId) {
+    var initialPet = document.querySelector('[data-pet-id="' + CSS.escape(activePetId) + '"]');
+    if (initialPet) selectPet(initialPet);
+  }
   closePetDropdown();
   updateChatSectionState(false);
   updateSessionItemStyles();

--- a/services/fastapi/core/db.py
+++ b/services/fastapi/core/db.py
@@ -1,0 +1,17 @@
+import os
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import declarative_base, sessionmaker
+
+
+DATABASE_URL = (
+    f"postgresql+psycopg2://{os.getenv('POSTGRES_USER', 'postgres')}:"
+    f"{os.getenv('POSTGRES_PASSWORD', 'postgres')}@"
+    f"{os.getenv('POSTGRES_HOST', 'localhost')}:"
+    f"{os.getenv('POSTGRES_PORT', '5432')}/"
+    f"{os.getenv('POSTGRES_DB', 'postgres')}"
+)
+
+engine = create_engine(DATABASE_URL, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base = declarative_base()

--- a/services/fastapi/core/models.py
+++ b/services/fastapi/core/models.py
@@ -1,0 +1,42 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from core.db import Base
+
+
+class UserModel(Base):
+    __tablename__ = "user"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+
+
+class ChatSessionModel(Base):
+    __tablename__ = "chat_session"
+
+    session_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("user.id"), nullable=False)
+    target_pet_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("pet.pet_id"), nullable=True)
+    title: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class ChatMessageModel(Base):
+    __tablename__ = "chat_message"
+
+    message_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    session_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("chat_session.session_id"), nullable=False)
+    role: Mapped[str] = mapped_column(String(10), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False)
+
+
+class PetModel(Base):
+    __tablename__ = "pet"
+
+    pet_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True)
+    user_id: Mapped[int] = mapped_column(Integer, ForeignKey("user.id"), nullable=False)

--- a/services/fastapi/pipeline/nodes/domain_qa.py
+++ b/services/fastapi/pipeline/nodes/domain_qa.py
@@ -4,15 +4,17 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue
-from pipeline.utils import llm, LLM_MODEL, qdrant, hybrid_search, build_pet_context, DOMAIN_INTENT_TO_CATEGORY
+from pipeline.utils import llm, LLM_MODEL, qdrant, hybrid_search, build_pet_context, build_history_context, DOMAIN_INTENT_TO_CATEGORY
 from pipeline.state import ChatState
 
 
 def general_node(state: ChatState) -> dict:
     """쿼리 정제: 모호한 질문을 펫 프로필 기반으로 검색 최적화"""
     pet_ctx = build_pet_context(state)
+    history_ctx = build_history_context(state)
     prompt  = (
         f"다음 질문을 반려동물 정보를 반영해 검색에 최적화된 한 문장으로 재작성하세요.\n"
+        f"이전 대화 맥락: {history_ctx or '없음'}\n"
         f"펫 정보: {pet_ctx}\n질문: {state['user_input']}"
     )
     refined = llm.chat.completions.create(

--- a/services/fastapi/pipeline/nodes/intent.py
+++ b/services/fastapi/pipeline/nodes/intent.py
@@ -4,7 +4,7 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
-from pipeline.utils import llm, LLM_MODEL
+from pipeline.utils import llm, LLM_MODEL, build_history_context
 from pipeline.state import ChatState
 
 CATEGORY_FILE = Path(__file__).resolve().parents[1] / "data" / "category.json"
@@ -37,17 +37,20 @@ health_disease / care_management / nutrition_diet / behavior_psychology / travel
 
 def intent_node(state: ChatState) -> dict:
     user_input = state["user_input"]
+    history_ctx = build_history_context(state)
 
     context = ""
     if state.get("clarification_count", 0) > 0 and state.get("intents"):
         prev = {k: state.get(k) for k in ["intents", "filters"]}
         context = f"\n이전 추출 정보: {json.dumps(prev, ensure_ascii=False)}"
 
+    history_block = f"\n이전 대화 맥락:\n{history_ctx}\n" if history_ctx else "\n"
+
     res = llm.chat.completions.create(
         model=LLM_MODEL,
         messages=[
             {"role": "system", "content": INTENT_SYSTEM + context},
-            {"role": "user",   "content": user_input},
+            {"role": "user",   "content": history_block + f"현재 사용자 입력:\n{user_input}"},
         ],
         response_format={"type": "json_object"},
         temperature=0,

--- a/services/fastapi/pipeline/nodes/recommend.py
+++ b/services/fastapi/pipeline/nodes/recommend.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from qdrant_client.models import FieldCondition, Filter, MatchAny, MatchValue, Range
-from pipeline.utils import llm, LLM_MODEL, qdrant, hybrid_search, build_pet_context
+from pipeline.utils import llm, LLM_MODEL, qdrant, hybrid_search, build_pet_context, build_history_context
 from pipeline.state import ChatState
 
 
@@ -44,6 +44,7 @@ def profile_node(state: ChatState) -> dict:
 def query_node(state: ChatState) -> dict:
     """검색 쿼리 생성 + Qdrant 필터 빌드"""
     pet_ctx        = build_pet_context(state)
+    history_ctx    = build_history_context(state)
     filters        = state.get("filters") or {}
     health_concerns = state.get("health_concerns") or []
     relaxation     = state.get("filter_relaxation_count", 0)
@@ -54,6 +55,7 @@ def query_node(state: ChatState) -> dict:
 
     prompt = (
         f"반려동물 상품 검색을 위한 최적화된 한국어 검색어를 한 문장으로만 반환하세요.\n"
+        f"이전 대화 맥락: {history_ctx or '없음'}\n"
         f"펫 정보: {pet_ctx}\n"
         f"카테고리: {category_hint} / 세부: {subcategory_hint}\n"
         f"원래 질문: {state['user_input']}"

--- a/services/fastapi/pipeline/nodes/respond.py
+++ b/services/fastapi/pipeline/nodes/respond.py
@@ -4,7 +4,7 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from langchain_core.messages import AIMessage
-from pipeline.utils import llm, LLM_MODEL, build_pet_context
+from pipeline.utils import llm, LLM_MODEL, build_pet_context, build_history_context
 from pipeline.state import ChatState
 
 RESPOND_SYSTEM = """\
@@ -25,6 +25,7 @@ def respond_node(state: ChatState) -> dict:
     domain_contexts  = state.get("domain_contexts")  or []
     reranked_results = state.get("reranked_results") or []
     pet_ctx          = build_pet_context(state)
+    history_ctx      = build_history_context(state)
     user_input       = state["user_input"]
     clarification_count = state.get("clarification_count", 0)
 
@@ -46,6 +47,7 @@ def respond_node(state: ChatState) -> dict:
     context_block = "\n\n".join(context_parts) if context_parts else "검색된 정보가 없습니다."
 
     user_msg = (
+        f"이전 대화 맥락: {history_ctx or '없음'}\n\n"
         f"펫 정보: {pet_ctx}\n\n"
         f"사용자 질문: {user_input}\n\n"
         f"{context_block}"

--- a/services/fastapi/pipeline/state.py
+++ b/services/fastapi/pipeline/state.py
@@ -7,6 +7,7 @@ class ChatState(TypedDict):
     # 대화
     messages:   Annotated[list, add_messages]  # HumanMessage / AIMessage
     user_input: str                            # 현재 턴 원문
+    conversation_history: str                  # 축약된 이전 대화 히스토리
 
     # 사용자 / 펫 (API 요청 페이로드에서 주입, DB 조회 없음)
     user_id:          str | None

--- a/services/fastapi/pipeline/utils.py
+++ b/services/fastapi/pipeline/utils.py
@@ -79,3 +79,7 @@ def build_pet_context(state: ChatState) -> str:
     if state.get("allergies"):
         parts.append(f"알레르기: {', '.join(state['allergies'])}")
     return " / ".join(parts) if parts else "펫 프로필 없음"
+
+
+def build_history_context(state: ChatState) -> str:
+    return (state.get("conversation_history") or "").strip()

--- a/services/fastapi/routers/chat.py
+++ b/services/fastapi/routers/chat.py
@@ -1,17 +1,32 @@
-import json
 import asyncio
+import hmac
+import json
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
 from typing import Optional
+from zoneinfo import ZoneInfo
 
-from fastapi import APIRouter
+from fastapi import APIRouter, Header, HTTPException, status
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
+from sqlalchemy import select
 
+from core.db import SessionLocal
+from core.models import ChatMessageModel, ChatSessionModel, PetModel
 from pipeline.chatbot_graph import build_graph
 
 router = APIRouter()
 
+SEOUL_TZ = ZoneInfo("Asia/Seoul")
+MAX_HISTORY_CHARS = int(os.getenv("CHAT_HISTORY_MAX_CHARS", "4000"))
+RECENT_HISTORY_CHARS = int(os.getenv("CHAT_HISTORY_RECENT_CHARS", "1800"))
+SUMMARY_PREVIEW_CHARS = int(os.getenv("CHAT_HISTORY_SUMMARY_CHARS", "700"))
+DEFAULT_SESSION_TITLE = "새 대화"
+
 # 앱 기동 시 한 번만 빌드 (MemorySaver 포함)
 _graph = None
+_internal_service_token = os.getenv("INTERNAL_SERVICE_TOKEN", "dev-internal-token")
 
 
 def get_graph():
@@ -24,27 +39,205 @@ def get_graph():
 class ChatRequest(BaseModel):
     message: str
     thread_id: str = "default"
-    pet_profile: Optional[dict] = None       # {species, breed, age, gender, weight}
-    health_concerns: list[str] = []
-    allergies: list[str] = []
-    food_preferences: list[str] = []
+    pet_profile: Optional[dict] = None
+    health_concerns: list[str] = Field(default_factory=list)
+    allergies: list[str] = Field(default_factory=list)
+    food_preferences: list[str] = Field(default_factory=list)
+
+
+class SessionCreateRequest(BaseModel):
+    title: str | None = None
+    target_pet_id: str | None = None
+
+
+class SessionUpdateRequest(BaseModel):
+    title: str
+
+
+class SessionMessageRequest(BaseModel):
+    message: str
+    pet_profile: Optional[dict] = None
+    health_concerns: list[str] = Field(default_factory=list)
+    allergies: list[str] = Field(default_factory=list)
+    food_preferences: list[str] = Field(default_factory=list)
 
 
 def _sse(event_type: str, data: dict) -> str:
     return f"data: {json.dumps({'type': event_type, **data}, ensure_ascii=False)}\n\n"
 
 
-async def _stream(req: ChatRequest):
-    graph = get_graph()
+def _verify_internal_request(service_token: str | None, user_id: str | None) -> int:
+    if not service_token or not hmac.compare_digest(service_token, _internal_service_token):
+        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+    if not user_id:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="X-User-Id header is required.")
+    try:
+        return int(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="X-User-Id must be an integer.") from exc
 
-    initial_state = {
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _as_seoul(dt: datetime) -> datetime:
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(SEOUL_TZ)
+
+
+def _session_title_from_message(message: str) -> str:
+    compact = " ".join((message or "").split()).strip()
+    if not compact:
+        return DEFAULT_SESSION_TITLE
+    return compact if len(compact) <= 24 else compact[:23].rstrip() + "…"
+
+
+def _trim_text(text: str, limit: int) -> str:
+    compact = " ".join((text or "").split()).strip()
+    if len(compact) <= limit:
+        return compact
+    return compact[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _serialize_session(session: ChatSessionModel) -> dict:
+    created_at = _as_seoul(session.created_at)
+    updated_at = _as_seoul(session.updated_at)
+    return {
+        "session_id": str(session.session_id),
+        "title": session.title,
+        "target_pet_id": str(session.target_pet_id) if session.target_pet_id else None,
+        "created_at": created_at.isoformat(),
+        "updated_at": updated_at.isoformat(),
+        "display_date": created_at.strftime("%y/%m/%d"),
+    }
+
+
+def _serialize_message(message: ChatMessageModel) -> dict:
+    created_at = _as_seoul(message.created_at)
+    return {
+        "message_id": str(message.message_id),
+        "role": message.role,
+        "content": message.content,
+        "created_at": created_at.isoformat(),
+    }
+
+
+def _group_key(reference: datetime, compared: datetime) -> str:
+    ref_date = _as_seoul(reference).date()
+    compared_date = _as_seoul(compared).date()
+    if compared_date == ref_date:
+        return "today"
+    if compared_date == ref_date - timedelta(days=1):
+        return "yesterday"
+    if compared_date >= ref_date - timedelta(days=7):
+        return "last_7_days"
+    return "older"
+
+
+def _build_grouped_sessions(sessions: list[ChatSessionModel]) -> dict:
+    now = _now()
+    grouped = {
+        "today": {"key": "today", "label": "오늘", "sessions": []},
+        "yesterday": {"key": "yesterday", "label": "어제", "sessions": []},
+        "last_7_days": {"key": "last_7_days", "label": "7일 이내", "sessions": []},
+        "older": {"key": "older", "label": "이전", "sessions": []},
+    }
+    serialized = []
+
+    for session in sessions:
+        payload = _serialize_session(session)
+        serialized.append(payload)
+        grouped[_group_key(now, session.updated_at)]["sessions"].append(payload)
+
+    return {
+        "sessions": serialized,
+        "groups": [group for group in grouped.values() if group["sessions"]],
+    }
+
+
+def _build_history_context(messages: list[ChatMessageModel]) -> tuple[str, bool]:
+    if not messages:
+        return "", False
+
+    rendered = [
+        f"{'사용자' if message.role == 'user' else 'AI'}: {_trim_text(message.content, 280)}"
+        for message in messages
+        if (message.content or "").strip()
+    ]
+    if not rendered:
+        return "", False
+
+    full_text = "\n".join(rendered)
+    if len(full_text) <= MAX_HISTORY_CHARS:
+        return full_text, False
+
+    recent_lines = []
+    recent_chars = 0
+    for line in reversed(rendered):
+        extra = len(line) + 1
+        if recent_lines and recent_chars + extra > RECENT_HISTORY_CHARS:
+            break
+        recent_lines.append(line)
+        recent_chars += extra
+    recent_lines.reverse()
+
+    older_lines = rendered[: len(rendered) - len(recent_lines)]
+    summary = " / ".join(_trim_text(line, 100) for line in older_lines[-6:])
+    summary = _trim_text(summary, SUMMARY_PREVIEW_CHARS)
+
+    parts = []
+    if summary:
+        parts.append("[이전 대화 요약]")
+        parts.append(summary)
+    if recent_lines:
+        parts.append("[최근 대화]")
+        parts.extend(recent_lines)
+    return "\n".join(parts), True
+
+
+def _get_session_or_404(db, user_id: int, session_id: uuid.UUID) -> ChatSessionModel:
+    session = db.execute(
+        select(ChatSessionModel).where(
+            ChatSessionModel.session_id == session_id,
+            ChatSessionModel.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+    if not session:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="세션을 찾을 수 없습니다.")
+    return session
+
+
+def _validate_target_pet(db, user_id: int, target_pet_id: str | None) -> uuid.UUID | None:
+    if not target_pet_id:
+        return None
+    try:
+        pet_uuid = uuid.UUID(target_pet_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="target_pet_id 형식이 올바르지 않습니다.") from exc
+
+    pet = db.execute(
+        select(PetModel).where(
+            PetModel.pet_id == pet_uuid,
+            PetModel.user_id == user_id,
+        )
+    ).scalar_one_or_none()
+    if not pet:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="반려동물을 찾을 수 없습니다.")
+    return pet_uuid
+
+
+def _build_initial_state(req: ChatRequest | SessionMessageRequest, user_id: int, history_context: str = "") -> dict:
+    return {
         "messages": [],
         "user_input": req.message,
-        "user_id": None,
+        "user_id": str(user_id),
         "pet_profile": req.pet_profile,
         "health_concerns": req.health_concerns,
         "allergies": req.allergies,
         "food_preferences": req.food_preferences,
+        "conversation_history": history_context,
         "intents": [],
         "domain_intent": None,
         "clarification_count": 0,
@@ -60,40 +253,237 @@ async def _stream(req: ChatRequest):
         "product_cards": [],
     }
 
-    config = {"configurable": {"thread_id": req.thread_id}}
 
-    # 그래프 실행 (동기 함수를 스레드풀에서 실행)
+async def _run_graph(req: ChatRequest | SessionMessageRequest, thread_id: str, user_id: int, history_context: str = ""):
+    graph = get_graph()
+    initial_state = _build_initial_state(req, user_id=user_id, history_context=history_context)
+    config = {"configurable": {"thread_id": thread_id}}
+
     loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None,
+        lambda: graph.invoke(initial_state, config=config),
+    )
+
+
+async def _legacy_stream(req: ChatRequest, user_id: int):
     try:
-        final_state = await loop.run_in_executor(
-            None,
-            lambda: graph.invoke(initial_state, config=config),
-        )
-    except Exception as e:
-        yield _sse("error", {"message": str(e)})
+        final_state = await _run_graph(req, thread_id=req.thread_id, user_id=user_id)
+    except Exception as exc:
+        yield _sse("error", {"message": str(exc)})
         return
 
     response_text = final_state.get("response", "")
     product_cards = final_state.get("product_cards", [])
 
-    # 응답 텍스트를 단어 단위로 스트리밍
     words = response_text.split(" ")
-    for i, word in enumerate(words):
-        chunk = word if i == 0 else " " + word
+    for index, word in enumerate(words):
+        chunk = word if index == 0 else " " + word
         yield _sse("token", {"content": chunk})
         await asyncio.sleep(0.03)
 
-    # 상품 카드 전송
     if product_cards:
         yield _sse("products", {"cards": product_cards})
 
     yield _sse("done", {})
 
 
-@router.post("/")
-async def chat(req: ChatRequest):
+async def _session_message_stream(
+    session_id: uuid.UUID,
+    req: SessionMessageRequest,
+    user_id: int,
+    history_context: str,
+):
+    try:
+        final_state = await _run_graph(req, thread_id=str(session_id), user_id=user_id, history_context=history_context)
+    except Exception as exc:
+        yield _sse("error", {"message": str(exc)})
+        return
+
+    response_text = final_state.get("response", "")
+    product_cards = final_state.get("product_cards", [])
+
+    with SessionLocal() as db:
+        session = _get_session_or_404(db, user_id, session_id)
+        session.updated_at = _now()
+        db.add(
+            ChatMessageModel(
+                message_id=uuid.uuid4(),
+                session_id=session_id,
+                role="assistant",
+                content=response_text,
+                created_at=_now(),
+            )
+        )
+        db.add(session)
+        db.commit()
+
+    words = response_text.split(" ")
+    for index, word in enumerate(words):
+        chunk = word if index == 0 else " " + word
+        yield _sse("token", {"content": chunk})
+        await asyncio.sleep(0.03)
+
+    if product_cards:
+        yield _sse("products", {"cards": product_cards})
+
+    yield _sse("done", {})
+
+
+@router.get("/sessions/")
+def list_sessions(
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    with SessionLocal() as db:
+        sessions = db.execute(
+            select(ChatSessionModel)
+            .where(ChatSessionModel.user_id == user_id)
+            .order_by(ChatSessionModel.updated_at.desc(), ChatSessionModel.created_at.desc())
+            .limit(50)
+        ).scalars().all()
+    return _build_grouped_sessions(sessions)
+
+
+@router.post("/sessions/", status_code=status.HTTP_201_CREATED)
+def create_session(
+    req: SessionCreateRequest,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    with SessionLocal() as db:
+        pet_id = _validate_target_pet(db, user_id, req.target_pet_id)
+        now = _now()
+        session = ChatSessionModel(
+            session_id=uuid.uuid4(),
+            user_id=user_id,
+            target_pet_id=pet_id,
+            title=(req.title or "").strip() or DEFAULT_SESSION_TITLE,
+            created_at=now,
+            updated_at=now,
+        )
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+        return _serialize_session(session)
+
+
+@router.patch("/sessions/{session_id}/")
+def update_session(
+    session_id: uuid.UUID,
+    req: SessionUpdateRequest,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    title = (req.title or "").strip()
+    if not title:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="title is required.")
+
+    with SessionLocal() as db:
+        session = _get_session_or_404(db, user_id, session_id)
+        session.title = title
+        session.updated_at = _now()
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+        return _serialize_session(session)
+
+
+@router.delete("/sessions/{session_id}/")
+def delete_session(
+    session_id: uuid.UUID,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    with SessionLocal() as db:
+        session = _get_session_or_404(db, user_id, session_id)
+        db.delete(session)
+        db.commit()
+    return {"deleted": True, "session_id": str(session_id)}
+
+
+@router.get("/sessions/{session_id}/messages/")
+def list_messages(
+    session_id: uuid.UUID,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    with SessionLocal() as db:
+        _get_session_or_404(db, user_id, session_id)
+        messages = db.execute(
+            select(ChatMessageModel)
+            .where(ChatMessageModel.session_id == session_id)
+            .order_by(ChatMessageModel.created_at.asc())
+        ).scalars().all()
+        _, trimmed = _build_history_context(messages)
+    return {
+        "session_id": str(session_id),
+        "messages": [_serialize_message(message) for message in messages],
+        "history_trimmed": trimmed,
+    }
+
+
+@router.post("/sessions/{session_id}/messages/")
+async def post_message(
+    session_id: uuid.UUID,
+    req: SessionMessageRequest,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    message = (req.message or "").strip()
+    if not message:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="message is required.")
+
+    with SessionLocal() as db:
+        session = _get_session_or_404(db, user_id, session_id)
+        existing_messages = db.execute(
+            select(ChatMessageModel)
+            .where(ChatMessageModel.session_id == session_id)
+            .order_by(ChatMessageModel.created_at.asc())
+        ).scalars().all()
+        history_context, _ = _build_history_context(existing_messages)
+
+        if not session.title or session.title == DEFAULT_SESSION_TITLE:
+            session.title = _session_title_from_message(message)
+        session.updated_at = _now()
+
+        db.add(
+            ChatMessageModel(
+                message_id=uuid.uuid4(),
+                session_id=session_id,
+                role="user",
+                content=message,
+                created_at=_now(),
+            )
+        )
+        db.add(session)
+        db.commit()
+
     return StreamingResponse(
-        _stream(req),
+        _session_message_stream(session_id=session_id, req=req, user_id=user_id, history_context=history_context),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+@router.post("/")
+async def chat(
+    req: ChatRequest,
+    x_internal_service_token: str | None = Header(default=None),
+    x_user_id: str | None = Header(default=None),
+):
+    user_id = _verify_internal_request(x_internal_service_token, x_user_id)
+    return StreamingResponse(
+        _legacy_stream(req, user_id=user_id),
         media_type="text/event-stream",
         headers={
             "Cache-Control": "no-cache",


### PR DESCRIPTION
## 요약
Django를 채팅 인증 게이트웨이로 두고 FastAPI 세션/메시지 API와 채팅 화면 연동을 추가했습니다.

## 변경 사항
- Django `/api/chat/` 프록시 엔드포인트와 내부 인증 헤더를 추가하고, Nginx 라우팅을 FastAPI 직행에서 Django 경유로 변경했습니다.
- FastAPI에 세션 생성/목록/수정/삭제, 세션별 메시지 조회/전송 API와 SSE 응답 저장 로직을 추가했습니다.
- 이전 대화가 길어질 때 `conversation_history`를 축약해 intent/recommend/domain_qa/respond 프롬프트에 주입하도록 변경했습니다.
- 채팅 화면을 세션 기반으로 연동하고, 로그인 사용자만 실제 입력창이 활성화되도록 조정했습니다.
- 펫 관계형 필드 직렬화 버그를 함께 정리하고 Django 채팅 프록시/페이지 테스트를 추가했습니다.
- 검증: `docker exec tailtalk-django-1 python manage.py test --keepdb chat users`

## 관련 이슈
closes #47
closes #163

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- Django 프록시와 FastAPI 내부 인증 헤더 경계가 의도한 보안 모델에 맞는지 확인 부탁드립니다.
- 세션 메시지 저장 시점과 `conversation_history` 축약 방식이 현재 제품 요구에 맞는지 봐주시면 됩니다.