### PR TITLE
FastAPI 서브모듈 자동 동기화 워크플로 및 설정 문서 추가

### DIFF
--- a/.github/workflows/sync-fastapi-submodule.yml
+++ b/.github/workflows/sync-fastapi-submodule.yml
@@ -1,0 +1,90 @@
+name: Sync FastAPI Submodule
+
+on:
+  repository_dispatch:
+    types:
+      - fastapi-updated
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: sync-fastapi-submodule
+  cancel-in-progress: true
+
+env:
+  BASE_BRANCH: develop
+  SUBMODULE_PATH: services/fastapi
+  SUBMODULE_URL: https://github.com/skn-ai22-251029/SKN22-Final-2Team-AI
+  SUBMODULE_BRANCH: develop
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout web repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Sync and initialize submodule
+        run: |
+          git submodule sync -- "${SUBMODULE_PATH}"
+          git submodule update --init --recursive "${SUBMODULE_PATH}"
+
+      - name: Resolve target FastAPI commit
+        id: target
+        env:
+          PAYLOAD_SHA: ${{ github.event.client_payload.sha || '' }}
+          PAYLOAD_BRANCH: ${{ github.event.client_payload.branch || '' }}
+        run: |
+          set -eu
+
+          target_branch="${PAYLOAD_BRANCH:-$SUBMODULE_BRANCH}"
+          current_sha="$(git ls-tree HEAD "${SUBMODULE_PATH}" | awk '{print $3}')"
+
+          git -C "${SUBMODULE_PATH}" remote set-url origin "${SUBMODULE_URL}"
+          git -C "${SUBMODULE_PATH}" fetch --depth 1 origin "${target_branch}"
+
+          if [ -n "${PAYLOAD_SHA}" ]; then
+            target_sha="${PAYLOAD_SHA}"
+            git -C "${SUBMODULE_PATH}" fetch --depth 1 origin "${target_sha}"
+          else
+            target_sha="$(git -C "${SUBMODULE_PATH}" rev-parse "origin/${target_branch}")"
+          fi
+
+          echo "current_sha=${current_sha}" >> "$GITHUB_OUTPUT"
+          echo "target_sha=${target_sha}" >> "$GITHUB_OUTPUT"
+          echo "target_branch=${target_branch}" >> "$GITHUB_OUTPUT"
+
+          if [ "${current_sha}" = "${target_sha}" ]; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          git -C "${SUBMODULE_PATH}" checkout --detach "${target_sha}"
+          git add "${SUBMODULE_PATH}"
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+
+      - name: Create pull request
+        if: steps.target.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ github.token }}
+          commit-message: "chore: update fastapi submodule to ${{ steps.target.outputs.target_sha }}"
+          title: "chore: update fastapi submodule to ${{ steps.target.outputs.target_sha }}"
+          body: |
+            Automated submodule update for `${{ env.SUBMODULE_PATH }}`.
+
+            - Previous commit: `${{ steps.target.outputs.current_sha }}`
+            - New commit: `${{ steps.target.outputs.target_sha }}`
+            - Source branch: `${{ steps.target.outputs.target_branch }}`
+            - Trigger: `${{ github.event_name }}`
+          branch: bot/update-fastapi-submodule
+          base: ${{ env.BASE_BRANCH }}
+          delete-branch: true
+          labels: |
+            automation
+            submodule

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "services/fastapi"]
 	path = services/fastapi
 	url = https://github.com/skn-ai22-251029/SKN22-Final-2Team-AI
+	branch = develop

