### PR TITLE
[feat] 장바구니 및 관심상품 저장/조회 구조 구현 (#173)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,11 +1,94 @@
 import json
 
+from django.db.models import Q
 from django.shortcuts import render
 from django.views.decorators.csrf import ensure_csrf_cookie
+
+from orders.models import Cart
+from products.models import Product
 
 
 def _format_price(value):
     return f"{value:,}원"
+
+
+def _display_product_name(brand_name, goods_name):
+    if not goods_name:
+        return ""
+
+    normalized_brand = (brand_name or "").strip()
+    normalized_name = goods_name.strip()
+
+    if normalized_brand and normalized_name.lower().startswith(normalized_brand.lower()):
+        trimmed = normalized_name[len(normalized_brand):].lstrip(" -_/|")
+        if trimmed:
+            return trimmed
+
+    return normalized_name
+
+
+def _single_product_queryset():
+    excluded_terms = [
+        "모음",
+        "모아보기",
+        "세트",
+        "BEST",
+        "color",
+        "Color",
+        "S-XL",
+        "S-M",
+        "SM-",
+        "2XL",
+        "3XL",
+        "4XL",
+        "무료배송",
+        "샘플",
+        "스쿱",
+    ]
+    query = Product.objects.filter(
+        soldout_yn=False,
+    ).filter(
+        Q(goods_name__icontains="영양제") | Q(goods_name__icontains="사료")
+    )
+
+    for term in excluded_terms:
+        query = query.exclude(goods_name__icontains=term)
+
+    return query.order_by("-review_count", "-discount_price", "goods_id")
+
+
+def _serialize_recommended_product(product):
+    final_price = product.discount_price or product.price
+    return {
+        "product_id": product.goods_id,
+        "name": _display_product_name(product.brand_name, product.goods_name),
+        "price": _format_price(product.price),
+        "discount_price": _format_price(final_price) if final_price != product.price else "",
+        "brand_name": product.brand_name,
+        "thumbnail_url": product.thumbnail_url,
+        "product_url": product.product_url,
+        "rating": str(product.rating or "0.0"),
+        "reviews": f"리뷰 {product.review_count}",
+    }
+
+
+def _serialize_cart_product(item):
+    product = item.product
+    price = product.discount_price or product.price
+    return {
+        "product_id": product.goods_id,
+        "name": _display_product_name(product.brand_name, product.goods_name),
+        "summary": "장바구니에 담긴 상품",
+        "price": _format_price(price),
+        "thumbnail_url": product.thumbnail_url,
+        "brand_name": product.brand_name,
+        "rating": str(product.rating or "0.0"),
+        "reviews": f"리뷰 {product.review_count}",
+        "quantity": item.quantity,
+        "unit_price": price,
+        "badge": "장바구니",
+        "accent": "bg-[#e9d5ff] text-[#7c3aed]",
+    }
 
 
 def _serialize_pet(pet):
@@ -394,6 +477,17 @@ def chat_view(request):
         registered_pet_count = request.user.pets.count()
         pets = request.user.pets.prefetch_related("health_concerns", "allergies", "food_preferences").order_by("created_at")[:5]
         member_pets = [_serialize_pet(pet) for pet in pets]
+        recommended_source = list(_single_product_queryset()[:6])
+        if recommended_source:
+            recommended_products = [_serialize_recommended_product(product) for product in recommended_source]
+
+        cart = Cart.objects.filter(user=request.user).prefetch_related("items__product").first()
+        if cart:
+            cart_products = [_serialize_cart_product(item) for item in cart.items.all().order_by("-added_at")]
+            cart_total = sum(product["unit_price"] * product["quantity"] for product in cart_products)
+        else:
+            cart_products = []
+            cart_total = 0
 
     future_pet = _serialize_future_pet(request.session.get("future_pet_profile"))
     if future_pet:

--- a/services/django/orders/migrations/0003_wishlist_wishlistitem.py
+++ b/services/django/orders/migrations/0003_wishlist_wishlistitem.py
@@ -1,0 +1,41 @@
+import uuid
+
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("orders", "0002_initial"),
+        ("products", "0001_initial"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Wishlist",
+            fields=[
+                ("wishlist_id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("user", models.OneToOneField(on_delete=django.db.models.deletion.CASCADE, to=settings.AUTH_USER_MODEL)),
+            ],
+            options={
+                "db_table": "wishlist",
+            },
+        ),
+        migrations.CreateModel(
+            name="WishlistItem",
+            fields=[
+                ("wishlist_item_id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("added_at", models.DateTimeField(auto_now_add=True)),
+                ("product", models.ForeignKey(on_delete=django.db.models.deletion.RESTRICT, related_name="wishlist_items", to="products.product")),
+                ("wishlist", models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name="items", to="orders.wishlist")),
+            ],
+            options={
+                "db_table": "wishlist_item",
+                "unique_together": {("wishlist", "product")},
+            },
+        ),
+    ]

--- a/services/django/orders/models.py
+++ b/services/django/orders/models.py
@@ -25,6 +25,26 @@ class CartItem(models.Model):
         unique_together = [("cart", "product")]
 
 
+class Wishlist(models.Model):
+    wishlist_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    user = models.OneToOneField(User, on_delete=models.CASCADE)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "wishlist"
+
+
+class WishlistItem(models.Model):
+    wishlist_item_id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    wishlist = models.ForeignKey(Wishlist, on_delete=models.CASCADE, related_name="items")
+    product = models.ForeignKey(Product, on_delete=models.RESTRICT, related_name="wishlist_items")
+    added_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        db_table = "wishlist_item"
+        unique_together = [("wishlist", "product")]
+
+
 class Order(models.Model):
     STATUS_CHOICES = [("pending", "주문 접수"), ("completed", "배송 완료"), ("cancelled", "취소")]
 

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -1,0 +1,131 @@
+from django.test import TestCase
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from products.models import Product
+from users.models import User
+
+from .models import Cart, CartItem, Wishlist, WishlistItem
+
+
+class CartApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(email="cart@example.com", password="Password123!")
+        self.client.force_authenticate(self.user)
+        self.product = Product.objects.create(
+            goods_id="GI1001",
+            goods_name="장바구니 테스트 상품",
+            brand_name="테스트 브랜드",
+            price=12000,
+            discount_price=9900,
+            thumbnail_url="https://example.com/cart-thumb.png",
+            product_url="https://example.com/cart-product",
+            crawled_at=timezone.now(),
+        )
+
+    def test_get_cart_returns_empty_defaults(self):
+        response = self.client.get("/api/orders/cart/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["items"], [])
+        self.assertEqual(response.data["item_count"], 0)
+        self.assertEqual(response.data["total_quantity"], 0)
+        self.assertTrue(Cart.objects.filter(user=self.user).exists())
+
+    def test_post_cart_adds_item(self):
+        response = self.client.post(
+            "/api/orders/cart/",
+            {"product_id": self.product.goods_id, "quantity": 2},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["cart_item"]["product_id"], self.product.goods_id)
+        self.assertEqual(response.data["cart_item"]["quantity"], 2)
+        self.assertTrue(CartItem.objects.filter(cart__user=self.user, product=self.product).exists())
+
+    def test_post_cart_existing_item_increments_quantity(self):
+        self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
+
+        response = self.client.post(
+            "/api/orders/cart/",
+            {"product_id": self.product.goods_id, "quantity": 3},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["cart_item"]["quantity"], 4)
+
+    def test_patch_cart_updates_quantity(self):
+        self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
+
+        response = self.client.patch(
+            "/api/orders/cart/",
+            {"product_id": self.product.goods_id, "quantity": 5},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["cart_item"]["quantity"], 5)
+
+    def test_delete_cart_removes_item(self):
+        self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
+
+        response = self.client.delete(
+            "/api/orders/cart/",
+            {"product_id": self.product.goods_id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(CartItem.objects.filter(cart__user=self.user, product=self.product).exists())
+
+
+class WishlistApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(email="wishlist@example.com", password="Password123!")
+        self.client.force_authenticate(self.user)
+        self.product = Product.objects.create(
+            goods_id="GI2001",
+            goods_name="관심상품 테스트 상품",
+            brand_name="테스트 브랜드",
+            price=18000,
+            discount_price=14900,
+            thumbnail_url="https://example.com/wishlist-thumb.png",
+            product_url="https://example.com/wishlist-product",
+            crawled_at=timezone.now(),
+        )
+
+    def test_get_wishlist_returns_empty_defaults(self):
+        response = self.client.get("/api/orders/wishlist/")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["items"], [])
+        self.assertEqual(response.data["item_count"], 0)
+        self.assertTrue(Wishlist.objects.filter(user=self.user).exists())
+
+    def test_post_wishlist_adds_item(self):
+        response = self.client.post(
+            "/api/orders/wishlist/",
+            {"product_id": self.product.goods_id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["wishlist_item"]["product_id"], self.product.goods_id)
+        self.assertTrue(WishlistItem.objects.filter(wishlist__user=self.user, product=self.product).exists())
+
+    def test_delete_wishlist_removes_item(self):
+        self.client.post("/api/orders/wishlist/", {"product_id": self.product.goods_id}, format="json")
+
+        response = self.client.delete(
+            "/api/orders/wishlist/",
+            {"product_id": self.product.goods_id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertFalse(WishlistItem.objects.filter(wishlist__user=self.user, product=self.product).exists())

--- a/services/django/orders/urls.py
+++ b/services/django/orders/urls.py
@@ -1,6 +1,8 @@
 from django.urls import path
-from .views import OrderListView
+from .views import CartView, OrderListView, WishlistView
 
 urlpatterns = [
     path("", OrderListView.as_view(), name="order-list"),
+    path("cart/", CartView.as_view(), name="order-cart"),
+    path("wishlist/", WishlistView.as_view(), name="order-wishlist"),
 ]

--- a/services/django/orders/views.py
+++ b/services/django/orders/views.py
@@ -1,8 +1,10 @@
 from django.db import transaction
+from rest_framework.authentication import SessionAuthentication
 from rest_framework import status
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
 
 from products.models import Product
 
@@ -92,6 +94,7 @@ class OrderListView(APIView):
 
 
 class CartView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -160,6 +163,7 @@ class CartView(APIView):
 
 
 class WishlistView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):

--- a/services/django/orders/views.py
+++ b/services/django/orders/views.py
@@ -1,7 +1,192 @@
-from rest_framework.views import APIView
+from django.db import transaction
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from products.models import Product
+
+from .models import Cart, CartItem, Wishlist, WishlistItem
+
+
+def serialize_product_summary(product: Product) -> dict:
+    price = product.discount_price or product.price
+    return {
+        "product_id": product.goods_id,
+        "name": product.goods_name,
+        "brand": product.brand_name,
+        "price": price,
+        "price_label": f"{price:,}원",
+        "rating": float(product.rating) if product.rating is not None else None,
+        "review_count": product.review_count,
+        "thumbnail_url": product.thumbnail_url,
+    }
+
+
+def serialize_cart_item(item: CartItem) -> dict:
+    product = item.product
+    summary = serialize_product_summary(product)
+    summary.update(
+        {
+            "cart_item_id": str(item.cart_item_id),
+            "quantity": item.quantity,
+            "line_total": summary["price"] * item.quantity,
+            "line_total_label": f"{summary['price'] * item.quantity:,}원",
+            "added_at": item.added_at.isoformat(),
+        }
+    )
+    return summary
+
+
+def serialize_wishlist_item(item: WishlistItem) -> dict:
+    product = item.product
+    summary = serialize_product_summary(product)
+    summary.update(
+        {
+            "wishlist_item_id": str(item.wishlist_item_id),
+            "added_at": item.added_at.isoformat(),
+        }
+    )
+    return summary
+
+
+def get_product_or_400(product_id):
+    if not product_id:
+        return None, Response({"detail": "product_id is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+    product = Product.objects.filter(goods_id=product_id).first()
+    if product is None:
+        return None, Response({"detail": "product not found."}, status=status.HTTP_404_NOT_FOUND)
+
+    return product, None
+
+
+def get_cart_response(user):
+    cart, _ = Cart.objects.get_or_create(user=user)
+    items = list(cart.items.select_related("product").order_by("-added_at"))
+    serialized_items = [serialize_cart_item(item) for item in items]
+    return Response(
+        {
+            "items": serialized_items,
+            "item_count": len(serialized_items),
+            "total_quantity": sum(item["quantity"] for item in serialized_items),
+        }
+    )
+
+
+def get_wishlist_response(user):
+    wishlist, _ = Wishlist.objects.get_or_create(user=user)
+    items = list(wishlist.items.select_related("product").order_by("-added_at"))
+    serialized_items = [serialize_wishlist_item(item) for item in items]
+    return Response(
+        {
+            "items": serialized_items,
+            "item_count": len(serialized_items),
+        }
+    )
 
 
 class OrderListView(APIView):
     def get(self, request):
         return Response({"message": "TODO"})
+
+
+class CartView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return get_cart_response(request.user)
+
+    @transaction.atomic
+    def post(self, request):
+        product, error_response = get_product_or_400(request.data.get("product_id"))
+        if error_response:
+            return error_response
+
+        quantity = int(request.data.get("quantity", 1) or 1)
+        if quantity < 1:
+            return Response({"detail": "quantity must be at least 1."}, status=status.HTTP_400_BAD_REQUEST)
+
+        cart, _ = Cart.objects.get_or_create(user=request.user)
+        cart_item, created = CartItem.objects.get_or_create(
+            cart=cart,
+            product=product,
+            defaults={"quantity": quantity},
+        )
+        if not created:
+            cart_item.quantity += quantity
+            cart_item.save(update_fields=["quantity"])
+
+        return Response(
+            {"cart_item": serialize_cart_item(cart_item)},
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+    @transaction.atomic
+    def patch(self, request):
+        product, error_response = get_product_or_400(request.data.get("product_id"))
+        if error_response:
+            return error_response
+
+        quantity = request.data.get("quantity")
+        if quantity is None:
+            return Response({"detail": "quantity is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        quantity = int(quantity)
+        if quantity < 1:
+            return Response({"detail": "quantity must be at least 1."}, status=status.HTTP_400_BAD_REQUEST)
+
+        cart, _ = Cart.objects.get_or_create(user=request.user)
+        cart_item = CartItem.objects.filter(cart=cart, product=product).select_related("product").first()
+        if cart_item is None:
+            return Response({"detail": "cart item not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        cart_item.quantity = quantity
+        cart_item.save(update_fields=["quantity"])
+        return Response({"cart_item": serialize_cart_item(cart_item)})
+
+    @transaction.atomic
+    def delete(self, request):
+        product, error_response = get_product_or_400(request.data.get("product_id"))
+        if error_response:
+            return error_response
+
+        cart, _ = Cart.objects.get_or_create(user=request.user)
+        deleted, _ = CartItem.objects.filter(cart=cart, product=product).delete()
+        if not deleted:
+            return Response({"detail": "cart item not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class WishlistView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return get_wishlist_response(request.user)
+
+    @transaction.atomic
+    def post(self, request):
+        product, error_response = get_product_or_400(request.data.get("product_id"))
+        if error_response:
+            return error_response
+
+        wishlist, _ = Wishlist.objects.get_or_create(user=request.user)
+        wishlist_item, created = WishlistItem.objects.get_or_create(wishlist=wishlist, product=product)
+        return Response(
+            {"wishlist_item": serialize_wishlist_item(wishlist_item)},
+            status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
+        )
+
+    @transaction.atomic
+    def delete(self, request):
+        product, error_response = get_product_or_400(request.data.get("product_id"))
+        if error_response:
+            return error_response
+
+        wishlist, _ = Wishlist.objects.get_or_create(user=request.user)
+        deleted, _ = WishlistItem.objects.filter(wishlist=wishlist, product=product).delete()
+        if not deleted:
+            return Response({"detail": "wishlist item not found."}, status=status.HTTP_404_NOT_FOUND)
+
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
+++ b/services/django/products/migrations/0002_product_embedding_product_embedding_text_and_more.py
@@ -3,6 +3,7 @@
 import django.contrib.postgres.indexes
 import django.contrib.postgres.search
 import pgvector.django.indexes
+import pgvector.django.extensions
 import pgvector.django.vector
 from django.db import migrations, models
 
@@ -14,6 +15,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        pgvector.django.extensions.VectorExtension(),
         migrations.AddField(
             model_name='product',
             name='embedding',

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -792,6 +792,7 @@
                     </div>
                     <button type="button"
                             class="flex h-[36px] w-[36px] shrink-0 items-center justify-center rounded-full bg-[#3182ce] text-white"
+                            data-product-id="{{ product.product_id|default:'' }}"
                             data-product-name="{{ product.name }}"
                             data-product-price="{{ product.price }}"
                             data-product-rating="{{ product.rating }}"
@@ -811,7 +812,7 @@
                 <div id="cartPanelList" class="space-y-[12px]">
                 {% for product in cart_products %}
                 <div class="group relative rounded-[20px] border border-[#dbe7f5] bg-white px-[14px] py-[13px] shadow-[0_8px_20px_rgba(45,55,72,0.05)]"
-                     data-cart-item data-unit-price="{{ product.unit_price }}" data-product-name="{{ product.name }}">
+                     data-cart-item data-unit-price="{{ product.unit_price }}" data-product-name="{{ product.name }}" data-goods-id="{{ product.product_id|default:'' }}" data-product-rating="{{ product.rating }}" data-product-reviews="{{ product.reviews }}">
                   <button type="button"
                           class="absolute right-[10px] top-[10px] flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white text-[14px] text-[#a0aec0] opacity-0 transition-opacity duration-150 group-hover:opacity-100"
                           onclick="removeCartItem(this)"
@@ -1069,6 +1070,34 @@
         return { detail: text };
       }
     });
+  }
+
+  function requestJson(url, options) {
+    var fetchOptions = Object.assign(
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfToken || '',
+        },
+        credentials: 'same-origin',
+      },
+      options || {}
+    );
+
+    return fetch(url, fetchOptions).then(function (res) {
+      return readJsonResponse(res).then(function (data) {
+        if (!res.ok) {
+          throw new Error((data && data.detail) || '요청 처리에 실패했습니다.');
+        }
+        return data;
+      });
+    });
+  }
+
+  function saveSharedCartCount(count) {
+    try {
+      window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
+    } catch (e) {}
   }
 
   function ensureSessionItem(session) {
@@ -1517,6 +1546,7 @@
         + '</div>'
         + '<button type="button"'
         + ' class="flex h-[36px] w-[36px] shrink-0 items-center justify-center rounded-full bg-[#3182ce] text-white shadow-[0_8px_18px_rgba(49,130,206,0.18)]"'
+        + ' data-product-id="' + (card.product_id || card.goods_id || '') + '"'
         + ' data-product-name="' + (card.product_name || '추천 상품') + '"'
         + ' data-product-price="' + finalPrice + '"'
         + ' data-product-rating="' + rating + '"'
@@ -1835,6 +1865,24 @@
     return item;
   }
 
+  function serializeCartItem(item) {
+    return {
+      goodsId: item.product_id || item.goodsId || '',
+      name: item.name || '상품',
+      price: Number(item.price || 0),
+      priceLabel: item.price_label || item.priceLabel || formatPrice(Number(item.price || 0)),
+      rating: item.rating || '0.0',
+      reviewCount: normalizeReviewCount(item.review_count || item.reviewCount || '0'),
+      reviews: '리뷰 ' + normalizeReviewCount(item.review_count || item.reviewCount || '0'),
+      quantity: Number(item.quantity || 1),
+      emoji: item.emoji || '🛍️',
+      brand: item.brand || '',
+      thumbnailUrl: item.thumbnail_url || item.thumbnailUrl || '',
+      note: item.note || '가격 비교를 위해 보관한 상품',
+      isWishlisted: !!item.is_wishlisted,
+    };
+  }
+
   function getCartState() {
     var items = [];
     document.querySelectorAll('[data-cart-item]').forEach(function (item) {
@@ -1863,21 +1911,41 @@
     if (!list) return;
     list.innerHTML = '';
     items.forEach(function (itemData) {
+      var serialized = serializeCartItem(itemData);
+      if (!serialized.goodsId) return;
       list.appendChild(buildCartItem({
-        goodsId: itemData.goodsId,
-        name: itemData.name,
-        unitPrice: Number(itemData.price || 0),
-        price: itemData.priceLabel || formatPrice(Number(itemData.price || 0)),
-        rating: itemData.rating || '0.0',
-        reviewCount: itemData.reviewCount || '0',
-        reviews: '리뷰 ' + normalizeReviewCount(itemData.reviewCount || '0'),
-        quantity: Number(itemData.quantity || 1),
-        emoji: itemData.emoji || '🛍️',
+        goodsId: serialized.goodsId,
+        name: serialized.name,
+        unitPrice: serialized.price,
+        price: serialized.priceLabel,
+        rating: serialized.rating,
+        reviewCount: serialized.reviewCount,
+        reviews: serialized.reviews,
+        quantity: serialized.quantity,
+        emoji: serialized.emoji,
       }));
     });
   }
 
-  function updateCartTotal() {
+  function refreshCartPanelFromApi(options) {
+    var config = options || {};
+    return requestJson('/api/orders/cart/')
+      .then(function (data) {
+        renderCartFromState(data.items || []);
+        if (config.syncShared) {
+          saveSharedCartItems((data.items || []).map(serializeCartItem));
+          saveSharedCartCount(Number(data.total_quantity || 0));
+        }
+        updateCartTotal(true);
+      })
+      .catch(function (error) {
+        if (!config.silent) {
+          window.alert(error.message || '장바구니 정보를 불러오지 못했습니다.');
+        }
+      });
+  }
+
+  function updateCartTotal(skipSharedSync) {
     var totalNode = document.getElementById('cartTotalAmount');
     var badgeNode = document.getElementById('cartCountBadge');
     var headerBadgeNode = document.getElementById('headerCartCountBadge');
@@ -1906,10 +1974,10 @@
         headerBadgeNode.classList.remove('inline-flex');
       }
     }
-    try {
-      window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
-    } catch (e) {}
-    saveSharedCartItems(getCartState());
+    if (!skipSharedSync) {
+      saveSharedCartCount(count);
+      saveSharedCartItems(getCartState());
+    }
     if (quickOrderModal && quickOrderModal.classList.contains('is-open')) {
       renderQuickOrderSummary();
     }
@@ -1954,6 +2022,7 @@
   window.adjustCartQuantity = function (button, delta) {
     var item = button.closest('[data-cart-item]');
     if (!item) return;
+    {% if is_preview_member %}
     var quantityNode = item.querySelector('[data-cart-quantity]');
     if (!quantityNode) return;
 
@@ -1961,13 +2030,40 @@
     var next = Math.max(1, current + delta);
     quantityNode.textContent = String(next);
     updateCartTotal();
+    return;
+    {% endif %}
+    var quantityNode = item.querySelector('[data-cart-quantity]');
+    var current = Number(quantityNode ? quantityNode.textContent || '1' : '1');
+    var next = Math.max(1, current + delta);
+    requestJson('/api/orders/cart/', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        product_id: item.getAttribute('data-goods-id'),
+        quantity: next,
+      }),
+    }).then(function () {
+      return refreshCartPanelFromApi({ silent: true, syncShared: true });
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니 수량을 변경하지 못했습니다.');
+    });
   };
 
   window.removeCartItem = function (button) {
     var item = button.closest('[data-cart-item]');
     if (!item) return;
+    {% if is_preview_member %}
     item.remove();
     updateCartTotal();
+    return;
+    {% endif %}
+    requestJson('/api/orders/cart/', {
+      method: 'DELETE',
+      body: JSON.stringify({ product_id: item.getAttribute('data-goods-id') }),
+    }).then(function () {
+      return refreshCartPanelFromApi({ silent: true, syncShared: true });
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니 상품을 삭제하지 못했습니다.');
+    });
   };
 
   window.addRecommendedToCart = function (button) {
@@ -1985,6 +2081,7 @@
       unitPrice: parsePrice(button.getAttribute('data-product-price')),
     };
 
+    {% if is_preview_member %}
     var existingItem = list.querySelector('[data-product-name="' + CSS.escape(product.name) + '"]');
     if (existingItem) {
       var quantityNode = existingItem.querySelector('[data-cart-quantity]');
@@ -1995,6 +2092,23 @@
       list.insertBefore(buildCartItem(product), list.firstChild);
     }
     updateCartTotal();
+    return;
+    {% endif %}
+    if (!product.goodsId) {
+      window.alert('현재 추천 상품은 장바구니 연동 준비 중입니다.');
+      return;
+    }
+    requestJson('/api/orders/cart/', {
+      method: 'POST',
+      body: JSON.stringify({
+        product_id: product.goodsId,
+        quantity: 1,
+      }),
+    }).then(function () {
+      return refreshCartPanelFromApi({ silent: true, syncShared: true });
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니에 상품을 담지 못했습니다.');
+    });
   };
 
   function renderPromoSlide() {
@@ -2427,6 +2541,7 @@
   }
 
   renderPromoSlide();
+  {% if is_preview_member %}
   var initialSharedCartItems = loadSharedCartItems();
   if (initialSharedCartItems.length) {
     renderCartFromState(initialSharedCartItems);
@@ -2434,6 +2549,9 @@
     saveSharedCartItems(getCartState());
   }
   updateCartTotal();
+  {% else %}
+  refreshCartPanelFromApi({ silent: true, syncShared: true });
+  {% endif %}
   applySharedCartCount();
   Object.keys(sessionThreads).forEach(ensureSessionState);
 
@@ -2444,7 +2562,11 @@
   startPromoAutoSlide();
 
   switchProductTab('recommended');
+  {% if chat_enabled %}
+  openProductPanel();
+  {% else %}
   hideProductPanel();
+  {% endif %}
   applyLayout();
   if (activePetId) {
     var initialPet = document.querySelector('[data-pet-id="' + CSS.escape(activePetId) + '"]');
@@ -2459,8 +2581,12 @@
       applySharedCartCount();
     }
     if (event.key === SHARED_CART_ITEMS_STORAGE_KEY) {
+      {% if is_preview_member %}
       renderCartFromState(loadSharedCartItems());
       updateCartTotal();
+      {% else %}
+      refreshCartPanelFromApi({ silent: true, syncShared: false });
+      {% endif %}
     }
   });
 

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -216,7 +216,7 @@
             <div class="flex items-center gap-3 md:flex-col md:items-end">
               <p class="text-[17px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
               <div class="flex items-center gap-2">
-                <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">
+                <button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white" onclick="addWishlistToCart(this)">
                   담기
                 </button>
               </div>
@@ -376,8 +376,6 @@
 {% block scripts %}
 <script>
 (function () {
-  var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
-  var SHARED_CART_ITEMS_STORAGE_KEY = 'tailtalk_shared_cart_items';
   var cartTab = document.getElementById('productsTabCart');
   var wishlistTab = document.getElementById('productsTabWishlist');
   var cartPanel = document.getElementById('productsPanelCart');
@@ -413,63 +411,48 @@
     return new Intl.NumberFormat('ko-KR').format(value) + '원';
   }
 
+  function getCsrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function requestJson(url, options) {
+    var fetchOptions = Object.assign(
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+      },
+      options || {}
+    );
+
+    return fetch(url, fetchOptions).then(function (response) {
+      return response.text().then(function (text) {
+        var data = {};
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch (e) {
+            data = {};
+          }
+        }
+        if (!response.ok) {
+          throw new Error(data.detail || '요청 처리에 실패했습니다.');
+        }
+        return data;
+      });
+    });
+  }
+
   function parsePrice(value) {
     return Number(String(value || '0').replace(/[^\d]/g, '')) || 0;
-  }
-
-  function saveSharedCartCount(count) {
-    try {
-      window.localStorage.setItem(SHARED_CART_COUNT_STORAGE_KEY, String(count));
-    } catch (e) {}
-  }
-
-  function loadSharedCartItems() {
-    try {
-      return JSON.parse(window.localStorage.getItem(SHARED_CART_ITEMS_STORAGE_KEY) || '[]');
-    } catch (e) {
-      return [];
-    }
-  }
-
-  function saveSharedCartItems(items) {
-    try {
-      window.localStorage.setItem(SHARED_CART_ITEMS_STORAGE_KEY, JSON.stringify(items));
-    } catch (e) {}
   }
 
   function normalizeReviewCount(value) {
     var digits = String(value || '').replace(/[^\d]/g, '');
     return digits || '0';
-  }
-
-  function getCatalogItemData(item) {
-    var unitPrice = Number(item.getAttribute('data-unit-price') || '0');
-    var priceLabel = item.getAttribute('data-price-label') || formatPrice(unitPrice);
-    if (!unitPrice) {
-      unitPrice = parsePrice(priceLabel);
-    }
-    return {
-      goodsId: item.getAttribute('data-goods-id') || '',
-      brand: item.getAttribute('data-brand') || '',
-      name: item.getAttribute('data-name') || '',
-      price: unitPrice,
-      priceLabel: priceLabel,
-      rating: item.getAttribute('data-rating') || '-',
-      reviewCount: normalizeReviewCount(item.getAttribute('data-review-count') || '0'),
-      thumbnailUrl: item.getAttribute('data-thumbnail-url') || '',
-      note: item.getAttribute('data-note') || '가격 비교를 위해 보관한 상품',
-      isWishlisted: item.classList.contains('is-active') || !!item.querySelector('.wishlist-heart.is-active'),
-    };
-  }
-
-  function buildProductCatalog() {
-    var catalog = {};
-    document.querySelectorAll('[data-cart-item], [data-wishlist-item]').forEach(function (item) {
-      var data = getCatalogItemData(item);
-      if (!data.goodsId) return;
-      catalog[data.goodsId] = Object.assign({}, catalog[data.goodsId] || {}, data);
-    });
-    return catalog;
   }
 
   function updateCartSummary() {
@@ -537,9 +520,6 @@
       cartCountBadge.textContent = String(cartCount);
       cartCountBadge.classList.toggle('hidden', cartCount === 0);
     }
-
-    saveSharedCartCount(cartCount);
-    saveSharedCartItems(getCartState());
 
     if (wishlistCountBadge) {
       wishlistCountBadge.textContent = String(wishlistCount);
@@ -677,6 +657,7 @@
       ' data-goods-id="' + escapeHtml(data.goodsId) + '"',
       ' data-brand="' + escapeHtml(data.brand) + '"',
       ' data-name="' + escapeHtml(data.name) + '"',
+      ' data-price="' + escapeHtml(data.price) + '"',
       ' data-price-label="' + escapeHtml(data.priceLabel) + '"',
       ' data-rating="' + escapeHtml(data.rating) + '"',
       ' data-review-count="' + escapeHtml(data.reviewCount) + '"',
@@ -696,7 +677,7 @@
       '<div class="mt-2 flex items-center gap-2 text-[11px]"><span class="font-bold text-[#d69e2e]">★ ' + escapeHtml(data.rating) + '</span><span class="text-[#a0aec0]">리뷰 ' + escapeHtml(data.reviewCount) + '</span></div>',
       '<p class="mt-2 text-[12px] text-[#4a5568]">' + escapeHtml(data.note) + '</p></div>',
       '<div class="flex items-center gap-3 md:flex-col md:items-end"><p class="text-[17px] font-bold text-[#2d3748]">' + escapeHtml(data.priceLabel) + '</p>',
-      '<div class="flex items-center gap-2"><button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">담기</button></div></div></div></article>'
+      '<div class="flex items-center gap-2"><button type="button" class="inline-flex h-[34px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white" onclick="addWishlistToCart(this)">담기</button></div></div></div></article>'
     ].join('');
   }
 
@@ -705,36 +686,13 @@
       goodsId: item.getAttribute('data-goods-id') || '',
       brand: item.getAttribute('data-brand') || '',
       name: item.getAttribute('data-name') || '',
+      price: Number(item.getAttribute('data-unit-price') || '0'),
       priceLabel: item.getAttribute('data-price-label') || '',
       rating: item.getAttribute('data-rating') || '-',
       reviewCount: item.getAttribute('data-review-count') || '0',
       thumbnailUrl: item.getAttribute('data-thumbnail-url') || '',
       note: item.getAttribute('data-note') || '가격 비교를 위해 보관한 상품',
     };
-  }
-
-  function syncCartHeart(goodsId, active) {
-    var cartItem = cartPanel.querySelector('[data-cart-item][data-goods-id="' + goodsId + '"]');
-    if (!cartItem) return;
-    var button = cartItem.querySelector('.wishlist-heart');
-    if (!button) return;
-    button.classList.toggle('is-active', active);
-  }
-
-  function addWishlistItem(data) {
-    if (wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + data.goodsId + '"]')) {
-      return;
-    }
-    wishlistPanel.insertAdjacentHTML('beforeend', wishlistItemMarkup(data));
-    updateTabCounts();
-  }
-
-  function removeWishlistItem(goodsId) {
-    var item = wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + goodsId + '"]');
-    if (item) {
-      item.remove();
-      updateTabCounts();
-    }
   }
 
   function setActiveTab(tab) {
@@ -767,26 +725,97 @@
     }
   }
 
