### PR TITLE
[feat] Django Template 기준 주문 / 상품 화면 UI 정비 (#130)

### DIFF
--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -229,6 +229,9 @@ def used_products(request):
     profile = getattr(request.user, "profile", None)
     recipient_name = getattr(profile, "nickname", "") or request.user.username or "주문자 정보 미등록"
     address = getattr(profile, "address", "") or "기본 배송지가 아직 등록되지 않았습니다."
+    address_parts = [part.strip() for part in address.split("|", 1)] if address else []
+    base_address = address_parts[0] if address_parts else address
+    detail_address = address_parts[1] if len(address_parts) > 1 else "상세 주소 정보가 아직 없습니다."
     phone = getattr(profile, "phone", "") or "연락처 정보가 아직 없습니다."
     for item in items:
         item["price_label"] = _format_price(item["price"])
@@ -249,7 +252,8 @@ def used_products(request):
             "shipping_fee": "무료" if shipping_fee == 0 else _format_price(shipping_fee),
             "final_total": _format_price(final_total),
             "recipient_name": recipient_name,
-            "delivery_address": address,
+            "delivery_base_address": base_address,
+            "delivery_detail_address": detail_address,
             "recipient_phone": phone,
             "payment_method": "우리카드 1234 / 일시불",
             "coupon_summary": "적용 가능한 쿠폰 2장",

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,12 +1,251 @@
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
+from django.db.models import Q
+
+from products.models import Product
+
+
+def _format_price(value):
+    return f"{value:,}원"
+
+
+def _product_summary(product):
+    pet_type = ", ".join(product.pet_type[:2]) if product.pet_type else "반려동물 공용"
+    category = product.subcategory[0] if product.subcategory else (product.category[0] if product.category else "기타")
+    return f"{pet_type} · {category}"
+
+
+def _display_product_name(brand_name, goods_name):
+    if not goods_name:
+        return ""
+
+    normalized_brand = (brand_name or "").strip()
+    normalized_name = goods_name.strip()
+
+    if normalized_brand and normalized_name.lower().startswith(normalized_brand.lower()):
+        trimmed = normalized_name[len(normalized_brand):].lstrip(" -_/|")
+        if trimmed:
+            return trimmed
+
+    return normalized_name
+
+
+def _recommended_note(index):
+    notes = [
+        "최근 상담 키워드와 잘 맞는 후보",
+        "재구매 후보로 저장된 상품",
+        "가격 비교를 위해 보관한 상품",
+    ]
+    return notes[index % len(notes)]
+
+
+def _single_product_queryset():
+    excluded_terms = [
+        "모음",
+        "모아보기",
+        "세트",
+        "BEST",
+        "color",
+        "Color",
+        "S-XL",
+        "S-M",
+        "SM-",
+        "2XL",
+        "3XL",
+        "4XL",
+        "무료배송",
+        "샘플",
+        "스쿱",
+    ]
+    query = Product.objects.filter(
+        soldout_yn=False,
+    ).filter(
+        Q(goods_name__icontains="영양제") | Q(goods_name__icontains="사료")
+    )
+
+    for term in excluded_terms:
+        query = query.exclude(goods_name__icontains=term)
+
+    return query.order_by("-review_count", "-discount_price", "goods_id")
+
+
+def _load_product_panels():
+    base_products = list(_single_product_queryset()[:30])
+
+    if not base_products:
+        return [], []
+
+    sorted_by_name_length = sorted(
+        base_products,
+        key=lambda product: len(_display_product_name(product.brand_name, product.goods_name)),
+        reverse=True,
+    )
+
+    selected_products = []
+    longest_product = sorted_by_name_length[0]
+    selected_products.append(longest_product)
+
+    for product in base_products:
+        if product.goods_id == longest_product.goods_id:
+            continue
+        selected_products.append(product)
+        if len(selected_products) >= 9:
+            break
+
+    cart_items = []
+    wishlist_items = []
+    for index, product in enumerate(selected_products[:5]):
+        cart_items.append(
+            {
+                "goods_id": product.goods_id,
+                "thumbnail_url": product.thumbnail_url,
+                "brand": product.brand_name,
+                "name": _display_product_name(product.brand_name, product.goods_name),
+                "summary": _product_summary(product),
+                "price": product.discount_price or product.price,
+                "rating": product.rating,
+                "review_count": product.review_count,
+                "quantity": (index % 3) + 1,
+            }
+        )
+
+    for index, product in enumerate(selected_products[5:9]):
+        wishlist_items.append(
+            {
+                "goods_id": product.goods_id,
+                "thumbnail_url": product.thumbnail_url,
+                "brand": product.brand_name,
+                "name": _display_product_name(product.brand_name, product.goods_name),
+                "summary": _product_summary(product),
+                "price": product.discount_price or product.price,
+                "rating": product.rating,
+                "review_count": product.review_count,
+                "note": _recommended_note(index),
+            }
+        )
+
+    return cart_items, wishlist_items
+
+
+def _order_groups():
+    return [
+        {
+            "order_id": "TT-20260325-1024",
+            "created_at": "2026.03.25",
+            "status": "배송 중",
+            "status_class": "bg-[#dbeafe] text-[#2563eb]",
+            "recipient": "황하령",
+            "total_price": _format_price(65700),
+            "delivery_message": "부재 시 문 앞에 놓아주세요",
+            "items": [
+                {
+                    "emoji": "🐟",
+                    "name": "닥터독 하이포알러지 연어 사료",
+                    "summary": "2kg · 1개",
+                    "price": _format_price(39800),
+                },
+                {
+                    "emoji": "👀",
+                    "name": "베러펫 눈물 케어 영양제",
+                    "summary": "30일분 · 1개",
+                    "price": _format_price(25900),
+                },
+            ],
+        },
+        {
+            "order_id": "TT-20260318-0841",
+            "created_at": "2026.03.18",
+            "status": "배송 완료",
+            "status_class": "bg-[#dcfce7] text-[#15803d]",
+            "recipient": "황하령",
+            "total_price": _format_price(31200),
+            "delivery_message": "배송이 완료되었습니다",
+            "items": [
+                {
+                    "emoji": "🦴",
+                    "name": "벨버드 덴탈 케어 껌",
+                    "summary": "30개입 · 2개",
+                    "price": _format_price(25800),
+                },
+                {
+                    "emoji": "🛁",
+                    "name": "저자극 샴푸",
+                    "summary": "민감 피부용 · 1개",
+                    "price": _format_price(5400),
+                },
+            ],
+        },
+        {
+            "order_id": "TT-20260310-2217",
+            "created_at": "2026.03.10",
+            "status": "주문 접수",
+            "status_class": "bg-[#fef3c7] text-[#b45309]",
+            "recipient": "황하령",
+            "total_price": _format_price(18400),
+            "delivery_message": "결제 확인 후 출고 준비 중입니다",
+            "items": [
+                {
+                    "emoji": "🍗",
+                    "name": "동결건조 치킨 트릿",
+                    "summary": "80g · 1개",
+                    "price": _format_price(18400),
+                },
+            ],
+        },
+    ]
 
 
 @login_required
 def order_list(request):
-    return render(request, "orders/list.html")
+    orders = _order_groups()
+    return render(
+        request,
+        "orders/list.html",
+        {
+            "order_groups": orders,
+            "order_count": len(orders),
+            "active_tab": "orders",
+        },
+    )
 
 
 @login_required
 def used_products(request):
-    return render(request, "orders/products.html")
+    items, wishlist_items = _load_product_panels()
+    product_total = sum(item["price"] * item["quantity"] for item in items)
+    discount = 5400
+    shipping_fee = 0 if product_total >= 30000 else 3000
+    final_total = product_total - discount + shipping_fee
+    profile = getattr(request.user, "profile", None)
+    recipient_name = getattr(profile, "nickname", "") or request.user.username or "주문자 정보 미등록"
+    address = getattr(profile, "address", "") or "기본 배송지가 아직 등록되지 않았습니다."
+    phone = getattr(profile, "phone", "") or "연락처 정보가 아직 없습니다."
+    for item in items:
+        item["price_label"] = _format_price(item["price"])
+        item["line_total_label"] = _format_price(item["price"] * item["quantity"])
+    for item in wishlist_items:
+        item["price_label"] = _format_price(item["price"])
+
+    return render(
+        request,
+        "orders/products.html",
+        {
+            "cart_items": items,
+            "wishlist_items": wishlist_items,
+            "item_count": sum(item["quantity"] for item in items),
+            "wishlist_count": len(wishlist_items),
+            "product_total": _format_price(product_total),
+            "discount_total": _format_price(discount),
+            "shipping_fee": "무료" if shipping_fee == 0 else _format_price(shipping_fee),
+            "final_total": _format_price(final_total),
+            "recipient_name": recipient_name,
+            "delivery_address": address,
+            "recipient_phone": phone,
+            "payment_method": "우리카드 1234 / 일시불",
+            "coupon_summary": "적용 가능한 쿠폰 2장",
+            "mileage_summary": "사용 가능 3,200원",
+            "discount_total_raw": discount,
+            "shipping_fee_raw": shipping_fee,
+            "active_tab": "cart",
+        },
+    )

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -92,9 +92,17 @@ def _load_product_panels():
         if len(selected_products) >= 9:
             break
 
+    cart_source = selected_products[:5]
+    wishlist_source = []
+    if len(cart_source) > 1:
+        wishlist_source.extend(cart_source[:2])
+    wishlist_source.extend(selected_products[5:7])
+
+    wishlist_goods_ids = {product.goods_id for product in wishlist_source}
+
     cart_items = []
     wishlist_items = []
-    for index, product in enumerate(selected_products[:5]):
+    for index, product in enumerate(cart_source):
         cart_items.append(
             {
                 "goods_id": product.goods_id,
@@ -106,10 +114,12 @@ def _load_product_panels():
                 "rating": product.rating,
                 "review_count": product.review_count,
                 "quantity": (index % 3) + 1,
+                "note": _recommended_note(index),
+                "is_wishlisted": product.goods_id in wishlist_goods_ids,
             }
         )
 
-    for index, product in enumerate(selected_products[5:9]):
+    for index, product in enumerate(wishlist_source):
         wishlist_items.append(
             {
                 "goods_id": product.goods_id,

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -895,13 +895,20 @@
         </div>
 
         {% if is_member_view %}
-        <div class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]" aria-label="장바구니">
+        <a href="{% if is_preview_member %}#{% else %}/products/{% endif %}"
+           class="relative flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+           aria-label="장바구니"
+           {% if is_preview_member %}onclick="return false"{% endif %}>
+          <span id="headerCartCountBadge"
+                class="absolute right-[-4px] top-[-5px] hidden h-[18px] min-w-[18px] items-center justify-center rounded-full bg-[#2d3748] px-[5px] text-[10px] font-bold leading-none text-white shadow-[0_4px_10px_rgba(45,55,72,0.16)]">
+            0
+          </span>
           <svg viewBox="0 0 24 24" class="h-[24px] w-[24px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
             <circle cx="9" cy="20" r="1.5"></circle>
             <circle cx="18" cy="20" r="1.5"></circle>
             <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
           </svg>
-        </div>
+        </a>
         <div class="relative h-[40px] w-[40px]" id="profileMenuWrapper">
           <button type="button" class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]" aria-label="프로필 메뉴 열기" onclick="toggleProfileMenu()">
             <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
@@ -1806,6 +1813,7 @@
   function updateCartTotal() {
     var totalNode = document.getElementById('cartTotalAmount');
     var badgeNode = document.getElementById('cartCountBadge');
+    var headerBadgeNode = document.getElementById('headerCartCountBadge');
     if (!totalNode) return;
 
     var total = 0;
@@ -1820,6 +1828,17 @@
 
     totalNode.textContent = formatPrice(total);
     if (badgeNode) badgeNode.textContent = String(count);
+    if (headerBadgeNode) {
+      if (count > 0) {
+        headerBadgeNode.textContent = count > 9 ? '9+' : String(count);
+        headerBadgeNode.classList.remove('hidden');
+        headerBadgeNode.classList.add('inline-flex');
+      } else {
+        headerBadgeNode.textContent = '0';
+        headerBadgeNode.classList.add('hidden');
+        headerBadgeNode.classList.remove('inline-flex');
+      }
+    }
     if (quickOrderModal && quickOrderModal.classList.contains('is-open')) {
       renderQuickOrderSummary();
     }

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1010,6 +1010,7 @@
   var activePetId = '{{ active_pet_id|escapejs }}';
   var PROFILE_ADDRESS_STORAGE_KEY = 'tailtalk_profile_address_preview';
   var PROFILE_PAYMENT_STORAGE_KEY = 'tailtalk_profile_payment_preview';
+  var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
   var quickOrderToastTimer = null;
   var quickOrderSlideEnabled = false;
   var quickOrderSlideDragging = false;
@@ -1839,8 +1840,38 @@
         headerBadgeNode.classList.remove('inline-flex');
       }
     }