--- a/docs/infra/04_fastapi_workflow_secret_setup.md
+++ b/docs/infra/04_fastapi_workflow_secret_setup.md
@@ -1,0 +1,223 @@
+# FastAPI 워크플로 시크릿 설정 가이드
+
+## 목적
+
+이 문서는 `services/fastapi/.github/workflows/notify-web-repo.yml` 워크플로가 정상 동작하도록, 어떤 토큰을 어디서 발급하고 어느 저장소에 등록해야 하는지 정리한 문서이다.
+
+현재 기준으로는 `classic PAT` 사용을 기준으로 설명한다.
+
+현재 전제:
+
+- AI 저장소는 public 저장소
+- Web upstream 저장소는 `skn-ai22-251029/SKN22-Final-2Team-WEB`
+- AI 저장소에서 `develop` 브랜치 대상 PR이 merge되어 closed 되면
+- AI 저장소 워크플로가 Web upstream 저장소로 `repository_dispatch` 이벤트를 보냄
+- Web upstream 저장소가 이 이벤트를 받아 `services/fastapi` 서브모듈 포인터 업데이트 PR을 생성함
+
+## 전체 흐름
+
+1. AI 저장소에서 `develop` 대상 PR이 merge되어 closed 됨
+2. AI 저장소 워크플로 `notify-web-repo.yml` 실행
+3. AI 저장소에 저장된 시크릿 `WEB_REPO_DISPATCH_TOKEN`으로 Web upstream 저장소 GitHub API 호출
+4. Web upstream 저장소에서 `fastapi-updated` 이벤트 수신
+5. Web upstream 저장소 워크플로 `sync-fastapi-submodule.yml` 실행
+6. Web upstream 저장소가 `services/fastapi` 서브모듈 포인터 변경 PR 생성
+
+## 필요한 시크릿
+
+현재 구조에서 추가로 필요한 시크릿은 하나뿐이다.
+
+- 이름: `WEB_REPO_DISPATCH_TOKEN`
+- 등록 위치: AI 저장소 GitHub Actions Secrets
+- 용도: AI 저장소가 Web upstream 저장소로 `repository_dispatch` 이벤트를 보내기 위한 인증
+
+## 왜 이 토큰이 필요한가
+
+AI 저장소 워크플로는 아래 API를 호출한다.
+
+```text
+POST https://api.github.com/repos/skn-ai22-251029/SKN22-Final-2Team-WEB/dispatches
+```
+
+이 호출은 AI 저장소 내부 작업이 아니라, 다른 저장소인 Web upstream 저장소에 이벤트를 보내는 작업이다.
+
+기본 `GITHUB_TOKEN`은 일반적으로 현재 실행 중인 저장소 범위 안에서만 동작하므로, 다른 저장소에 `repository_dispatch`를 보내는 용도로 쓰기 어렵다.
+
+그래서 Web upstream 저장소에 접근 가능한 별도 토큰을 AI 저장소 시크릿으로 넣어야 한다.
+
+## 어떤 토큰을 발급해야 하는가
+
+현재 상황에서는 `classic PAT`를 사용하는 것이 가장 현실적이다.
+
+권장 토큰 종류:
+
+- Personal access token (classic)
+
+이유:
+
+- upstream 저장소가 fine-grained token의 `Only select repositories` 목록에 보이지 않을 수 있음
+- `repository_dispatch` 호출을 빠르게 구성하기에 classic PAT가 단순함
+- 현재 목적은 AI 저장소에서 Web upstream 저장소로 이벤트를 보내는 것임
+
+## 토큰 발급 방법
+
+### 1. GitHub에서 classic PAT 발급 페이지로 이동
+
+GitHub 웹에서 아래 순서로 이동한다.
+
+1. 우측 상단 프로필 클릭
+2. `Settings`
+3. 왼쪽 메뉴 하단 `Developer settings`
+4. `Personal access tokens`
+5. `Tokens (classic)`
+6. `Generate new token`
+
+### 2. 토큰 기본 정보 입력
+
+예시:
+
+- Token name: `ai-to-web-dispatch-classic`
+- Expiration: 적절한 기간 선택
+
+### 3. Scope 설정
+
+최소한 아래 scope를 체크한다.
+
+- `repo`
+
+이 scope를 주면 Web upstream 저장소에 `repository_dispatch`를 보내는 용도로 가장 덜 애매하게 동작한다.
+
+### 4. 토큰 생성 후 값 복사
+
+토큰은 생성 직후 한 번만 전체 값을 볼 수 있다.
+
+반드시 생성 직후 복사해서 안전한 곳에 보관해야 한다.
+
+## 토큰을 어디에 넣어야 하는가
+
+이 토큰은 Web upstream 저장소가 아니라 AI 저장소에 넣어야 한다.
+
+등록 위치:
+
+1. AI 저장소 GitHub 페이지로 이동
+2. `Settings`
+3. 왼쪽 메뉴 `Secrets and variables`
+4. `Actions`
+5. `New repository secret`
+
+입력값:
+
+- Name: `WEB_REPO_DISPATCH_TOKEN`
+- Secret: 방금 발급한 토큰 값
+
+## AI 저장소 워크플로에서 이 토큰을 어떻게 쓰는가
+
+현재 AI 저장소에 추가한 워크플로 파일:
+
+- `services/fastapi/.github/workflows/notify-web-repo.yml`
+
+핵심 부분:
+
+```yaml
+env:
+  WEB_REPO_DISPATCH_TOKEN: ${{ secrets.WEB_REPO_DISPATCH_TOKEN }}
+```
+
+이 값으로 아래 API를 호출한다.
+
+```yaml
+curl -X POST \
+  -H "Accept: application/vnd.github+json" \
+  -H "Authorization: Bearer ${WEB_REPO_DISPATCH_TOKEN}" \
+  https://api.github.com/repos/skn-ai22-251029/SKN22-Final-2Team-WEB/dispatches \
+  -d '{
+    "event_type": "fastapi-updated",
+    "client_payload": {
+      "branch": "develop",
+      "sha": "'"${{ github.event.pull_request.merge_commit_sha }}"'"
+    }
+  }'
+```
+
+## Web upstream 저장소에는 어떤 시크릿이 필요한가
+
+현재 기준으로는 별도 추가 시크릿이 꼭 필요하지 않다.
+
+이유:
+
+- AI 저장소는 public 저장소
+- Web upstream 저장소 워크플로는 public AI 저장소를 읽어 서브모듈 최신 커밋을 가져올 수 있음
+- Web upstream 저장소의 PR 생성은 기본 `github.token`으로 처리하도록 구성해 둠
+
+즉, 현재 구조에서 새로 직접 등록해야 하는 시크릿은 AI 저장소의 `WEB_REPO_DISPATCH_TOKEN` 하나다.
+
+## 실제 설정 후 확인 방법
+
+### 1. AI 저장소 워크플로 파일이 커밋되어 있어야 함
+
+AI 저장소에 아래 파일이 있어야 한다.
+
+- `services/fastapi/.github/workflows/notify-web-repo.yml`
+
+### 2. AI 저장소에 시크릿 등록
+
+- `WEB_REPO_DISPATCH_TOKEN`
+
+### 3. AI 저장소에서 `develop` 대상 PR merge
+
+PR이 정상적으로 merge되어 closed 되면 AI 저장소 워크플로가 실행된다.
+
+### 4. Web upstream 저장소 Actions 확인
+
+Web upstream 저장소에서 아래 워크플로가 실행되는지 확인한다.
+
+- `.github/workflows/sync-fastapi-submodule.yml`
+
+### 5. Web upstream 저장소 PR 생성 확인
+
+정상이라면 Web upstream 저장소에 아래 형태의 PR이 자동 생성된다.
+
+- 브랜치: `bot/update-fastapi-submodule`
+- 제목: `chore: update fastapi submodule to <sha>`
+
+## 실패 시 점검 포인트
+
+### 1. AI 저장소 시크릿 이름 오타
+
+아래 이름이 정확히 일치해야 한다.
+
+```text
+WEB_REPO_DISPATCH_TOKEN
+```
+
+### 2. 토큰 권한 부족
+
+Web upstream 저장소에 대한 권한이 너무 약하면 `repository_dispatch` 호출이 실패할 수 있다.
+
+classic PAT 기준으로는 아래 scope가 가장 안전하다.
+
+- `repo`
+
+### 3. 조직 정책으로 classic PAT가 막혀 있음
+
+조직에서 classic PAT 접근을 제한해두었다면 이 방식도 실패할 수 있다.
+
+이 경우 조직 관리자 정책 확인이 필요하다.
+
+### 4. AI 저장소 워크플로가 `develop`에 없거나 아직 푸시되지 않음
+
+워크플로 파일이 로컬에만 있고 AI 저장소 원격에 반영되지 않았다면 동작하지 않는다.
+
+### 5. Web upstream 저장소 워크플로 파일이 아직 반영되지 않음
+
+Web upstream 저장소에도 아래 파일이 반영되어 있어야 한다.
+
+- `.github/workflows/sync-fastapi-submodule.yml`
+
+## 참고
+
+fine-grained PAT도 원칙적으로 더 안전한 방식이지만, 현재처럼 upstream 저장소가 토큰 대상 목록에 보이지 않는 상황에서는 classic PAT가 더 현실적인 대안이다.
+
+## 한 줄 정리
+
+FastAPI 워크플로를 실제로 동작시키려면, GitHub에서 classic PAT를 발급하고 `repo` scope를 준 뒤 AI 저장소의 Actions Secret에 `WEB_REPO_DISPATCH_TOKEN` 이름으로 등록하면 된다.