+  function renderWishlistFromState(items) {
+    wishlistPanel.innerHTML = '';
+    items.forEach(function (item) {
+      wishlistPanel.insertAdjacentHTML('beforeend', wishlistItemMarkup({
+        goodsId: item.product_id || item.goodsId,
+        brand: item.brand || '',
+        name: item.name || '상품',
+        price: Number(item.price || 0),
+        priceLabel: item.price_label || item.priceLabel || formatPrice(Number(item.price || 0)),
+        rating: item.rating || '-',
+        reviewCount: normalizeReviewCount(item.review_count || item.reviewCount || '0'),
+        thumbnailUrl: item.thumbnail_url || item.thumbnailUrl || '',
+        note: item.note || '가격 비교를 위해 보관한 상품',
+      }));
+    });
+  }
+
+  function refreshProductsData() {
+    return Promise.all([
+      requestJson('/api/orders/cart/'),
+      requestJson('/api/orders/wishlist/'),
+    ]).then(function (results) {
+      var cartData = results[0];
+      var wishlistData = results[1];
+      var wishlistIds = {};
+      (wishlistData.items || []).forEach(function (item) {
+        wishlistIds[item.product_id] = true;
+      });
+
+      cartListViewport.innerHTML = '';
+      (cartData.items || []).forEach(function (item) {
+        cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup({
+          goodsId: item.product_id,
+          brand: item.brand || '',
+          name: item.name || '상품',
+          price: Number(item.price || 0),
+          priceLabel: item.price_label || formatPrice(Number(item.price || 0)),
+          rating: item.rating || '-',
+          reviewCount: normalizeReviewCount(item.review_count || '0'),
+          thumbnailUrl: item.thumbnail_url || '',
+          note: item.note || '가격 비교를 위해 보관한 상품',
+          quantity: Number(item.quantity || 1),
+          isWishlisted: !!wishlistIds[item.product_id],
+        }));
+      });
+
+      renderWishlistFromState(wishlistData.items || []);
+      updateCartSummary();
+      updateTabCounts();
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니 정보를 불러오지 못했습니다.');
+    });
+  }
+
   window.toggleWishlistHeart = function (button) {
+    if (!button) return;
     var cartItem = button.closest('[data-cart-item]');
     var wishlistItem = button.closest('[data-wishlist-item]');
 
     if (cartItem) {
-      var cartData = getCartItemData(cartItem);
-      var nextActive = !button.classList.contains('is-active');
-      button.classList.toggle('is-active', nextActive);
-      if (nextActive) {
-        addWishlistItem(cartData);
-      } else {
-        removeWishlistItem(cartData.goodsId);
+      var goodsId = cartItem.getAttribute('data-goods-id');
+      if (!goodsId) {
+        window.alert('상품 식별 정보를 찾을 수 없습니다.');
+        return;
       }
+      var nextActive = !button.classList.contains('is-active');
+      requestJson('/api/orders/wishlist/', {
+        method: nextActive ? 'POST' : 'DELETE',
+        body: JSON.stringify({ product_id: goodsId }),
+      }).then(function () {
+        return refreshProductsData();
+      }).catch(function (error) {
+        window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+      });
       return;
     }
 
     if (wishlistItem) {
       var goodsId = wishlistItem.getAttribute('data-goods-id');
-      wishlistItem.remove();
-      syncCartHeart(goodsId, false);
+      if (!goodsId) {
+        window.alert('상품 식별 정보를 찾을 수 없습니다.');
+        return;
+      }
+      requestJson('/api/orders/wishlist/', {
+        method: 'DELETE',
+        body: JSON.stringify({ product_id: goodsId }),
+      }).then(function () {
+        return refreshProductsData();
+      }).catch(function (error) {
+        window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+      });
     }
   };
 
@@ -806,17 +835,46 @@
 
     var current = Number(quantityNode.textContent || '1');
     var next = Math.max(1, current + delta);
-    quantityNode.textContent = String(next);
-    updateCartSummary();
-    updateTabCounts();
+    requestJson('/api/orders/cart/', {
+      method: 'PATCH',
+      body: JSON.stringify({
+        product_id: item.getAttribute('data-goods-id'),
+        quantity: next,
+      }),
+    }).then(function () {
+      return refreshProductsData();
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니 수량을 변경하지 못했습니다.');
+    });
   };
 
   window.removeCartItem = function (button) {
     var item = button.closest('[data-cart-item]');
     if (!item) return;
-    item.remove();
-    updateCartSummary();
-    updateTabCounts();
+    requestJson('/api/orders/cart/', {
+      method: 'DELETE',
+      body: JSON.stringify({ product_id: item.getAttribute('data-goods-id') }),
+    }).then(function () {
+      return refreshProductsData();
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니 상품을 삭제하지 못했습니다.');
+    });
+  };
+
+  window.addWishlistToCart = function (button) {
+    var item = button.closest('[data-wishlist-item]');
+    if (!item) return;
+    requestJson('/api/orders/cart/', {
+      method: 'POST',
+      body: JSON.stringify({
+        product_id: item.getAttribute('data-goods-id'),
+        quantity: 1,
+      }),
+    }).then(function () {
+      return refreshProductsData();
+    }).catch(function (error) {
+      window.alert(error.message || '장바구니에 상품을 담지 못했습니다.');
+    });
   };
 
   if (openDiscountModalBtn) {
@@ -880,59 +938,34 @@
   }
 
   var cartListViewport = document.getElementById('cartListViewport');