+    try {
+      window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
+    } catch (e) {}
     if (quickOrderModal && quickOrderModal.classList.contains('is-open')) {
       renderQuickOrderSummary();
+    }
+  }
+
+  function applySharedCartCount() {
+    var badgeNode = document.getElementById('cartCountBadge');
+    var headerBadgeNode = document.getElementById('headerCartCountBadge');
+    var count = 0;
+    try {
+      count = Number(window.localStorage.getItem(SHARED_CART_COUNT_STORAGE_KEY) || '0');
+    } catch (e) {
+      count = 0;
+    }
+
+    if (badgeNode) {
+      badgeNode.textContent = String(count);
+    }
+
+    if (headerBadgeNode) {
+      if (count > 0) {
+        headerBadgeNode.textContent = count > 9 ? '9+' : String(count);
+        headerBadgeNode.classList.remove('hidden');
+        headerBadgeNode.classList.add('inline-flex');
+      } else {
+        headerBadgeNode.textContent = '0';
+        headerBadgeNode.classList.add('hidden');
+        headerBadgeNode.classList.remove('inline-flex');
+      }
     }
   }
 
@@ -2328,6 +2359,7 @@
 
   renderPromoSlide();
   updateCartTotal();
+  applySharedCartCount();
   Object.keys(sessionThreads).forEach(ensureSessionState);
 
   if (promoCarouselGroup) {
@@ -2346,6 +2378,12 @@
   closePetDropdown();
   updateChatSectionState(false);
   updateSessionItemStyles();
+
+  window.addEventListener('storage', function (event) {
+    if (event.key === SHARED_CART_COUNT_STORAGE_KEY) {
+      applySharedCartCount();
+    }
+  });
 
   if (activePetId) {
     var initialPet = document.querySelector('[data-pet-id="' + activePetId + '"]');

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1011,6 +1011,7 @@
   var PROFILE_ADDRESS_STORAGE_KEY = 'tailtalk_profile_address_preview';
   var PROFILE_PAYMENT_STORAGE_KEY = 'tailtalk_profile_payment_preview';
   var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
+  var SHARED_CART_ITEMS_STORAGE_KEY = 'tailtalk_shared_cart_items';
   var quickOrderToastTimer = null;
   var quickOrderSlideEnabled = false;
   var quickOrderSlideDragging = false;
@@ -1769,12 +1770,35 @@
     return Number(String(value || '0').replace(/[^\d]/g, '')) || 0;
   }
 
+  function normalizeReviewCount(value) {
+    var digits = String(value || '').replace(/[^\d]/g, '');
+    return digits || '0';
+  }
+
+  function loadSharedCartItems() {
+    try {
+      return JSON.parse(window.localStorage.getItem(SHARED_CART_ITEMS_STORAGE_KEY) || '[]');
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveSharedCartItems(items) {
+    try {
+      window.localStorage.setItem(SHARED_CART_ITEMS_STORAGE_KEY, JSON.stringify(items));
+    } catch (e) {}
+  }
+
   function buildCartItem(product) {
     var item = document.createElement('div');
     item.className = 'group relative rounded-[20px] border border-[#dbe7f5] bg-white px-[14px] py-[13px] shadow-[0_8px_20px_rgba(45,55,72,0.05)]';
     item.setAttribute('data-cart-item', '');
     item.setAttribute('data-unit-price', String(product.unitPrice));
     item.setAttribute('data-product-name', product.name);
+    item.setAttribute('data-goods-id', product.goodsId || product.name);
+    item.setAttribute('data-product-rating', product.rating || '0.0');
+    item.setAttribute('data-product-reviews', normalizeReviewCount(product.reviewCount || product.reviews || '0'));
+    item.setAttribute('data-product-emoji', product.emoji || '🛍️');
     item.innerHTML = ''
       + '<button type="button"'
       + ' class="absolute right-[10px] top-[10px] flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white text-[14px] text-[#a0aec0] opacity-0 transition-opacity duration-150 group-hover:opacity-100"'
@@ -1800,7 +1824,7 @@
       + '          aria-label="수량 감소">'
       + '    <span class="relative top-[-1px]">-</span>'
       + '  </button>'
-      + '  <span class="min-w-[22px] text-center text-[13px] font-bold text-[#2d3748]" data-cart-quantity>1</span>'
+      + '  <span class="min-w-[22px] text-center text-[13px] font-bold text-[#2d3748]" data-cart-quantity>' + String(product.quantity || 1) + '</span>'
       + '  <button type="button"'
       + '          class="flex h-[28px] w-[28px] items-center justify-center rounded-full text-[18px] font-semibold leading-none text-[#2d3748] hover:bg-white"'
       + '          onclick="adjustCartQuantity(this, 1)"'
@@ -1809,6 +1833,48 @@
       + '  </button>'
       + '</div>';
     return item;
+  }
+
+  function getCartState() {
+    var items = [];
+    document.querySelectorAll('[data-cart-item]').forEach(function (item) {
+      var quantityNode = item.querySelector('[data-cart-quantity]');
+      items.push({
+        goodsId: item.getAttribute('data-goods-id') || item.getAttribute('data-product-name') || '',
+        name: item.getAttribute('data-product-name') || '상품',
+        price: Number(item.getAttribute('data-unit-price') || '0'),
+        priceLabel: formatPrice(Number(item.getAttribute('data-unit-price') || '0')),
+        rating: item.getAttribute('data-product-rating') || '0.0',
+        reviewCount: normalizeReviewCount(item.getAttribute('data-product-reviews') || '0'),
+        reviews: '리뷰 ' + normalizeReviewCount(item.getAttribute('data-product-reviews') || '0'),
+        quantity: Number(quantityNode ? quantityNode.textContent || '0' : '0'),
+        emoji: item.getAttribute('data-product-emoji') || '🛍️',
+        brand: '',
+        thumbnailUrl: '',
+        note: '가격 비교를 위해 보관한 상품',
+        isWishlisted: false,
+      });
+    });
+    return items;
+  }
+
+  function renderCartFromState(items) {
+    var list = document.getElementById('cartPanelList');
+    if (!list) return;
+    list.innerHTML = '';
+    items.forEach(function (itemData) {
+      list.appendChild(buildCartItem({
+        goodsId: itemData.goodsId,
+        name: itemData.name,
+        unitPrice: Number(itemData.price || 0),
+        price: itemData.priceLabel || formatPrice(Number(itemData.price || 0)),
+        rating: itemData.rating || '0.0',
+        reviewCount: itemData.reviewCount || '0',
+        reviews: '리뷰 ' + normalizeReviewCount(itemData.reviewCount || '0'),
+        quantity: Number(itemData.quantity || 1),
+        emoji: itemData.emoji || '🛍️',
+      }));
+    });
   }
 
   function updateCartTotal() {
@@ -1843,6 +1909,7 @@
     try {
       window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
     } catch (e) {}
+    saveSharedCartItems(getCartState());
     if (quickOrderModal && quickOrderModal.classList.contains('is-open')) {
       renderQuickOrderSummary();
     }
@@ -1908,10 +1975,12 @@
     if (!list || !button) return;
 
     var product = {
+      goodsId: button.getAttribute('data-product-id') || button.getAttribute('data-product-name') || 'product-' + Date.now(),
       name: button.getAttribute('data-product-name') || '추천 상품',
       price: button.getAttribute('data-product-price') || '0원',
       rating: button.getAttribute('data-product-rating') || '0.0',
-      reviews: button.getAttribute('data-product-reviews') || '리뷰 0',
+      reviewCount: normalizeReviewCount(button.getAttribute('data-product-reviews') || '0'),
+      reviews: '리뷰 ' + normalizeReviewCount(button.getAttribute('data-product-reviews') || '0'),
       emoji: button.getAttribute('data-product-emoji') || '🛍️',
       unitPrice: parsePrice(button.getAttribute('data-product-price')),
     };
@@ -2358,6 +2427,12 @@
   }
 
   renderPromoSlide();
+  var initialSharedCartItems = loadSharedCartItems();
+  if (initialSharedCartItems.length) {
+    renderCartFromState(initialSharedCartItems);
+  } else {
+    saveSharedCartItems(getCartState());
+  }
   updateCartTotal();
   applySharedCartCount();
   Object.keys(sessionThreads).forEach(ensureSessionState);
@@ -2382,6 +2457,10 @@
   window.addEventListener('storage', function (event) {
     if (event.key === SHARED_CART_COUNT_STORAGE_KEY) {
       applySharedCartCount();
+    }
+    if (event.key === SHARED_CART_ITEMS_STORAGE_KEY) {
+      renderCartFromState(loadSharedCartItems());
+      updateCartTotal();
     }
   });
 

--- a/services/django/templates/orders/list.html
+++ b/services/django/templates/orders/list.html
@@ -1,5 +1,90 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}구매 내역 — TailTalk{% endblock %}
+
 {% block content %}
-<!-- TODO: orders/list.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="mx-auto max-w-[1180px] px-4 py-8 md:px-6">
+    <div class="flex items-center justify-between gap-4">
+      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
+        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+      </a>
+      <a href="/products/" class="inline-flex h-[42px] items-center justify-center rounded-[12px] border border-[#dbe7f5] bg-white px-4 text-[14px] font-semibold text-[#4a5568]">
+        장바구니 보기
+      </a>
+    </div>
+
+    <div class="mt-8 flex items-center justify-start">
+      <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+        <a href="/products/" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
+            장바구니
+          </a>
+        <a href="/orders/" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">
+            구매 내역
+          </a>
+      </div>
+    </div>
+
+    <div class="mt-8 space-y-5">
+      {% for order in order_groups %}
+      <section class="overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+        <div class="border-b border-[#edf2f7] px-6 py-5">
+          <div class="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+            <div>
+              <div class="flex flex-wrap items-center gap-2">
+                <p class="text-[19px] font-bold text-[#2d3748]">{{ order.created_at }}</p>
+                <span class="inline-flex rounded-full px-3 py-1 text-[12px] font-bold {{ order.status_class }}">
+                  {{ order.status }}
+                </span>
+              </div>
+              <p class="mt-2 text-[13px] text-[#718096]">주문번호 {{ order.order_id }} · 수령인 {{ order.recipient }}</p>
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+              <a href="/products/" class="inline-flex h-[40px] items-center justify-center rounded-[12px] border border-[#dbe7f5] bg-white px-4 text-[13px] font-semibold text-[#4a5568]">
+                다시 주문
+              </a>
+              <button type="button" class="inline-flex h-[40px] items-center justify-center rounded-[12px] bg-[#edf2f7] px-4 text-[13px] font-semibold text-[#2d3748]">
+                상세 보기
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div class="grid gap-5 px-6 py-6 lg:grid-cols-[minmax(0,1fr)_240px]">
+          <div class="space-y-3">
+            {% for item in order.items %}
+            <div class="flex items-center gap-4 rounded-[18px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-4">
+              <div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-[18px] bg-white text-[28px] shadow-[0_4px_14px_rgba(49,130,206,0.08)]">
+                {{ item.emoji }}
+              </div>
+              <div class="min-w-0 flex-1">
+                <p class="truncate text-[16px] font-bold text-[#2d3748]">{{ item.name }}</p>
+                <p class="mt-1 text-[13px] text-[#718096]">{{ item.summary }}</p>
+              </div>
+              <div class="text-right">
+                <p class="text-[15px] font-bold text-[#2d3748]">{{ item.price }}</p>
+              </div>
+            </div>
+            {% endfor %}
+          </div>
+
+          <aside class="rounded-[20px] border border-[#dbe7f5] bg-[#f8fbff] px-5 py-5">
+            <p class="text-[13px] font-semibold text-[#90a4b8]">주문 요약</p>
+            <p class="mt-3 text-[24px] font-bold text-[#2d3748]">{{ order.total_price }}</p>
+            <div class="mt-5 space-y-3 text-[13px] text-[#4a5568]">
+              <div class="flex items-center justify-between">
+                <span>주문 상태</span>
+                <span class="font-semibold text-[#2d3748]">{{ order.status }}</span>
+              </div>
+              <div class="flex items-start justify-between gap-3">
+                <span>배송 메모</span>
+                <span class="max-w-[120px] text-right leading-[1.5] text-[#718096]">{{ order.delivery_message }}</span>
+              </div>
+            </div>
+          </aside>
+        </div>
+      </section>
+      {% endfor %}
+    </div>
+  </div>
+</div>
 {% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -10,6 +10,26 @@
   .product-tab-panel.is-active {
     display: block;
   }
+
+  .wishlist-heart svg:last-child {
+    display: none;
+  }
+
+  .wishlist-heart {
+    color: #4a5568;
+  }
+
+  .wishlist-heart.is-active {
+    color: #e53e3e;
+  }
+
+  .wishlist-heart.is-active svg:first-child {
+    display: none;
+  }
+
+  .wishlist-heart.is-active svg:last-child {
+    display: block;
+  }
 </style>
 {% endblock %}
 
@@ -24,69 +44,127 @@
 
     <div class="mt-8 flex items-center justify-start">
       <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
-        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white transition-colors">
-          장바구니
+        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white transition-colors">
+          <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
+            <span class="inline-flex h-[18px] items-center leading-none">장바구니</span>
+            <span id="productsTabCartCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full bg-white/18 px-1.5 text-[11px] font-bold leading-none text-white {% if item_count == 0 %}hidden{% endif %}">
+              <span class="inline-flex h-[18px] items-center">{{ item_count }}</span>
+            </span>
+          </span>
         </button>
-        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
-          관심 상품
+        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
+          <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
+            <span class="inline-flex h-[18px] items-center leading-none">관심 상품</span>
+            <span id="productsTabWishlistCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full bg-[#edf2f7] px-1.5 text-[11px] font-bold leading-none text-[#4a5568] {% if wishlist_count == 0 %}hidden{% endif %}">
+              <span class="inline-flex h-[18px] items-center">{{ wishlist_count }}</span>
+            </span>
+          </span>
         </button>
-        <a href="/orders/" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
-          구매 내역
+        <a href="/orders/" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold leading-none text-[#718096] transition-colors hover:text-[#2d3748]">
+          <span class="inline-flex h-[18px] items-center justify-center gap-1.5 leading-none">
+            <span class="inline-flex h-[18px] items-center leading-none">구매 내역</span>
+          </span>
         </a>
       </div>
     </div>
 
     <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
-      <section class="min-h-[720px] lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
-        <div id="productsPanelCart" class="product-tab-panel is-active space-y-3">
+      <section class="min-h-[720px]">
+        <div id="productsPanelCart" class="product-tab-panel is-active min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
         {% for item in cart_items %}
-        <article class="rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
+        <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
                  data-cart-item
-                 data-unit-price="{{ item.price }}">
-          <div class="flex flex-col gap-3 md:flex-row md:items-center">
-            <div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
+                 data-goods-id="{{ item.goods_id }}"
+                 data-unit-price="{{ item.price }}"
+                 data-brand="{{ item.brand }}"
+                 data-name="{{ item.name }}"
+                 data-price-label="{{ item.price_label }}"
+                 data-rating="{{ item.rating|default:'-' }}"
+                 data-review-count="{{ item.review_count }}"
+                 data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
+                 data-note="{{ item.note }}">
+          <div class="absolute right-4 top-4 flex items-center gap-2">
+            <button type="button"
+                    class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]"
+                    aria-label="관심 상품 상태 변경"
+                    onclick="toggleWishlistHeart(this)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+              </svg>
+            </button>
+            <button type="button"
+                    class="inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[14px] font-bold uppercase text-[#a0aec0] transition-colors hover:text-[#e53e3e]"
+                    aria-label="상품 삭제"
+                    onclick="removeCartItem(this)">X</button>
+          </div>
+          <div class="flex items-start gap-3">
+            <div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
               {% if item.thumbnail_url %}
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
               {% else %}
               <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
               {% endif %}
             </div>
-            <div class="min-w-0 flex-1">
-              <p class="text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
+            <div class="min-w-0 flex-1 pr-14">
+              <div class="flex items-center justify-between gap-3">
+                <p class="truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
+                <span class="shrink-0 text-[12px] text-[#90a4b8]">개당 {{ item.price_label }}</span>
+              </div>
               <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]">{{ item.name }}</p>
               <div class="mt-2 flex items-center gap-2 text-[11px]">
                 <span class="font-bold text-[#d69e2e]">★ {{ item.rating|default:"-" }}</span>
                 <span class="text-[#a0aec0]">리뷰 {{ item.review_count }}</span>
               </div>
             </div>
-            <div class="flex items-center justify-between gap-3 md:flex-col md:items-end">
-              <div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[4px] py-[4px] text-[13px] font-semibold text-[#2d3748]">
-                <button type="button"
-                        class="flex h-[28px] w-[28px] items-center justify-center rounded-full bg-white text-[15px]"
-                        onclick="adjustCartQuantity(this, -1)">−</button>
-                <span class="inline-flex min-w-[34px] items-center justify-center" data-cart-quantity>{{ item.quantity }}</span>
-                <button type="button"
-                        class="flex h-[28px] w-[28px] items-center justify-center rounded-full bg-white text-[15px]"
-                        onclick="adjustCartQuantity(this, 1)">+</button>
-              </div>
-              <div class="text-right">
-                <p class="text-[12px] text-[#90a4b8]">{{ item.price_label }} / 개</p>
-                <p class="mt-1 text-[17px] font-bold text-[#2d3748]" data-cart-line-total>{{ item.line_total_label }}</p>
-              </div>
-            </div>
           </div>
-          <div class="mt-3 flex items-center justify-end border-t border-[#edf2f7] pt-3">
-            <button type="button" class="text-[13px] font-semibold text-[#e53e3e]" onclick="removeCartItem(this)">삭제</button>
+          <div class="mt-2.5 flex items-center justify-end gap-2.5 border-t border-[#edf2f7] pt-2.5">
+            <div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">
+              <button type="button"
+                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
+                      onclick="adjustCartQuantity(this, -1)">−</button>
+              <span class="inline-flex min-w-[28px] items-center justify-center px-1" data-cart-quantity>{{ item.quantity }}</span>
+              <button type="button"
+                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
+                      onclick="adjustCartQuantity(this, 1)">+</button>
+            </div>
+            <div class="min-w-[96px] text-right">
+              <p class="text-[17px] font-bold text-[#2d3748]" data-cart-line-total>{{ item.line_total_label }}</p>
+            </div>
           </div>
         </article>
         {% endfor %}
         </div>
 
-        <div id="productsPanelWishlist" class="product-tab-panel space-y-3">
+        <div id="productsPanelWishlist" class="product-tab-panel min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
         {% for item in wishlist_items %}
-        <article class="rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+        <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
+                 data-wishlist-item
+                 data-goods-id="{{ item.goods_id }}"
+                 data-brand="{{ item.brand }}"
+                 data-name="{{ item.name }}"
+                 data-price-label="{{ item.price_label }}"
+                 data-rating="{{ item.rating|default:'-' }}"
+                 data-review-count="{{ item.review_count }}"
+                 data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
+                 data-note="{{ item.note }}">
+          <div class="absolute right-4 top-4">
+            <button type="button"
+                    class="wishlist-heart is-active inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]"
+                    aria-label="관심 상품 상태 변경"
+                    onclick="toggleWishlistHeart(this)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+              </svg>
+            </button>
+          </div>
           <div class="flex flex-col gap-3 md:flex-row md:items-center">
-            <div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
+            <div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
               {% if item.thumbnail_url %}
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
               {% else %}
@@ -95,7 +173,7 @@
             </div>
             <div class="min-w-0 flex-1">
               <p class="text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
-              <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]">{{ item.name }}</p>
+              <p class="mt-1 max-w-[calc(100%-44px)] truncate text-[16px] font-bold text-[#2d3748] md:max-w-full">{{ item.name }}</p>
               <div class="mt-2 flex items-center gap-2 text-[11px]">
                 <span class="font-bold text-[#d69e2e]">★ {{ item.rating|default:"-" }}</span>
                 <span class="text-[#a0aec0]">리뷰 {{ item.review_count }}</span>
@@ -105,9 +183,6 @@
             <div class="flex items-center gap-3 md:flex-col md:items-end">
               <p class="text-[17px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
               <div class="flex items-center gap-2">
-                <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-3 text-[12px] font-semibold text-[#4a5568]">
-                  삭제
-                </button>
                 <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">
                   담기
                 </button>
@@ -203,6 +278,8 @@
   var wishlistTab = document.getElementById('productsTabWishlist');
   var cartPanel = document.getElementById('productsPanelCart');
   var wishlistPanel = document.getElementById('productsPanelWishlist');
+  var cartCountBadge = document.getElementById('productsTabCartCount');
+  var wishlistCountBadge = document.getElementById('productsTabWishlistCount');
   var discountTotalRaw = {{ discount_total_raw }};
   var shippingFeeRaw = {{ shipping_fee_raw }};
 
@@ -240,6 +317,105 @@
     if (finalTotalNode) finalTotalNode.textContent = formatPrice(finalTotal);
   }
 
+  function updateTabCounts() {
+    var cartCount = 0;
+    cartPanel.querySelectorAll('[data-cart-item]').forEach(function (item) {
+      var quantityNode = item.querySelector('[data-cart-quantity]');
+      var quantity = quantityNode ? Number(quantityNode.textContent || '0') : 0;
+      cartCount += quantity;
+    });
+    var wishlistCount = wishlistPanel.querySelectorAll('[data-wishlist-item]').length;
+
+    if (cartCountBadge) {
+      cartCountBadge.textContent = String(cartCount);
+      cartCountBadge.classList.toggle('hidden', cartCount === 0);
+    }
+
+    if (wishlistCountBadge) {
+      wishlistCountBadge.textContent = String(wishlistCount);
+      wishlistCountBadge.classList.toggle('hidden', wishlistCount === 0);
+    }
+  }
+
+  function escapeHtml(value) {
+    return String(value || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function wishlistItemMarkup(data) {
+    var thumbnail = data.thumbnailUrl
+      ? '<img src="' + escapeHtml(data.thumbnailUrl) + '" alt="' + escapeHtml(data.name) + '" class="h-full w-full object-cover" />'
+      : '<span class="text-[20px] font-bold text-[#90a4b8]">?</span>';
+
+    return [
+      '<article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]" data-wishlist-item',
+      ' data-goods-id="' + escapeHtml(data.goodsId) + '"',
+      ' data-brand="' + escapeHtml(data.brand) + '"',
+      ' data-name="' + escapeHtml(data.name) + '"',
+      ' data-price-label="' + escapeHtml(data.priceLabel) + '"',
+      ' data-rating="' + escapeHtml(data.rating) + '"',
+      ' data-review-count="' + escapeHtml(data.reviewCount) + '"',
+      ' data-thumbnail-url="' + escapeHtml(data.thumbnailUrl) + '"',
+      ' data-note="' + escapeHtml(data.note) + '">',
+      '<div class="absolute right-4 top-4">',
+      '<button type="button" class="wishlist-heart is-active inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)">',
+      '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>',
+      '</button></div>',
+      '<div class="flex flex-col gap-3 md:flex-row md:items-center">',
+      '<div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">',
+      thumbnail,
+      '</div>',
+      '<div class="min-w-0 flex-1"><p class="text-[12px] font-semibold text-[#90a4b8]">' + escapeHtml(data.brand) + '</p>',
+      '<p class="mt-1 max-w-[calc(100%-44px)] truncate text-[16px] font-bold text-[#2d3748] md:max-w-full">' + escapeHtml(data.name) + '</p>',
+      '<div class="mt-2 flex items-center gap-2 text-[11px]"><span class="font-bold text-[#d69e2e]">★ ' + escapeHtml(data.rating) + '</span><span class="text-[#a0aec0]">리뷰 ' + escapeHtml(data.reviewCount) + '</span></div>',
+      '<p class="mt-2 text-[12px] text-[#4a5568]">' + escapeHtml(data.note) + '</p></div>',
+      '<div class="flex items-center gap-3 md:flex-col md:items-end"><p class="text-[17px] font-bold text-[#2d3748]">' + escapeHtml(data.priceLabel) + '</p>',
+      '<div class="flex items-center gap-2"><button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">담기</button></div></div></div></article>'
+    ].join('');
+  }
+
+  function getCartItemData(item) {
+    return {
+      goodsId: item.getAttribute('data-goods-id') || '',
+      brand: item.getAttribute('data-brand') || '',
+      name: item.getAttribute('data-name') || '',
+      priceLabel: item.getAttribute('data-price-label') || '',
+      rating: item.getAttribute('data-rating') || '-',
+      reviewCount: item.getAttribute('data-review-count') || '0',
+      thumbnailUrl: item.getAttribute('data-thumbnail-url') || '',
+      note: item.getAttribute('data-note') || '가격 비교를 위해 보관한 상품',
+    };
+  }
+
+  function syncCartHeart(goodsId, active) {
+    var cartItem = cartPanel.querySelector('[data-cart-item][data-goods-id="' + goodsId + '"]');
+    if (!cartItem) return;
+    var button = cartItem.querySelector('.wishlist-heart');
+    if (!button) return;
+    button.classList.toggle('is-active', active);
+  }
+
+  function addWishlistItem(data) {
+    if (wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + data.goodsId + '"]')) {
+      return;
+    }
+    wishlistPanel.insertAdjacentHTML('beforeend', wishlistItemMarkup(data));
+    updateTabCounts();
+  }
+
+  function removeWishlistItem(goodsId) {
+    var item = wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + goodsId + '"]');
+    if (item) {
+      item.remove();
+      updateTabCounts();
+    }
+  }
+
   function setActiveTab(tab) {
     var cartActive = tab === 'cart';
     cartPanel.classList.toggle('is-active', cartActive);
@@ -254,7 +430,44 @@
     wishlistTab.classList.toggle('text-white', !cartActive);
     wishlistTab.classList.toggle('text-[#718096]', cartActive);
     wishlistTab.classList.toggle('hover:text-[#2d3748]', cartActive);
+
+    if (cartCountBadge) {
+      cartCountBadge.classList.toggle('bg-white/18', cartActive);
+      cartCountBadge.classList.toggle('text-white', cartActive);
+      cartCountBadge.classList.toggle('bg-[#edf2f7]', !cartActive);
+      cartCountBadge.classList.toggle('text-[#4a5568]', !cartActive);
+    }
+
+    if (wishlistCountBadge) {
+      wishlistCountBadge.classList.toggle('bg-white/18', !cartActive);
+      wishlistCountBadge.classList.toggle('text-white', !cartActive);
+      wishlistCountBadge.classList.toggle('bg-[#edf2f7]', cartActive);
+      wishlistCountBadge.classList.toggle('text-[#4a5568]', cartActive);
+    }
   }
+
+  window.toggleWishlistHeart = function (button) {
+    var cartItem = button.closest('[data-cart-item]');
+    var wishlistItem = button.closest('[data-wishlist-item]');
+
+    if (cartItem) {
+      var cartData = getCartItemData(cartItem);
+      var nextActive = !button.classList.contains('is-active');
+      button.classList.toggle('is-active', nextActive);
+      if (nextActive) {
+        addWishlistItem(cartData);
+      } else {
+        removeWishlistItem(cartData.goodsId);
+      }
+      return;
+    }
+
+    if (wishlistItem) {
+      var goodsId = wishlistItem.getAttribute('data-goods-id');
+      wishlistItem.remove();
+      syncCartHeart(goodsId, false);
+    }
+  };
 
   cartTab.addEventListener('click', function () {
     setActiveTab('cart');
@@ -274,6 +487,7 @@
     var next = Math.max(1, current + delta);
     quantityNode.textContent = String(next);
     updateCartSummary();
+    updateTabCounts();
   };
 
   window.removeCartItem = function (button) {
@@ -281,9 +495,11 @@
     if (!item) return;
     item.remove();
     updateCartSummary();
+    updateTabCounts();
   };
 
   updateCartSummary();
+  updateTabCounts();
 })();
 </script>
 {% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -11,6 +11,10 @@
     display: block;
   }
 
+  .product-list-viewport {
+    scrollbar-gutter: stable;
+  }
+
   .wishlist-heart svg:last-child {
     display: none;
   }
@@ -68,9 +72,17 @@
       </div>
     </div>
 
-    <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+    <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_470px]">
       <section class="min-h-[720px]">
-        <div id="productsPanelCart" class="product-tab-panel is-active min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
+        <div id="productsPanelCart" class="product-tab-panel is-active min-h-[720px]">
+        <div id="cartEmptyState" class="hidden max-w-[650px] rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-14 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+          <p class="text-[18px] font-bold text-[#2d3748]">장바구니가 비어 있습니다</p>
+          <p class="mt-2 text-[14px] text-[#718096]">대화를 통해 추천 상품을 담거나 관심 상품에서 다시 추가해보세요.</p>
+          <a href="/chat/" class="mt-6 inline-flex h-[42px] items-center justify-center rounded-full bg-[#2d3748] px-5 text-[13px] font-semibold text-white">
+            채팅으로 돌아가기
+          </a>
+        </div>
+        <div id="cartListViewport" class="product-list-viewport min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
         {% for item in cart_items %}
         <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
                  data-cart-item
@@ -137,8 +149,10 @@
         </article>
         {% endfor %}
         </div>
+        </div>
 
-        <div id="productsPanelWishlist" class="product-tab-panel min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
+        <div id="productsPanelWishlist" class="product-tab-panel min-h-[720px]">
+        <div class="product-list-viewport min-h-[720px] max-w-[650px] space-y-3 lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
         {% for item in wishlist_items %}
         <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
                  data-wishlist-item
@@ -192,49 +206,50 @@
         </article>
         {% endfor %}
         </div>
+        </div>
       </section>
 
-      <aside class="h-fit rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
+      <aside id="orderSummaryPanel" class="flex min-h-[720px] flex-col rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
         <h2 class="text-[22px] font-bold text-[#2d3748]">주문 정보</h2>
 
-        <div class="mt-5 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-[13px] font-semibold text-[#2d3748]">배송지</p>
-              <p class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
-              <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_address }}</p>
-              <p class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
-            </div>
-            <a href="/profile/" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
-          </div>
-        </div>
-
-        <div class="mt-3 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-[13px] font-semibold text-[#2d3748]">결제수단</p>
-              <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
-            </div>
-            <a href="/profile/" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
-          </div>
-        </div>
-
-        <div class="mt-4 rounded-[18px] border border-dashed border-[#bfdbfe] bg-[#eef7ff] px-4 py-4">
-          <div class="flex items-start justify-between gap-3">
-            <div>
-              <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
-              <div class="mt-3 space-y-3">
-                <div>
-                  <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
-                  <p class="mt-1 text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
-                </div>
-                <div>
-                  <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
-                  <p class="mt-1 text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
-                </div>
+        <div class="mt-5 grid gap-3 md:grid-cols-2">
+          <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+            <div class="flex items-start justify-between gap-4">
+              <div class="min-w-0 flex-1">
+                <p class="text-[13px] font-semibold text-[#2d3748]">배송 정보</p>
+                <p class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
+                <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
+                <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
+                <p class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
               </div>
