### PR TITLE
feat(deploy): add test elastic beanstalk pipeline

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -34,6 +34,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -76,6 +77,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -137,6 +139,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
+          submodules: recursive
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,27 +1,44 @@
-name: CI/CD
+name: Test EB CI/CD
 
 on:
   pull_request:
-    branches:
-      - main
-  push:
+    types:
+      - closed
     branches:
       - main
 
+permissions:
+  contents: read
+
+concurrency:
+  group: test-eb-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  AWS_REGION: ap-northeast-2
+  DJANGO_IMAGE_REPO: kimheejoon91/test-tailtalk-django
+  FASTAPI_IMAGE_REPO: kimheejoon91/test-tailtalk-fastapi
+  DJANGO_EB_APP_NAME: test-tailtalk-django
+  DJANGO_EB_ENV_NAME: test-tailtalk-django-env
+  FASTAPI_EB_APP_NAME: test-tailtalk-fastapi
+  FASTAPI_EB_ENV_NAME: test-tailtalk-fastapi-env
+
 jobs:
   ci:
-    name: CI — Build & Test
+    name: CI - Build & Test
     runs-on: ubuntu-latest
-    if: github.repository == 'skn-ai22-251029/SKN22-Final-2Team-WEB'
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Create .env
+      - name: Create test env file
         run: |
           cat <<'EOF' > infra/.env
           DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
@@ -35,9 +52,10 @@ jobs:
           CORS_ALLOWED_ORIGINS=http://localhost
           QDRANT_HOST=qdrant
           QDRANT_PORT=6333
+          INTERNAL_SERVICE_TOKEN=test-internal-token
           EOF
 
-      - name: Build
+      - name: Build local test stack
         run: docker compose -f infra/docker-compose.yml build
 
       - name: Run Django tests
@@ -47,18 +65,24 @@ jobs:
         if: always()
         run: docker compose -f infra/docker-compose.yml down -v
 
-  cd:
-    name: CD — Push & Deploy
+  deploy-fastapi:
+    name: CD - FastAPI Test EB
     runs-on: ubuntu-latest
     needs: ci
-    if: github.repository == 'skn-ai22-251029/SKN22-Final-2Team-WEB' && github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: fastapi-meta
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -66,35 +90,98 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build & Push Django
-        uses: docker/build-push-action@v6
-        with:
-          context: services/django
-          platforms: linux/amd64
-          push: true
-          tags: leemdo/tailtalk-django:latest
-
-      - name: Build & Push FastAPI
+      - name: Build & push FastAPI image
         uses: docker/build-push-action@v6
         with:
           context: services/fastapi
           platforms: linux/amd64
           push: true
-          tags: leemdo/tailtalk-fastapi:latest
+          tags: |
+            ${{ env.FASTAPI_IMAGE_REPO }}:latest
+            ${{ env.FASTAPI_IMAGE_REPO }}:${{ steps.fastapi-meta.outputs.short_sha }}
 
-      - name: Create deployment package
+      - name: Create FastAPI deployment bundle
         run: |
-          cp infra/docker-compose.yml docker-compose.yml
-          cp -r infra/nginx nginx
-          zip -r deploy.zip docker-compose.yml nginx
+          rm -rf .deploy-fastapi fastapi-deploy.zip
+          mkdir -p .deploy-fastapi
+          cp deploy/eb/test-fastapi/docker-compose.yml .deploy-fastapi/docker-compose.yml
+          cat <<EOF > .deploy-fastapi/.env
+          FASTAPI_IMAGE=${{ env.FASTAPI_IMAGE_REPO }}:${{ steps.fastapi-meta.outputs.short_sha }}
+          EOF
+          cd .deploy-fastapi
+          zip -r ../fastapi-deploy.zip docker-compose.yml .env
 
-      - name: Deploy to Elastic Beanstalk
+      - name: Deploy FastAPI to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v22
         with:
           aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          region: ${{ secrets.AWS_REGION }}