-  var productCatalog = buildProductCatalog();
-
-  function mergeCartItemData(sharedItem) {
-    var catalogItem = productCatalog[sharedItem.goodsId] || {};
-    return {
-      goodsId: sharedItem.goodsId || catalogItem.goodsId || '',
-      brand: sharedItem.brand || catalogItem.brand || '',
-      name: sharedItem.name || catalogItem.name || '상품',
-      price: Number(sharedItem.price || catalogItem.price || 0),
-      priceLabel: sharedItem.priceLabel || catalogItem.priceLabel || formatPrice(Number(sharedItem.price || catalogItem.price || 0)),
-      rating: sharedItem.rating || catalogItem.rating || '-',
-      reviewCount: normalizeReviewCount(sharedItem.reviewCount || catalogItem.reviewCount || '0'),
-      thumbnailUrl: sharedItem.thumbnailUrl || catalogItem.thumbnailUrl || '',
-      note: sharedItem.note || catalogItem.note || '가격 비교를 위해 보관한 상품',
-      quantity: Number(sharedItem.quantity || 1),
-      isWishlisted: typeof sharedItem.isWishlisted === 'boolean'
-        ? sharedItem.isWishlisted
-        : !!wishlistPanel.querySelector('[data-wishlist-item][data-goods-id="' + (sharedItem.goodsId || '') + '"]'),
-    };
-  }
 
   function renderCartFromState(items) {
     if (!cartListViewport) return;
     cartListViewport.innerHTML = '';
     items.forEach(function (item) {
-      var merged = mergeCartItemData(item);
-      if (!merged.goodsId) return;
-      cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup(merged));
+      var goodsId = item.product_id || item.goodsId;
+      if (!goodsId) return;
+      cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup({
+        goodsId: goodsId,
+        brand: item.brand || '',
+        name: item.name || '상품',
+        price: Number(item.price || 0),
+        priceLabel: item.price_label || item.priceLabel || formatPrice(Number(item.price || 0)),
+        rating: item.rating || '-',
+        reviewCount: normalizeReviewCount(item.review_count || item.reviewCount || '0'),
+        thumbnailUrl: item.thumbnail_url || item.thumbnailUrl || '',
+        note: item.note || '가격 비교를 위해 보관한 상품',
+        quantity: Number(item.quantity || 1),
+        isWishlisted: typeof item.is_wishlisted === 'boolean' ? item.is_wishlisted : !!item.isWishlisted,
+      }));
     });
     updateCartSummary();
     updateTabCounts();
   }
 