+              <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
             </div>
-            <button type="button" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
+          </div>
+          <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+            <div class="flex items-start justify-between gap-4">
+              <div class="min-w-0 flex-1">
+                <p class="text-[13px] font-semibold text-[#2d3748]">결제 수단</p>
+                <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
+              </div>
+              <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+          <div class="flex items-start justify-between gap-4">
+            <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
+            <button type="button" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
+          </div>
+          <div class="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+            <div class="min-w-0">
+              <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
+              <p class="mt-1 truncate text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
+            </div>
+            <div class="min-w-0 md:pl-4">
+              <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
+              <p class="mt-1 truncate text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
+            </div>
           </div>
         </div>
 
@@ -262,7 +277,7 @@
           </div>
         </div>
 
-        <button type="button" class="mt-6 inline-flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[15px] font-bold text-white shadow-[0_10px_24px_rgba(45,55,72,0.18)]">
+        <button type="button" class="mt-auto inline-flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[15px] font-bold text-white shadow-[0_10px_24px_rgba(45,55,72,0.18)]">
           주문하기
         </button>
       </aside>
@@ -274,10 +289,13 @@
 {% block scripts %}
 <script>
 (function () {
+  var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
   var cartTab = document.getElementById('productsTabCart');
   var wishlistTab = document.getElementById('productsTabWishlist');
   var cartPanel = document.getElementById('productsPanelCart');
   var wishlistPanel = document.getElementById('productsPanelWishlist');
+  var cartEmptyState = document.getElementById('cartEmptyState');
+  var orderSummaryPanel = document.getElementById('orderSummaryPanel');
   var cartCountBadge = document.getElementById('productsTabCartCount');
   var wishlistCountBadge = document.getElementById('productsTabWishlistCount');
   var discountTotalRaw = {{ discount_total_raw }};
@@ -287,6 +305,12 @@
 
   function formatPrice(value) {
     return new Intl.NumberFormat('ko-KR').format(value) + '원';
+  }
+
+  function saveSharedCartCount(count) {
+    try {
+      window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
+    } catch (e) {}
   }
 
   function updateCartSummary() {
@@ -319,10 +343,12 @@
 
   function updateTabCounts() {
     var cartCount = 0;
+    var cartItemCount = 0;
     cartPanel.querySelectorAll('[data-cart-item]').forEach(function (item) {
       var quantityNode = item.querySelector('[data-cart-quantity]');
       var quantity = quantityNode ? Number(quantityNode.textContent || '0') : 0;
       cartCount += quantity;
+      cartItemCount += 1;
     });
     var wishlistCount = wishlistPanel.querySelectorAll('[data-wishlist-item]').length;
 
@@ -331,9 +357,19 @@
       cartCountBadge.classList.toggle('hidden', cartCount === 0);
     }
 
+    saveSharedCartCount(cartCount);
+
     if (wishlistCountBadge) {
       wishlistCountBadge.textContent = String(wishlistCount);
       wishlistCountBadge.classList.toggle('hidden', wishlistCount === 0);
+    }
+
+    if (cartEmptyState) {
+      cartEmptyState.classList.toggle('hidden', cartItemCount !== 0);
+    }
+
+    if (orderSummaryPanel) {
+      orderSummaryPanel.classList.toggle('hidden', cartItemCount === 0);
     }
   }
 

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -11,6 +11,14 @@
     display: block;
   }
 
+  .discount-modal {
+    display: none;
+  }
+
+  .discount-modal.is-open {
+    display: flex;
+  }
+
   .product-list-viewport {
     scrollbar-gutter: stable;
   }
@@ -33,6 +41,17 @@
 
   .wishlist-heart.is-active svg:last-child {
     display: block;
+  }
+
+  #mileageInput::-webkit-outer-spin-button,
+  #mileageInput::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  #mileageInput {
+    -moz-appearance: textfield;
+    appearance: textfield;
   }
 </style>
 {% endblock %}