-          application_name: ${{ secrets.EB_APP_NAME }}
-          environment_name: ${{ secrets.EB_ENV_NAME }}
-          version_label: ${{ github.sha }}
-          deployment_package: deploy.zip
+          region: ${{ env.AWS_REGION }}
+          application_name: ${{ env.FASTAPI_EB_APP_NAME }}
+          environment_name: ${{ env.FASTAPI_EB_ENV_NAME }}
+          version_label: fastapi-${{ steps.fastapi-meta.outputs.short_sha }}
+          deployment_package: fastapi-deploy.zip
+          use_existing_version_if_available: true
+          wait_for_deployment: true
+
+  deploy-django:
+    name: CD - Django Test EB
+    runs-on: ubuntu-latest
+    needs:
+      - ci
+      - deploy-fastapi
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Resolve image tag
+        id: django-meta
+        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build & push Django image
+        uses: docker/build-push-action@v6
+        with:
+          context: services/django
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.DJANGO_IMAGE_REPO }}:latest
+            ${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}
+
+      - name: Create Django deployment bundle
+        run: |
+          rm -rf .deploy-django django-deploy.zip
+          mkdir -p .deploy-django
+          cp deploy/eb/test-django/docker-compose.yml .deploy-django/docker-compose.yml
+          cp -r deploy/eb/test-django/nginx .deploy-django/nginx
+          cat <<EOF > .deploy-django/.env
+          DJANGO_IMAGE=${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}
+          EOF
+          cd .deploy-django
+          zip -r ../django-deploy.zip docker-compose.yml nginx .env
+
+      - name: Deploy Django to Elastic Beanstalk
+        uses: einaregilsson/beanstalk-deploy@v22
+        with:
+          aws_access_key: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws_secret_key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          region: ${{ env.AWS_REGION }}
+          application_name: ${{ env.DJANGO_EB_APP_NAME }}
+          environment_name: ${{ env.DJANGO_EB_ENV_NAME }}
+          version_label: django-${{ steps.django-meta.outputs.short_sha }}
+          deployment_package: django-deploy.zip
+          use_existing_version_if_available: true
+          wait_for_deployment: true

--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ notebooks/**/data/
 
 # 도메인 데이터셋 (domain_qa)
 domain-data/
+
+# Local workspace data
+.local/

--- a/deploy/eb/test-django/docker-compose.yml
+++ b/deploy/eb/test-django/docker-compose.yml
@@ -1,0 +1,51 @@
+services:
+  nginx:
+    image: nginx:alpine
+    platform: linux/amd64
+    ports:
+      - "80:80"
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - django
+    restart: unless-stopped
+
+  django:
+    image: ${DJANGO_IMAGE:-kimheejoon91/test-tailtalk-django:latest}
+    platform: linux/amd64
+    command: >
+      sh -c "python manage.py migrate --noinput &&
+             python manage.py collectstatic --noinput &&
+             gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
+    environment:
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
+      APP_BASE_URL: ${APP_BASE_URL:-}
+      FASTAPI_INTERNAL_CHAT_URL: ${FASTAPI_INTERNAL_CHAT_URL}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:-}
+      NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:-}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID:-}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-}
+      SOCIAL_AUTH_REQUESTS_TIMEOUT: ${SOCIAL_AUTH_REQUESTS_TIMEOUT:-10}
+      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-False}
+      DJANGO_SESSION_COOKIE_SECURE: ${DJANGO_SESSION_COOKIE_SECURE:-False}
+      DJANGO_CSRF_COOKIE_SECURE: ${DJANGO_CSRF_COOKIE_SECURE:-False}
+      AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME:-}
+      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME:-}
+      AWS_S3_CUSTOM_DOMAIN: ${AWS_S3_CUSTOM_DOMAIN:-}
+      AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL:-}
+      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
+      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+    expose:
+      - "8000"
+    restart: unless-stopped