--- a/docs/infra/05_eb_env_var_guide.md
+++ b/docs/infra/05_eb_env_var_guide.md
@@ -1,0 +1,301 @@
+# 테스트 배포 환경 `.env` 및 EB 환경변수 정리
+
+## 목적
+
+이 문서는 현재 테스트 배포 구조에서 아래 두 가지를 구분해서 정리한 문서이다.
+
+1. 배포 zip 내부의 `.env` 파일에 들어가야 하는 값
+2. Elastic Beanstalk 환경에 등록해 두어야 하는 환경변수 key
+
+현재 기준 배포 대상:
+
+- Django + nginx: `test-tailtalk-django-env`
+- FastAPI: `test-tailtalk-fastapi-env`
+
+## 핵심 원칙
+
+현재 CI/CD 구조에서는 배포 zip 안의 `.env`에는 주로 **이미지 태그**만 넣고, 실제 운영 설정값은 **Elastic Beanstalk 환경변수**로 관리하는 방식이다.
+
+즉:
+
+- 배포 zip `.env` = 어떤 Docker 이미지를 띄울지
+- EB 환경변수 = 앱이 실제로 실행될 때 필요한 설정값
+
+## 1. 배포 zip 안 `.env`에 필요한 값
+
+### nginx 폴더
+
+nginx는 현재 별도 `.env`가 필요하지 않다.
+
+이유:
+
+- `deploy/eb/test-django/nginx/nginx.conf`는 환경변수를 읽지 않음
+- nginx 컨테이너는 정적 설정 파일만 마운트해서 사용함
+
+즉, nginx 폴더에는 `.env`가 필요 없다.
+
+### Django 배포 폴더
+
+현재 구조에서 Django 배포 zip 내부 `.env`에 최소한 필요한 값은 아래 하나다.
+
+```text
+DJANGO_IMAGE=<도커허브_이미지:태그>
+```
+
+예시:
+
+```text
+DJANGO_IMAGE=kimheejoon91/test-tailtalk-django:72a1915
+```
+
+현재 CI/CD도 이 방식으로 `.env`를 생성해서 zip에 포함한다.
+
+### FastAPI 배포 폴더
+
+현재 구조에서 FastAPI 배포 zip 내부 `.env`에 최소한 필요한 값은 아래 하나다.
+
+```text
+FASTAPI_IMAGE=<도커허브_이미지:태그>
+```
+
+예시:
+
+```text
+FASTAPI_IMAGE=kimheejoon91/test-tailtalk-fastapi:b3bba0d
+```
+
+현재 CI/CD도 이 방식으로 `.env`를 생성해서 zip에 포함한다.
+
+## 2. Elastic Beanstalk 환경에 등록해야 하는 환경변수
+
+아래는 **애플리케이션 실행에 필요한 값**이며, 배포 zip `.env`가 아니라 **Elastic Beanstalk 환경변수**에 넣어 두는 것을 기준으로 정리했다.
+
+---
+
+## Django + nginx 환경에 등록할 변수
+
+대상 환경:
+
+- `test-tailtalk-django-env`
+
+### 필수
+
+아래 값들은 현재 Django 설정상 사실상 필수다.
+
+```text
+DJANGO_SECRET_KEY
+POSTGRES_DB
+POSTGRES_USER
+POSTGRES_PASSWORD
+POSTGRES_HOST
+FASTAPI_INTERNAL_CHAT_URL
+INTERNAL_SERVICE_TOKEN
+```
+
+설명:
+
+- `DJANGO_SECRET_KEY`: Django 앱 실행 필수
+- `POSTGRES_DB`: PostgreSQL DB 이름
+- `POSTGRES_USER`: PostgreSQL 사용자명
+- `POSTGRES_PASSWORD`: PostgreSQL 비밀번호
+- `POSTGRES_HOST`: PostgreSQL 호스트
+- `FASTAPI_INTERNAL_CHAT_URL`: Django가 FastAPI 내부 API를 호출할 주소
+- `INTERNAL_SERVICE_TOKEN`: Django와 FastAPI 간 내부 인증 토큰
+
+### 권장
+
+아래 값들은 운영 편의를 위해 넣는 것이 좋다.
+
+```text
+DJANGO_ALLOWED_HOSTS
+POSTGRES_PORT
+APP_BASE_URL
+DJANGO_DEBUG
+CORS_ALLOWED_ORIGINS
+DJANGO_SECURE_SSL_REDIRECT
+DJANGO_SESSION_COOKIE_SECURE
+DJANGO_CSRF_COOKIE_SECURE
+SOCIAL_AUTH_REQUESTS_TIMEOUT
+```
+
+설명:
+
+- `DJANGO_ALLOWED_HOSTS`: 기본값은 `*`지만 명시하는 편이 안전함
+- `POSTGRES_PORT`: 기본값은 `5432`
+- `APP_BASE_URL`: OAuth 콜백 URL 생성에 중요
+- `DJANGO_DEBUG`: 기본값은 `False`
+- `CORS_ALLOWED_ORIGINS`: 프론트엔드 도메인 허용 시 필요
+- `DJANGO_SECURE_SSL_REDIRECT`: HTTPS 리다이렉트 여부
+- `DJANGO_SESSION_COOKIE_SECURE`: 세션 쿠키 보안 설정
+- `DJANGO_CSRF_COOKIE_SECURE`: CSRF 쿠키 보안 설정
+- `SOCIAL_AUTH_REQUESTS_TIMEOUT`: 소셜 로그인 API 타임아웃, 기본값 `10`
+
+### OAuth 사용 시 필수
+
+소셜 로그인 기능을 사용할 경우 아래 값들을 반드시 등록해야 한다.
+
+```text
+GOOGLE_CLIENT_ID
+GOOGLE_CLIENT_SECRET
+NAVER_CLIENT_ID
+NAVER_CLIENT_SECRET
+KAKAO_CLIENT_ID
+KAKAO_CLIENT_SECRET
+```
+
+주의:
+
+- OAuth 키가 없으면 `/auth/<provider>/start/`는 라우트는 살아 있어도 정상 로그인 진행이 안 됨
+- `APP_BASE_URL`이 비어 있으면 콜백 URL이 의도와 다르게 생성될 수 있음
+
+### S3 업로드 사용 시 필요
+
+사용하는 경우에만 넣으면 된다.
+
+```text
+AWS_S3_BUCKET_NAME
+AWS_S3_REGION_NAME
+AWS_S3_CUSTOM_DOMAIN
+AWS_S3_ENDPOINT_URL
+AWS_ACCESS_KEY_ID
+AWS_SECRET_ACCESS_KEY
+```
+
+현재 코드 기준으로는 S3 관련 기능이 항상 강제되지는 않는다.
+
+### 선택
+
+```text
+USE_SQLITE
+SQLITE_NAME
+```
+
+설명:
+
+- 테스트나 임시 환경에서 PostgreSQL 대신 SQLite를 사용할 때만 필요
+- 현재 배포 구조에서는 일반적으로 사용하지 않음
+
+---
+
+## FastAPI 환경에 등록할 변수
+
+대상 환경:
+
+- `test-tailtalk-fastapi-env`
+
+### 필수
+
+현재 Docker Compose 기준으로 최소한 아래 값들은 준비되어 있어야 한다.
+
+```text
+POSTGRES_DB
+POSTGRES_USER
+POSTGRES_PASSWORD
+POSTGRES_HOST
+INTERNAL_SERVICE_TOKEN
+```
+
+설명:
+
+- `POSTGRES_DB`: PostgreSQL DB 이름
+- `POSTGRES_USER`: PostgreSQL 사용자명
+- `POSTGRES_PASSWORD`: PostgreSQL 비밀번호
+- `POSTGRES_HOST`: PostgreSQL 호스트
+- `INTERNAL_SERVICE_TOKEN`: Django와 FastAPI 간 내부 인증 토큰
+
+### 권장
+
+```text
+POSTGRES_PORT
+OPENAI_API_KEY
+QDRANT_HOST
+QDRANT_PORT
+```
+
+설명:
+
+- `POSTGRES_PORT`: 기본값은 `5432`
+- `OPENAI_API_KEY`: OpenAI 호출 기능 사용 시 필요
+- `QDRANT_HOST`: Qdrant 사용 시 필요
+- `QDRANT_PORT`: 기본값은 `6333`
+
+주의:
+
+- 기능에 따라 `OPENAI_API_KEY`, `QDRANT_HOST`, `QDRANT_PORT`가 없으면 일부 API가 정상 동작하지 않을 수 있음
+- 현재 compose 파일에서는 기본값이 있어 컨테이너는 뜰 수 있지만, 실제 기능은 제한될 수 있음
+
+---
+
+## 3. 현재 구조 기준 권장 운영 방식
+
+현재 구조에서는 아래처럼 운영하는 것이 가장 명확하다.
+
+### 배포 zip `.env`
+
+- Django: `DJANGO_IMAGE`만 포함
+- FastAPI: `FASTAPI_IMAGE`만 포함
+- nginx: `.env` 없음
+
+### EB 환경변수
+
+- 앱 실행에 필요한 실제 값 전부 등록
+- DB 접속 정보
+- 내부 인증 토큰
+- OAuth 키
+- OpenAI 키
+- 기타 운영 설정값
+
+## 4. 예시
+
+### Django 배포 zip용 `.env`
+
+```text
+DJANGO_IMAGE=kimheejoon91/test-tailtalk-django:72a1915
+```
+
+### FastAPI 배포 zip용 `.env`
+
+```text
+FASTAPI_IMAGE=kimheejoon91/test-tailtalk-fastapi:b3bba0d
+```
+
+### Django EB 환경변수 예시
+
+```text
+DJANGO_SECRET_KEY=...
+DJANGO_DEBUG=False
+DJANGO_ALLOWED_HOSTS=*
+APP_BASE_URL=https://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
+POSTGRES_DB=tailtalk
+POSTGRES_USER=tailtalk
+POSTGRES_PASSWORD=...
+POSTGRES_HOST=...
+POSTGRES_PORT=5432
+FASTAPI_INTERNAL_CHAT_URL=http://test-tailtalk-fastapi-env.eba-5ymgtjp9.ap-northeast-2.elasticbeanstalk.com/api/chat/
+INTERNAL_SERVICE_TOKEN=...
+CORS_ALLOWED_ORIGINS=
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+NAVER_CLIENT_ID=...
+NAVER_CLIENT_SECRET=...
+KAKAO_CLIENT_ID=...
+KAKAO_CLIENT_SECRET=...
+```
+
+### FastAPI EB 환경변수 예시
+
+```text
+POSTGRES_DB=tailtalk
+POSTGRES_USER=tailtalk
+POSTGRES_PASSWORD=...
+POSTGRES_HOST=...
+POSTGRES_PORT=5432
+INTERNAL_SERVICE_TOKEN=...
+OPENAI_API_KEY=...
+QDRANT_HOST=...
+QDRANT_PORT=6333
+```
+
+## 5. 한 줄 정리
+
+현재 테스트 배포 구조에서는 **배포 zip 안 `.env`에는 이미지 태그만 넣고**, 실제 앱 실행에 필요한 값은 **Elastic Beanstalk 환경변수에 등록하는 방식**으로 관리하면 된다.


### PR DESCRIPTION
## 요약
  AI 저장소의 머지 이벤트를 받아 FastAPI 서브모듈 포인터 업데이트 PR을 자동 생성하는 워크플로를 추가했습니다.

  ## 변경 사항
  - `.github/workflows/sync-fastapi-submodule.yml` 파일을 추가했습니다.
  - `fastapi-updated` `repository_dispatch` 이벤트를 수신하면 동작하도록 설정했습니다.
  - 전달받은 SHA 기준으로 `services/fastapi` 서브모듈 포인터를 갱신하도록 구성했습니다.
  - `.gitmodules`에 `services/fastapi` 서브모듈의 추적 브랜치를 `develop`으로 명시했습니다.
  - `docs/infra/04_fastapi_workflow_secret_setup.md` 문서를 추가했습니다.

  ## 관련 이슈
  <!-- 완전 해결: closes #번호 / 부분 관련: ref #번호 -->

  ## 체크리스트
  - [x] 변경 사항이 의도한 대로 동작함을 확인했다
  - [x] 관련 문서를 업데이트했다

  ## 리뷰 요청 사항
  - Web upstream 저장소에서 `repository_dispatch` 수신 후 PR 생성까지 정상 동작하는지 확인 부탁드립니다.