@@ -216,7 +235,7 @@
           <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0 flex-1">
-                <p class="text-[13px] font-semibold text-[#2d3748]">배송 정보</p>
+                <p class="text-[13px] font-semibold text-[#2563eb]">배송 정보</p>
                 <p class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
                 <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
                 <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
@@ -228,7 +247,7 @@
           <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0 flex-1">
-                <p class="text-[13px] font-semibold text-[#2d3748]">결제 수단</p>
+                <p class="text-[13px] font-semibold text-[#2563eb]">결제 수단</p>
                 <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
               </div>
               <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
@@ -239,22 +258,22 @@
         <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
           <div class="flex items-start justify-between gap-4">
             <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
-            <button type="button" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
+            <button type="button" id="openDiscountModalBtn" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
           </div>
           <div class="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
             <div class="min-w-0">
               <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
-              <p class="mt-1 truncate text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
+              <p id="couponSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
             </div>
             <div class="min-w-0 md:pl-4">
               <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
-              <p class="mt-1 truncate text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
+              <p id="mileageSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
             </div>
           </div>
         </div>
 
         <div class="mt-5 rounded-[18px] bg-[#f8fbff] px-4 py-4">
-          <p class="text-[13px] font-semibold text-[#2d3748]">결제 금액</p>
+          <p class="text-[13px] font-semibold text-[#2563eb]">결제 금액</p>
           <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
             <div class="flex items-center justify-between">
               <span>상품 금액</span>