--- a/deploy/eb/test-django/nginx/nginx.conf
+++ b/deploy/eb/test-django/nginx/nginx.conf
@@ -1,0 +1,45 @@
+http {
+    upstream django {
+        server django:8000;
+    }
+
+    server {
+        listen 80;
+        server_name _;
+
+        location /health/ {
+            proxy_pass http://django;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location /api/chat/ {
+            proxy_pass http://django;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_buffering off;
+            proxy_cache off;
+            proxy_read_timeout 300s;
+        }
+
+        location /api/ {
+            proxy_pass http://django;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location /admin/ {
+            proxy_pass http://django;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location / {
+            proxy_pass http://django;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}
+
+events {}

--- a/deploy/eb/test-fastapi/docker-compose.yml
+++ b/deploy/eb/test-fastapi/docker-compose.yml
@@ -1,0 +1,18 @@
+services:
+  fastapi:
+    image: ${FASTAPI_IMAGE:-kimheejoon91/test-tailtalk-fastapi:latest}
+    platform: linux/amd64
+    command: uvicorn main:app --host 0.0.0.0 --port 8001 --workers 2
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
+      QDRANT_HOST: ${QDRANT_HOST:-}
+      QDRANT_PORT: ${QDRANT_PORT:-6333}
+    ports:
+      - "80:8001"
+    restart: unless-stopped

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -92,6 +92,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     expose:
       - "5432"
+    ports:
+      - 5432:5432
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 10s

--- a/scripts/build_and_push_test_images.sh
+++ b/scripts/build_and_push_test_images.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+git_tag="$(git -C "$repo_root" rev-parse --short HEAD)"
+
+django_repo="kimheejoon91/test-tailtalk-django"
+fastapi_repo="kimheejoon91/test-tailtalk-fastapi"
+
+build_and_push() {
+  local context_dir="$1"
+  local image_repo="$2"
+
+  docker build \
+    -t "${image_repo}:latest" \
+    -t "${image_repo}:${git_tag}" \
+    "$context_dir"
+
+  docker push "${image_repo}:latest"
+  docker push "${image_repo}:${git_tag}"
+}
+
+build_and_push "$repo_root/services/django" "$django_repo"
+build_and_push "$repo_root/services/fastapi" "$fastapi_repo"
+
+printf 'DJANGO_IMAGE=%s:%s\n' "$django_repo" "$git_tag"
+printf 'FASTAPI_IMAGE=%s:%s\n' "$fastapi_repo" "$git_tag"

--- a/services/django/.dockerignore
+++ b/services/django/.dockerignore
@@ -2,6 +2,14 @@
 .env
 .env.*
 
+# Git / editor
+.git
+.gitignore
+.dockerignore
+.idea/
+.vscode/
+.DS_Store
+
 # Python
 .venv/
 venv/
@@ -12,6 +20,15 @@ __pycache__/
 .pytest_cache/
 .ruff_cache/
 .mypy_cache/
+.tox/
+.nox/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+build/
+dist/
+*.egg-info/
 
 # Django 런타임 생성 파일
 db.sqlite3

--- a/services/django/config/urls.py
+++ b/services/django/config/urls.py
@@ -1,11 +1,19 @@
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.http import JsonResponse
 from django.urls import path, include
 from rest_framework_simplejwt.views import TokenObtainPairView, TokenRefreshView
 from django.views.static import serve
 
+
+def health_check(_request):
+    return JsonResponse({"status": "ok"})
+
+
 urlpatterns = [
+    path("health/", health_check, name="health-check"),
+
     # ── Admin ────────────────────────────────────────────────────────────────
     path("admin/", admin.site.urls),
 

--- a/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
+++ b/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
@@ -2,6 +2,7 @@
 
 import django.contrib.postgres.indexes
 import django.contrib.postgres.search
+import pgvector.django.extensions
 import pgvector.django.indexes
 import pgvector.django.vector
 from django.db import migrations, models
@@ -14,6 +15,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        pgvector.django.extensions.VectorExtension(),
         migrations.AddField(
             model_name='product',
             name='embedding',

--- a/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
+++ b/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
@@ -2,7 +2,6 @@
 
 import django.contrib.postgres.indexes
 import django.contrib.postgres.search
-import pgvector.django.extensions
 import pgvector.django.indexes
 import pgvector.django.vector
 from django.db import migrations, models
@@ -15,7 +14,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        pgvector.django.extensions.VectorExtension(),
         migrations.AddField(
             model_name='product',
             name='embedding',


### PR DESCRIPTION
## 요약
테스트용 Elastic Beanstalk 배포 파이프라인과 배포 번들을 추가하고, Django 헬스체크 및 pgvector 초기화 구성을 반영합니다.

## 변경 사항
- PR merge 이후 동작하는 Test EB CI/CD 워크플로우를 추가했습니다.
- FastAPI/Django 각각의 EB 배포용 `docker-compose.yml`과 Django용 nginx 설정을 추가했습니다.
- Docker Hub 테스트 이미지 빌드/푸시 스크립트를 추가했습니다.
- Django `/health/` 엔드포인트와 관련 프록시 설정을 추가했습니다.
- `VectorExtension()`을 migration에 추가하고 로컬 Postgres 포트를 노출했습니다.
- Django 빌드 컨텍스트 정리를 위해 `.dockerignore`를 보강했습니다.
- `services/fastapi` 서브모듈 포인터를 FastAPI PR 변경분에 맞춰 업데이트했습니다.
- CI/CD checkout 단계에서 fastapi submodule을 함께 내려받도록 수정했습니다.

## 관련 이슈
- 없음

## 체크리스트
- [ ] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- FastAPI 선행 PR: https://github.com/skn-ai22-251029/SKN22-Final-2Team-AI/pull/4
- 위 PR이 먼저 머지되어야 이 PR의 submodule SHA가 upstream AI 저장소에서도 정상적으로 해석됩니다.
- Test EB 앱/환경명과 Docker Hub 저장소명이 현재 운영 의도와 맞는지 확인 부탁드립니다.