-  var initialSharedCartItems = loadSharedCartItems();
-  if (initialSharedCartItems.length) {
-    renderCartFromState(initialSharedCartItems);
-  } else {
-    saveSharedCartItems(getCartState());
-  }
-
   updateDiscountSummaryTexts();
   updateDiscountPreview();
-  updateCartSummary();
-  updateTabCounts();
-
-  window.addEventListener('storage', function (event) {
-    if (event.key === SHARED_CART_ITEMS_STORAGE_KEY) {
-      renderCartFromState(loadSharedCartItems());
-    }
-    if (event.key === SHARED_CART_COUNT_STORAGE_KEY && event.key !== SHARED_CART_ITEMS_STORAGE_KEY) {
-      updateTabCounts();
-    }
-  });
+  refreshProductsData();
 })();
 </script>
 {% endblock %}


### PR DESCRIPTION
## 요약
- 장바구니/관심상품 저장 및 조회 API를 구현했습니다.
- 브라우저 세션 로그인 기준으로 cart/wishlist API 인증을 허용했습니다.
- /products/ 와 /chat 우측 장바구니 패널을 서버 cart/wishlist API 기준으로 연결했습니다.

## 포함 내용
- Cart, Wishlist 기반 조회/변경 API 구현
- 장바구니 추가 / 수량 변경 / 삭제 처리
- 관심상품 추가 / 삭제 처리
- /products 장바구니/관심상품 화면 API 연동
- /chat 우측 장바구니 패널 cart API 연동

## 확인 사항
- python manage.py test orders --noinput 통과
- /products 에서 장바구니/관심상품 동작 확인
- /chat 우측 패널에서 cart API 연동 확인

## 참고
- 실제 채팅 세션/메시지 전송은 FastAPI 세션 API 미구현으로 별도 확인이 필요합니다.