@@ -284,12 +303,81 @@
     </div>
   </div>
 </div>
+
+<div id="discountBenefitModal" class="discount-modal fixed inset-0 z-50 items-center justify-center bg-[rgba(15,23,42,0.46)] px-4" onclick="closeDiscountModal(event)">
+  <div class="w-full max-w-[520px] rounded-[24px] bg-white px-6 py-6 shadow-[0_20px_60px_rgba(15,23,42,0.24)]">
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-[22px] font-bold text-[#2d3748]">할인 혜택 적용</p>
+        <p class="mt-1 text-[13px] text-[#718096]">쿠폰과 마일리지를 선택하면 주문 정보에 바로 반영됩니다.</p>
+      </div>
+      <button type="button" class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]" onclick="closeDiscountModal()" aria-label="할인 혜택 모달 닫기">X</button>
+    </div>
+
+    <div class="mt-5 inline-flex rounded-full border border-[#dbe7f5] bg-[#f8fbff] p-[4px]">
+      <button type="button" id="discountTabCoupon" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">쿠폰</button>
+      <button type="button" id="discountTabMileage" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">마일리지</button>
+    </div>
+
+    <div id="discountPanelCoupon" class="mt-5 space-y-3">
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="none" data-coupon-label="적용된 쿠폰 없음" data-coupon-discount="0">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">쿠폰 적용 안 함</p>
+          <p class="mt-1 text-[12px] text-[#718096]">할인을 적용하지 않고 현재 금액으로 주문합니다.</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#718096]">0원</span>
+      </button>
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="new-member" data-coupon-label="신규회원 3,000원 할인" data-coupon-discount="3000">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">신규회원 3,000원 할인</p>
+          <p class="mt-1 text-[12px] text-[#718096]">30,000원 이상 결제 시 사용 가능</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#2563eb]">-3,000원</span>
+      </button>
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="pet-care" data-coupon-label="펫케어 5,000원 할인" data-coupon-discount="5000">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">펫케어 5,000원 할인</p>
+          <p class="mt-1 text-[12px] text-[#718096]">60,000원 이상 결제 시 사용 가능</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#2563eb]">-5,000원</span>
+      </button>
+    </div>
+
+    <div id="discountPanelMileage" class="mt-5 hidden">
+      <div class="rounded-[18px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-4">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <p class="text-[14px] font-semibold text-[#2d3748]">사용 가능한 마일리지</p>
+            <p class="mt-1 text-[12px] text-[#718096]">보유 마일리지 3,200원</p>
+          </div>
+          <button type="button" id="useAllMileageBtn" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">전액 사용</button>
+        </div>
+        <label class="mt-4 block">
+          <span class="text-[12px] font-semibold text-[#2d3748]">사용할 마일리지</span>
+          <div class="mt-2 flex items-center rounded-[14px] border border-[#dbe7f5] bg-white px-4">
+            <input id="mileageInput" type="number" min="0" max="3200" step="100" value="0" class="h-[48px] w-full bg-transparent text-[15px] font-semibold text-[#2d3748] outline-none" />
+            <span class="shrink-0 text-[13px] font-semibold text-[#718096]">원</span>
+          </div>
+        </label>
+      </div>
+    </div>
+
+    <div class="mt-6 flex items-center justify-between gap-4 rounded-[18px] bg-[#f8fbff] px-4 py-4">
+      <div>
+        <p class="text-[12px] font-semibold text-[#718096]">예상 할인 금액</p>
+        <p id="discountModalPreviewAmount" class="mt-1 text-[22px] font-bold text-[#2563eb]">- 0원</p>
+      </div>
+      <button type="button" id="applyDiscountBtn" class="inline-flex h-[46px] items-center justify-center rounded-[14px] bg-[#2d3748] px-5 text-[14px] font-semibold text-white">적용하기</button>
+    </div>
+  </div>
+</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
 (function () {
   var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
+  var SHARED_CART_ITEMS_STORAGE_KEY = 'tailtalk_shared_cart_items';
   var cartTab = document.getElementById('productsTabCart');
   var wishlistTab = document.getElementById('productsTabWishlist');
   var cartPanel = document.getElementById('productsPanelCart');
@@ -300,6 +388,24 @@
   var wishlistCountBadge = document.getElementById('productsTabWishlistCount');
   var discountTotalRaw = {{ discount_total_raw }};
   var shippingFeeRaw = {{ shipping_fee_raw }};
+  var couponSummaryText = document.getElementById('couponSummaryText');
+  var mileageSummaryText = document.getElementById('mileageSummaryText');
+  var discountModal = document.getElementById('discountBenefitModal');
+  var openDiscountModalBtn = document.getElementById('openDiscountModalBtn');
+  var discountTabCoupon = document.getElementById('discountTabCoupon');
+  var discountTabMileage = document.getElementById('discountTabMileage');
+  var discountPanelCoupon = document.getElementById('discountPanelCoupon');
+  var discountPanelMileage = document.getElementById('discountPanelMileage');
+  var couponOptions = Array.prototype.slice.call(document.querySelectorAll('.discount-coupon-option'));
+  var mileageInput = document.getElementById('mileageInput');
+  var useAllMileageBtn = document.getElementById('useAllMileageBtn');
+  var applyDiscountBtn = document.getElementById('applyDiscountBtn');
+  var discountModalPreviewAmount = document.getElementById('discountModalPreviewAmount');
+  var selectedCouponId = 'none';
+  var selectedCouponLabel = '{{ coupon_summary|escapejs }}';
+  var selectedCouponDiscount = {{ discount_total_raw }};
+  var selectedMileageValue = 0;
+  var discountMode = 'coupon';
 
   if (!cartTab || !wishlistTab || !cartPanel || !wishlistPanel) return;
 
@@ -307,10 +413,63 @@
     return new Intl.NumberFormat('ko-KR').format(value) + '원';
   }
 
+  function parsePrice(value) {
+    return Number(String(value || '0').replace(/[^\d]/g, '')) || 0;
+  }
+
   function saveSharedCartCount(count) {
     try {
       window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
     } catch (e) {}
+  }
+
+  function loadSharedCartItems() {
+    try {
+      return JSON.parse(window.localStorage.getItem(SHARED_CART_ITEMS_STORAGE_KEY) || '[]');
+    } catch (e) {
+      return [];
+    }
+  }
+
+  function saveSharedCartItems(items) {
+    try {
+      window.localStorage.setItem(SHARED_CART_ITEMS_STORAGE_KEY, JSON.stringify(items));
+    } catch (e) {}
+  }
+
+  function normalizeReviewCount(value) {
+    var digits = String(value || '').replace(/[^\d]/g, '');
+    return digits || '0';
+  }
+
+  function getCatalogItemData(item) {
+    var unitPrice = Number(item.getAttribute('data-unit-price') || '0');
+    var priceLabel = item.getAttribute('data-price-label') || formatPrice(unitPrice);
+    if (!unitPrice) {
+      unitPrice = parsePrice(priceLabel);
+    }
+    return {
+      goodsId: item.getAttribute('data-goods-id') || '',
+      brand: item.getAttribute('data-brand') || '',
+      name: item.getAttribute('data-name') || '',
+      price: unitPrice,
+      priceLabel: priceLabel,
+      rating: item.getAttribute('data-rating') || '-',
+      reviewCount: normalizeReviewCount(item.getAttribute('data-review-count') || '0'),
+      thumbnailUrl: item.getAttribute('data-thumbnail-url') || '',
+      note: item.getAttribute('data-note') || '가격 비교를 위해 보관한 상품',
+      isWishlisted: item.classList.contains('is-active') || !!item.querySelector('.wishlist-heart.is-active'),
+    };
+  }
+
+  function buildProductCatalog() {
+    var catalog = {};
+    document.querySelectorAll('[data-cart-item], [data-wishlist-item]').forEach(function (item) {
+      var data = getCatalogItemData(item);
+      if (!data.goodsId) return;
+      catalog[data.goodsId] = Object.assign({}, catalog[data.goodsId] || {}, data);
+    });
+    return catalog;
   }
 
   function updateCartSummary() {
@@ -327,8 +486,9 @@
       productTotal += lineTotal;
     });
 
+    var currentDiscountTotal = selectedCouponDiscount + selectedMileageValue;
     var shippingFee = productTotal > 0 && productTotal < 30000 ? shippingFeeRaw : 0;
-    var finalTotal = Math.max(productTotal - discountTotalRaw, 0) + shippingFee;
+    var finalTotal = Math.max(productTotal - currentDiscountTotal, 0) + shippingFee;
 
     var productTotalNode = document.getElementById('productTotalAmount');
     var discountNode = document.getElementById('discountTotalAmount');
@@ -336,9 +496,30 @@
     var finalTotalNode = document.getElementById('finalTotalAmount');
 
     if (productTotalNode) productTotalNode.textContent = formatPrice(productTotal);
-    if (discountNode) discountNode.textContent = '- ' + formatPrice(discountTotalRaw);
+    if (discountNode) discountNode.textContent = '- ' + formatPrice(currentDiscountTotal);
     if (shippingNode) shippingNode.textContent = shippingFee === 0 ? '무료' : formatPrice(shippingFee);
     if (finalTotalNode) finalTotalNode.textContent = formatPrice(finalTotal);
+  }
+
+  function getCartState() {
+    var items = [];
+    cartPanel.querySelectorAll('[data-cart-item]').forEach(function (item) {
+      var quantityNode = item.querySelector('[data-cart-quantity]');
+      items.push({
+        goodsId: item.getAttribute('data-goods-id') || '',
+        brand: item.getAttribute('data-brand') || '',
+        name: item.getAttribute('data-name') || '',
+        price: Number(item.getAttribute('data-unit-price') || '0'),
+        priceLabel: item.getAttribute('data-price-label') || formatPrice(Number(item.getAttribute('data-unit-price') || '0')),
+        rating: item.getAttribute('data-rating') || '-',
+        reviewCount: normalizeReviewCount(item.getAttribute('data-review-count') || '0'),
+        thumbnailUrl: item.getAttribute('data-thumbnail-url') || '',
+        note: item.getAttribute('data-note') || '가격 비교를 위해 보관한 상품',
+        quantity: Number(quantityNode ? quantityNode.textContent || '0' : '0'),
+        isWishlisted: !!item.querySelector('.wishlist-heart.is-active'),
+      });
+    });
+    return items;
   }
 
   function updateTabCounts() {
@@ -358,6 +539,7 @@
     }
 
     saveSharedCartCount(cartCount);
+    saveSharedCartItems(getCartState());
 
     if (wishlistCountBadge) {
       wishlistCountBadge.textContent = String(wishlistCount);
@@ -380,6 +562,109 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  function updateDiscountSummaryTexts() {
+    if (couponSummaryText) {
+      couponSummaryText.textContent = selectedCouponLabel || '적용된 쿠폰 없음';
+    }
+    if (mileageSummaryText) {
+      mileageSummaryText.textContent = selectedMileageValue > 0 ? '사용 ' + formatPrice(selectedMileageValue) : '사용 가능 3,200원';
+    }
+  }
+
+  function updateDiscountPreview() {
+    if (!discountModalPreviewAmount) return;
+    discountModalPreviewAmount.textContent = '- ' + formatPrice(selectedCouponDiscount + selectedMileageValue);
+  }
+
+  function setDiscountTab(mode) {
+    discountMode = mode;
+    var couponActive = mode === 'coupon';
+    if (discountPanelCoupon) discountPanelCoupon.classList.toggle('hidden', !couponActive);
+    if (discountPanelMileage) discountPanelMileage.classList.toggle('hidden', couponActive);
+    if (discountTabCoupon) {
+      discountTabCoupon.classList.toggle('bg-[#2d3748]', couponActive);
+      discountTabCoupon.classList.toggle('text-white', couponActive);
+      discountTabCoupon.classList.toggle('text-[#718096]', !couponActive);
+    }
+    if (discountTabMileage) {
+      discountTabMileage.classList.toggle('bg-[#2d3748]', !couponActive);
+      discountTabMileage.classList.toggle('text-white', !couponActive);
+      discountTabMileage.classList.toggle('text-[#718096]', couponActive);
+    }
+  }
+
+  function highlightSelectedCoupon() {
+    couponOptions.forEach(function (option) {
+      var isSelected = option.getAttribute('data-coupon-id') === selectedCouponId;
+      option.classList.toggle('border-[#90cdf4]', isSelected);
+      option.classList.toggle('bg-[#f8fbff]', isSelected);
+    });
+  }
+
+  window.closeDiscountModal = function (event) {
+    if (!discountModal) return;
+    if (event && event.target !== discountModal) return;
+    discountModal.classList.remove('is-open');
+  };
+
+  window.openDiscountModal = function () {
+    if (!discountModal) return;
+    if (mileageInput) mileageInput.value = String(selectedMileageValue);
+    highlightSelectedCoupon();
+    updateDiscountPreview();
+    setDiscountTab('coupon');
+    discountModal.classList.add('is-open');
+  };
+
+  function cartItemMarkup(data) {
+    var thumbnail = data.thumbnailUrl
+      ? '<img src="' + escapeHtml(data.thumbnailUrl) + '" alt="' + escapeHtml(data.name) + '" class="h-full w-full object-cover" />'
+      : '<span class="text-[20px] font-bold text-[#90a4b8]">?</span>';
+
+    return [
+      '<article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"',
+      ' data-cart-item',
+      ' data-goods-id="' + escapeHtml(data.goodsId) + '"',
+      ' data-unit-price="' + escapeHtml(data.price) + '"',
+      ' data-brand="' + escapeHtml(data.brand) + '"',
+      ' data-name="' + escapeHtml(data.name) + '"',
+      ' data-price-label="' + escapeHtml(data.priceLabel) + '"',
+      ' data-rating="' + escapeHtml(data.rating) + '"',
+      ' data-review-count="' + escapeHtml(data.reviewCount) + '"',
+      ' data-thumbnail-url="' + escapeHtml(data.thumbnailUrl) + '"',
+      ' data-note="' + escapeHtml(data.note) + '">',
+      '<div class="absolute right-4 top-4 flex items-center gap-2">',
+      '<button type="button" class="wishlist-heart ' + (data.isWishlisted ? 'is-active ' : '') + 'inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)">',
+      '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>',
+      '</button>',
+      '<button type="button" class="inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[14px] font-bold uppercase text-[#a0aec0] transition-colors hover:text-[#e53e3e]" aria-label="상품 삭제" onclick="removeCartItem(this)">X</button>',
+      '</div>',
+      '<div class="flex items-start gap-3">',
+      '<div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">',
+      thumbnail,
+      '</div>',
+      '<div class="min-w-0 flex-1 pr-14">',
+      '<div class="flex items-center justify-between gap-3">',
+      '<p class="truncate text-[12px] font-semibold text-[#90a4b8]">' + escapeHtml(data.brand) + '</p>',
+      '<span class="shrink-0 text-[12px] text-[#90a4b8]">개당 ' + escapeHtml(data.priceLabel) + '</span>',
+      '</div>',
+      '<p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]">' + escapeHtml(data.name) + '</p>',
+      '<div class="mt-2 flex items-center gap-2 text-[11px]"><span class="font-bold text-[#d69e2e]">★ ' + escapeHtml(data.rating) + '</span><span class="text-[#a0aec0]">리뷰 ' + escapeHtml(data.reviewCount) + '</span></div>',
+      '</div>',
+      '</div>',
+      '<div class="mt-2.5 flex items-center justify-end gap-2.5 border-t border-[#edf2f7] pt-2.5">',
+      '<div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">',
+      '<button type="button" class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]" onclick="adjustCartQuantity(this, -1)">−</button>',
+      '<span class="inline-flex min-w-[28px] items-center justify-center px-1" data-cart-quantity>' + escapeHtml(data.quantity) + '</span>',
+      '<button type="button" class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]" onclick="adjustCartQuantity(this, 1)">+</button>',
+      '</div>',
+      '<div class="min-w-[96px] text-right"><p class="text-[17px] font-bold text-[#2d3748]" data-cart-line-total>' + escapeHtml(formatPrice(Number(data.price || 0) * Number(data.quantity || 1))) + '</p></div>',
+      '</div>',
+      '</article>'
+    ].join('');
   }
 
   function wishlistItemMarkup(data) {
@@ -534,8 +819,120 @@
     updateTabCounts();
   };
 
+  if (openDiscountModalBtn) {
+    openDiscountModalBtn.addEventListener('click', window.openDiscountModal);
+  }
+
+  if (discountTabCoupon) {
+    discountTabCoupon.addEventListener('click', function () {
+      setDiscountTab('coupon');
+    });
+  }
+
+  if (discountTabMileage) {
+    discountTabMileage.addEventListener('click', function () {
+      setDiscountTab('mileage');
+    });
+  }
+
+  couponOptions.forEach(function (option) {
+    option.addEventListener('click', function () {
+      selectedCouponId = option.getAttribute('data-coupon-id') || 'none';
+      selectedCouponLabel = option.getAttribute('data-coupon-label') || '적용된 쿠폰 없음';
+      selectedCouponDiscount = Number(option.getAttribute('data-coupon-discount') || '0');
+      highlightSelectedCoupon();
+      updateDiscountPreview();
+    });
+  });
+
+  if (useAllMileageBtn) {
+    useAllMileageBtn.addEventListener('click', function () {
+      if (mileageInput) {
+        mileageInput.value = '3200';
+        selectedMileageValue = 3200;
+        updateDiscountPreview();
+      }
+    });
+  }
+
+  if (mileageInput) {
+    mileageInput.addEventListener('input', function () {
+      var nextValue = Number(mileageInput.value || '0');
+      nextValue = Math.max(0, Math.min(3200, nextValue));
+      if (nextValue !== Number(mileageInput.value || '0')) {
+        mileageInput.value = String(nextValue);
+      }
+      selectedMileageValue = nextValue;
+      updateDiscountPreview();
+    });
+  }
+
+  if (applyDiscountBtn) {
+    applyDiscountBtn.addEventListener('click', function () {
+      if (mileageInput) {
+        selectedMileageValue = Math.max(0, Math.min(3200, Number(mileageInput.value || '0')));
+        mileageInput.value = String(selectedMileageValue);
+      }
+      updateDiscountSummaryTexts();
+      updateCartSummary();
+      window.closeDiscountModal();
+    });
+  }
+
+  var cartListViewport = document.getElementById('cartListViewport');
+  var productCatalog = buildProductCatalog();
+
+  function mergeCartItemData(sharedItem) {
+    var catalogItem = productCatalog[sharedItem.goodsId] || {};
+    return {
+      goodsId: sharedItem.goodsId || catalogItem.goodsId || '',
+      brand: sharedItem.brand || catalogItem.brand || '',
+      name: sharedItem.name || catalogItem.name || '상품',
+      price: Number(sharedItem.price || catalogItem.price || 0),
+      priceLabel: sharedItem.priceLabel || catalogItem.priceLabel || formatPrice(Number(sharedItem.price || catalogItem.price || 0)),
+      rating: sharedItem.rating || catalogItem.rating || '-',
+      reviewCount: normalizeReviewCount(sharedItem.reviewCount || catalogItem.reviewCount || '0'),
+      thumbnailUrl: sharedItem.thumbnailUrl || catalogItem.thumbnailUrl || '',
+      note: sharedItem.note || catalogItem.note || '가격 비교를 위해 보관한 상품',
+      quantity: Number(sharedItem.quantity || 1),
+      isWishlisted: typeof sharedItem.isWishlisted === 'boolean'
+        ? sharedItem.isWishlisted
+        : !!wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + (sharedItem.goodsId || '') + '"]'),
+    };
+  }
+
+  function renderCartFromState(items) {
+    if (!cartListViewport) return;
+    cartListViewport.innerHTML = '';
+    items.forEach(function (item) {
+      var merged = mergeCartItemData(item);
+      if (!merged.goodsId) return;
+      cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup(merged));
+    });
+    updateCartSummary();
+    updateTabCounts();
+  }
+
+  var initialSharedCartItems = loadSharedCartItems();
+  if (initialSharedCartItems.length) {
+    renderCartFromState(initialSharedCartItems);
+  } else {
+    saveSharedCartItems(getCartState());
+  }
+
+  updateDiscountSummaryTexts();
+  updateDiscountPreview();
   updateCartSummary();
   updateTabCounts();
+
+  window.addEventListener('storage', function (event) {
+    if (event.key === SHARED_CART_ITEMS_STORAGE_KEY) {
+      renderCartFromState(loadSharedCartItems());
+    }
+    if (event.key === SHARED_CART_COUNT_STORAGE_KEY && event.key !== SHARED_CART_ITEMS_STORAGE_KEY) {
+      updateTabCounts();
+    }
+  });
 })();
 </script>
 {% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -1,5 +1,289 @@
 {% extends "base.html" %}
-{% block title %}TailTalk{% endblock %}
+{% block title %}장바구니 — TailTalk{% endblock %}
+
+{% block head %}
+<style>
+  .product-tab-panel {
+    display: none;
+  }
+
+  .product-tab-panel.is-active {
+    display: block;
+  }
+</style>
+{% endblock %}
+
 {% block content %}
-<!-- TODO: orders/products.html 포팅 (#119~#121) -->
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="mx-auto max-w-[1180px] px-4 py-8 md:px-6">
+    <div class="flex items-center justify-start">
+      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
+        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+      </a>
+    </div>
+
+    <div class="mt-8 flex items-center justify-start">
+      <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white transition-colors">
+          장바구니
+        </button>
+        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
+          관심 상품
+        </button>
+        <a href="/orders/" class="inline-flex h-[38px] min-w-[108px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
+          구매 내역
+        </a>
+      </div>
+    </div>
+
+    <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_340px]">
+      <section class="min-h-[720px] lg:max-h-[calc(100vh-220px)] lg:overflow-y-auto lg:pr-2">
+        <div id="productsPanelCart" class="product-tab-panel is-active space-y-3">
+        {% for item in cart_items %}
+        <article class="rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
+                 data-cart-item
+                 data-unit-price="{{ item.price }}">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center">
+            <div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+              {% else %}
+              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
+              <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]">{{ item.name }}</p>
+              <div class="mt-2 flex items-center gap-2 text-[11px]">
+                <span class="font-bold text-[#d69e2e]">★ {{ item.rating|default:"-" }}</span>
+                <span class="text-[#a0aec0]">리뷰 {{ item.review_count }}</span>
+              </div>
+            </div>
+            <div class="flex items-center justify-between gap-3 md:flex-col md:items-end">
+              <div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[4px] py-[4px] text-[13px] font-semibold text-[#2d3748]">
+                <button type="button"
+                        class="flex h-[28px] w-[28px] items-center justify-center rounded-full bg-white text-[15px]"
+                        onclick="adjustCartQuantity(this, -1)">−</button>
+                <span class="inline-flex min-w-[34px] items-center justify-center" data-cart-quantity>{{ item.quantity }}</span>
+                <button type="button"
+                        class="flex h-[28px] w-[28px] items-center justify-center rounded-full bg-white text-[15px]"
+                        onclick="adjustCartQuantity(this, 1)">+</button>
+              </div>
+              <div class="text-right">
+                <p class="text-[12px] text-[#90a4b8]">{{ item.price_label }} / 개</p>
+                <p class="mt-1 text-[17px] font-bold text-[#2d3748]" data-cart-line-total>{{ item.line_total_label }}</p>
+              </div>
+            </div>
+          </div>
+          <div class="mt-3 flex items-center justify-end border-t border-[#edf2f7] pt-3">
+            <button type="button" class="text-[13px] font-semibold text-[#e53e3e]" onclick="removeCartItem(this)">삭제</button>
+          </div>
+        </article>
+        {% endfor %}
+        </div>
+
+        <div id="productsPanelWishlist" class="product-tab-panel space-y-3">
+        {% for item in wishlist_items %}
+        <article class="rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+          <div class="flex flex-col gap-3 md:flex-row md:items-center">
+            <div class="flex h-[58px] w-[58px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+              {% else %}
+              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
+            </div>
+            <div class="min-w-0 flex-1">
+              <p class="text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
+              <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]">{{ item.name }}</p>
+              <div class="mt-2 flex items-center gap-2 text-[11px]">
+                <span class="font-bold text-[#d69e2e]">★ {{ item.rating|default:"-" }}</span>
+                <span class="text-[#a0aec0]">리뷰 {{ item.review_count }}</span>
+              </div>
+              <p class="mt-2 text-[12px] text-[#4a5568]">{{ item.note }}</p>
+            </div>
+            <div class="flex items-center gap-3 md:flex-col md:items-end">
+              <p class="text-[17px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
+              <div class="flex items-center gap-2">
+                <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-3 text-[12px] font-semibold text-[#4a5568]">
+                  삭제
+                </button>
+                <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">
+                  담기
+                </button>
+              </div>
+            </div>
+          </div>
+        </article>
+        {% endfor %}
+        </div>
+      </section>
+
+      <aside class="h-fit rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
+        <h2 class="text-[22px] font-bold text-[#2d3748]">주문 정보</h2>
+
+        <div class="mt-5 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[13px] font-semibold text-[#2d3748]">배송지</p>
+              <p class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
+              <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_address }}</p>
+              <p class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
+            </div>
+            <a href="/profile/" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
+          </div>
+        </div>
+
+        <div class="mt-3 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[13px] font-semibold text-[#2d3748]">결제수단</p>
+              <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
+            </div>
+            <a href="/profile/" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
+          </div>
+        </div>
+
+        <div class="mt-4 rounded-[18px] border border-dashed border-[#bfdbfe] bg-[#eef7ff] px-4 py-4">
+          <div class="flex items-start justify-between gap-3">
+            <div>
+              <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
+              <div class="mt-3 space-y-3">
+                <div>
+                  <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
+                  <p class="mt-1 text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
+                </div>
+                <div>
+                  <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
+                  <p class="mt-1 text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
+                </div>
+              </div>
+            </div>
+            <button type="button" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
+          </div>
+        </div>
+
+        <div class="mt-5 rounded-[18px] bg-[#f8fbff] px-4 py-4">
+          <p class="text-[13px] font-semibold text-[#2d3748]">결제 금액</p>
+          <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+            <div class="flex items-center justify-between">
+              <span>상품 금액</span>
+              <span class="font-semibold text-[#2d3748]" id="productTotalAmount">{{ product_total }}</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>할인 적용</span>
+              <span class="font-semibold text-[#2563eb]" id="discountTotalAmount">- {{ discount_total }}</span>
+            </div>
+            <div class="flex items-center justify-between">
+              <span>배송비</span>
+              <span class="font-semibold text-[#2d3748]" id="shippingFeeAmount">{{ shipping_fee }}</span>
+            </div>
+          </div>
+          <div class="mt-4 border-t border-[#dbe7f5] pt-4">
+            <div class="flex items-center justify-between">
+              <span class="text-[14px] font-semibold text-[#4a5568]">최종 결제 금액</span>
+              <span class="text-[24px] font-bold text-[#2563eb]" id="finalTotalAmount">{{ final_total }}</span>
+            </div>
+          </div>
+        </div>
+
+        <button type="button" class="mt-6 inline-flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[15px] font-bold text-white shadow-[0_10px_24px_rgba(45,55,72,0.18)]">
+          주문하기
+        </button>
+      </aside>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var cartTab = document.getElementById('productsTabCart');
+  var wishlistTab = document.getElementById('productsTabWishlist');
+  var cartPanel = document.getElementById('productsPanelCart');
+  var wishlistPanel = document.getElementById('productsPanelWishlist');
+  var discountTotalRaw = {{ discount_total_raw }};
+  var shippingFeeRaw = {{ shipping_fee_raw }};
+
+  if (!cartTab || !wishlistTab || !cartPanel || !wishlistPanel) return;
+
+  function formatPrice(value) {
+    return new Intl.NumberFormat('ko-KR').format(value) + '원';
+  }
+
+  function updateCartSummary() {
+    var productTotal = 0;
+    document.querySelectorAll('[data-cart-item]').forEach(function (item) {
+      var unitPrice = Number(item.getAttribute('data-unit-price') || '0');
+      var quantityNode = item.querySelector('[data-cart-quantity]');
+      var quantity = quantityNode ? Number(quantityNode.textContent || '0') : 0;
+      var lineTotal = unitPrice * quantity;
+      var lineNode = item.querySelector('[data-cart-line-total]');
+      if (lineNode) {
+        lineNode.textContent = formatPrice(lineTotal);
+      }
+      productTotal += lineTotal;
+    });
+
+    var shippingFee = productTotal > 0 && productTotal < 30000 ? shippingFeeRaw : 0;
+    var finalTotal = Math.max(productTotal - discountTotalRaw, 0) + shippingFee;
+
+    var productTotalNode = document.getElementById('productTotalAmount');
+    var discountNode = document.getElementById('discountTotalAmount');
+    var shippingNode = document.getElementById('shippingFeeAmount');
+    var finalTotalNode = document.getElementById('finalTotalAmount');
+
+    if (productTotalNode) productTotalNode.textContent = formatPrice(productTotal);
+    if (discountNode) discountNode.textContent = '- ' + formatPrice(discountTotalRaw);
+    if (shippingNode) shippingNode.textContent = shippingFee === 0 ? '무료' : formatPrice(shippingFee);
+    if (finalTotalNode) finalTotalNode.textContent = formatPrice(finalTotal);
+  }
+
+  function setActiveTab(tab) {
+    var cartActive = tab === 'cart';
+    cartPanel.classList.toggle('is-active', cartActive);
+    wishlistPanel.classList.toggle('is-active', !cartActive);
+
+    cartTab.classList.toggle('bg-[#2d3748]', cartActive);
+    cartTab.classList.toggle('text-white', cartActive);
+    cartTab.classList.toggle('text-[#718096]', !cartActive);
+    cartTab.classList.toggle('hover:text-[#2d3748]', !cartActive);
+
+    wishlistTab.classList.toggle('bg-[#2d3748]', !cartActive);
+    wishlistTab.classList.toggle('text-white', !cartActive);
+    wishlistTab.classList.toggle('text-[#718096]', cartActive);
+    wishlistTab.classList.toggle('hover:text-[#2d3748]', cartActive);
+  }
+
+  cartTab.addEventListener('click', function () {
+    setActiveTab('cart');
+  });
+
+  wishlistTab.addEventListener('click', function () {
+    setActiveTab('wishlist');
+  });
+
+  window.adjustCartQuantity = function (button, delta) {
+    var item = button.closest('[data-cart-item]');
+    if (!item) return;
+    var quantityNode = item.querySelector('[data-cart-quantity]');
+    if (!quantityNode) return;
+
+    var current = Number(quantityNode.textContent || '1');
+    var next = Math.max(1, current + delta);
+    quantityNode.textContent = String(next);
+    updateCartSummary();
+  };
+
+  window.removeCartItem = function (button) {
+    var item = button.closest('[data-cart-item]');
+    if (!item) return;
+    item.remove();
+    updateCartSummary();
+  };
+
+  updateCartSummary();
+})();
+</script>
 {% endblock %}


### PR DESCRIPTION
## 요약
- Django Template 기준 장바구니 페이지 UI를 정리했습니다.
- 관심 상품 탭과 구매 내역 진입 구조를 함께 구성했습니다.
- 주문 정보 패널과 할인 혜택 선택 모달을 추가했습니다.
- 프론트 기준 장바구니 배지/상태 동기화를 정리했습니다.

## 포함 내용
- 장바구니 페이지 레이아웃 및 상품 카드 정리
- 관심 상품 탭 구성 및 탭 배지 정리
- 구매 내역 진입 구조 정리
- 주문 정보 패널 레이아웃 정리
- 할인 혜택 선택 모달 추가
- 장바구니 수량/배지 동기화 및 chat 연동 보강

## 확인 사항
- `/products/` 장바구니/관심 상품 탭 UI 확인
- 할인 혜택 적용 시 주문 정보 금액 갱신 확인
- 채팅 헤더/우측 패널 장바구니 배지 동기화 확인

## 관련 이슈
- Closes #130
