### PR TITLE
chore(eb): develop 머지 기준 테스트 EB 배포 및 환경변수 처리 정리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,7 +5,7 @@ on:
     types:
       - closed
     branches:
-      - main
+      - develop
 
 permissions:
   contents: read
@@ -106,12 +106,16 @@ jobs:
         run: |
           rm -rf .deploy-fastapi fastapi-deploy.zip
           mkdir -p .deploy-fastapi
-          cp deploy/eb/test-fastapi/docker-compose.yml .deploy-fastapi/docker-compose.yml
-          cat <<EOF > .deploy-fastapi/.env
-          FASTAPI_IMAGE=${{ env.FASTAPI_IMAGE_REPO }}:${{ steps.fastapi-meta.outputs.short_sha }}
-          EOF
+          python3 - <<'PY'
+          from pathlib import Path
+          src = Path("deploy/eb/test-fastapi/docker-compose.yml").read_text()
+          image = "${{ env.FASTAPI_IMAGE_REPO }}:${{ steps.fastapi-meta.outputs.short_sha }}"
+          Path(".deploy-fastapi/docker-compose.yml").write_text(
+              src.replace("__FASTAPI_IMAGE__", image)
+          )
+          PY
           cd .deploy-fastapi
-          zip -r ../fastapi-deploy.zip docker-compose.yml .env
+          zip -r ../fastapi-deploy.zip docker-compose.yml
 
       - name: Deploy FastAPI to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v22
@@ -168,13 +172,17 @@ jobs:
         run: |
           rm -rf .deploy-django django-deploy.zip
           mkdir -p .deploy-django
-          cp deploy/eb/test-django/docker-compose.yml .deploy-django/docker-compose.yml
+          python3 - <<'PY'
+          from pathlib import Path
+          src = Path("deploy/eb/test-django/docker-compose.yml").read_text()
+          image = "${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}"
+          Path(".deploy-django/docker-compose.yml").write_text(
+              src.replace("__DJANGO_IMAGE__", image)
+          )
+          PY
           cp -r deploy/eb/test-django/nginx .deploy-django/nginx
-          cat <<EOF > .deploy-django/.env
-          DJANGO_IMAGE=${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}
-          EOF
           cd .deploy-django
-          zip -r ../django-deploy.zip docker-compose.yml nginx .env
+          zip -r ../django-deploy.zip docker-compose.yml nginx
 
       - name: Deploy Django to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v22

--- a/deploy/eb/test-django/docker-compose.yml
+++ b/deploy/eb/test-django/docker-compose.yml
@@ -11,41 +11,14 @@ services:
     restart: unless-stopped
 
   django:
-    image: ${DJANGO_IMAGE:-kimheejoon91/test-tailtalk-django:latest}
+    image: __DJANGO_IMAGE__
     platform: linux/amd64
     command: >
       sh -c "python manage.py migrate --noinput &&
              python manage.py collectstatic --noinput &&
              gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
-    environment:
-      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
-      DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
-      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
-      APP_BASE_URL: ${APP_BASE_URL:-}
-      FASTAPI_INTERNAL_CHAT_URL: ${FASTAPI_INTERNAL_CHAT_URL}
-      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_HOST: ${POSTGRES_HOST}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
-      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
-      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
-      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
-      NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:-}
-      NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:-}
-      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID:-}
-      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-}
-      SOCIAL_AUTH_REQUESTS_TIMEOUT: ${SOCIAL_AUTH_REQUESTS_TIMEOUT:-10}
-      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-False}
-      DJANGO_SESSION_COOKIE_SECURE: ${DJANGO_SESSION_COOKIE_SECURE:-False}
-      DJANGO_CSRF_COOKIE_SECURE: ${DJANGO_CSRF_COOKIE_SECURE:-False}
-      AWS_S3_BUCKET_NAME: ${AWS_S3_BUCKET_NAME:-}
-      AWS_S3_REGION_NAME: ${AWS_S3_REGION_NAME:-}
-      AWS_S3_CUSTOM_DOMAIN: ${AWS_S3_CUSTOM_DOMAIN:-}
-      AWS_S3_ENDPOINT_URL: ${AWS_S3_ENDPOINT_URL:-}
-      AWS_ACCESS_KEY_ID: ${AWS_ACCESS_KEY_ID:-}
-      AWS_SECRET_ACCESS_KEY: ${AWS_SECRET_ACCESS_KEY:-}
+    env_file:
+      - .env
     expose:
       - "8000"
     restart: unless-stopped

--- a/deploy/eb/test-fastapi/docker-compose.yml
+++ b/deploy/eb/test-fastapi/docker-compose.yml
@@ -1,18 +1,10 @@
 services:
   fastapi:
-    image: ${FASTAPI_IMAGE:-kimheejoon91/test-tailtalk-fastapi:latest}
+    image: __FASTAPI_IMAGE__
     platform: linux/amd64
     command: uvicorn main:app --host 0.0.0.0 --port 8001 --workers 2
-    environment:
-      POSTGRES_DB: ${POSTGRES_DB}
-      POSTGRES_USER: ${POSTGRES_USER}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
-      POSTGRES_HOST: ${POSTGRES_HOST}
-      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
-      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
-      QDRANT_HOST: ${QDRANT_HOST:-}
-      QDRANT_PORT: ${QDRANT_PORT:-6333}
+    env_file:
+      - .env
     ports:
       - "80:8001"
     restart: unless-stopped

--- a/docs/infra/05_eb_env_var_guide.md
+++ b/docs/infra/05_eb_env_var_guide.md
@@ -1,301 +1,273 @@
-# 테스트 배포 환경 `.env` 및 EB 환경변수 정리
+# Elastic Beanstalk 환경변수 입력 가이드
 
 ## 목적
 
-이 문서는 현재 테스트 배포 구조에서 아래 두 가지를 구분해서 정리한 문서이다.
+이 문서는 테스트 Elastic Beanstalk 환경에서 프로젝트 실행에 필요한 환경변수를 어디에 넣어야 하는지, AWS 콘솔에서 어떻게 입력하는지, Django/FastAPI 각각 어떤 키가 필요한지를 정리한 문서이다.
 
-1. 배포 zip 내부의 `.env` 파일에 들어가야 하는 값
-2. Elastic Beanstalk 환경에 등록해 두어야 하는 환경변수 key
+대상 환경:
 
-현재 기준 배포 대상:
-
-- Django + nginx: `test-tailtalk-django-env`
+- Django: `test-tailtalk-django-env`
 - FastAPI: `test-tailtalk-fastapi-env`
+- AWS Region: `ap-northeast-2`
 
 ## 핵심 원칙
 
-현재 CI/CD 구조에서는 배포 zip 안의 `.env`에는 주로 **이미지 태그**만 넣고, 실제 운영 설정값은 **Elastic Beanstalk 환경변수**로 관리하는 방식이다.
+이 프로젝트에서 실제 실행 설정값의 원천은 로컬 `.env` 파일이 아니라 Elastic Beanstalk 환경변수다.
 
-즉:
+정리하면:
 
-- 배포 zip `.env` = 어떤 Docker 이미지를 띄울지
-- EB 환경변수 = 앱이 실제로 실행될 때 필요한 설정값
+- 로컬 개발: 각 서비스의 로컬 `.env` 또는 셸 환경변수 사용
+- EB 배포: AWS Elastic Beanstalk `Environment properties` 사용
+- 배포 번들: 애플리케이션 설정값을 담는 곳이 아니라, 배포에 필요한 파일만 담는 곳
 
-## 1. 배포 zip 안 `.env`에 필요한 값
+현재 테스트 EB 배포 구조 기준 핵심 파일:
 
-### nginx 폴더
+- `.github/workflows/ci-cd.yml`
+- `deploy/eb/test-django/docker-compose.yml`
+- `deploy/eb/test-fastapi/docker-compose.yml`
 
-nginx는 현재 별도 `.env`가 필요하지 않다.
+권장 구조는 아래와 같다.
 
-이유:
+1. EB 배포 번들에는 앱 비밀값이 들어 있는 `.env` 파일을 넣지 않는다.
+2. EB 환경 속성(`Environment properties`)에 값을 저장한다.
+3. 배포 시 EB가 런타임 환경변수를 컨테이너에 전달하도록 사용한다.
 
-- `deploy/eb/test-django/nginx/nginx.conf`는 환경변수를 읽지 않음
-- nginx 컨테이너는 정적 설정 파일만 마운트해서 사용함
+AWS 공식 문서도 Elastic Beanstalk 환경변수를 `Environment properties`에서 관리하도록 안내한다.
 
-즉, nginx 폴더에는 `.env`가 필요 없다.
+- Environment properties: <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-softwaresettings.html>
+- Running environment configuration changes: <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-configuration-methods-after.html>
 
-### Django 배포 폴더
+## 왜 EB 환경변수로 넣어야 하는가
 
-현재 구조에서 Django 배포 zip 내부 `.env`에 최소한 필요한 값은 아래 하나다.
+이 프로젝트에서 필요한 값 중 상당수는 비밀값 또는 환경 의존 값이다.
+
+예:
+
+- `DJANGO_SECRET_KEY`
+- `POSTGRES_PASSWORD`
+- `INTERNAL_SERVICE_TOKEN`
+- `GOOGLE_CLIENT_SECRET`
+- `OPENAI_API_KEY`
+
+이 값들을 저장소나 배포 zip에 넣으면 관리가 어렵고 유출 위험이 커진다. 따라서 AWS Console 또는 AWS CLI를 통해 EB 환경에 저장하는 편이 맞다.
+
+## AWS 콘솔에서 입력하는 방법
+
+아래 절차는 AWS 공식 문서의 Elastic Beanstalk 콘솔 흐름을 기준으로 작성했다.
+
+### 1. AWS 콘솔 접속
+
+1. AWS Management Console에 로그인한다.
+2. 우측 상단 Region이 `Asia Pacific (Seoul) / ap-northeast-2`인지 확인한다.
+3. 서비스 검색에서 `Elastic Beanstalk`를 연다.
+
+### 2. 대상 환경 선택
+
+1. 왼쪽에서 `Environments`를 선택한다.
+2. 아래 중 하나를 클릭한다.
+   - Django: `test-tailtalk-django-env`
+   - FastAPI: `test-tailtalk-fastapi-env`
+
+### 3. Environment properties 편집 화면으로 이동
+
+1. 환경 상세 페이지에서 `Configuration`으로 이동한다.
+2. `Updates, monitoring, and logging` 카드에서 `Edit`를 누른다.
+3. 페이지 아래쪽의 `Environment properties` 섹션으로 내려간다.
+
+참고:
+
+- 콘솔 UI 문구는 시점에 따라 약간 바뀔 수 있지만, `Configuration` 안의 `Environment properties` 편집 화면으로 들어가면 된다.
+
+### 4. 키와 값 입력
+
+1. `Environment properties`에서 한 줄에 하나씩 `Key`와 `Value`를 입력한다.
+2. 새 항목을 추가할 때는 `Add environment property`를 사용한다.
+3. 이미 존재하는 키는 해당 줄의 값을 수정한다.
+
+입력 예시:
 
 ```text
-DJANGO_IMAGE=<도커허브_이미지:태그>
+Key: GOOGLE_CLIENT_ID
+Value: 발급받은 OAuth client id
 ```
-
-예시:
 
 ```text
-DJANGO_IMAGE=kimheejoon91/test-tailtalk-django:72a1915
+Key: OPENAI_API_KEY
+Value: 실제 OpenAI API key
 ```
 
-현재 CI/CD도 이 방식으로 `.env`를 생성해서 zip에 포함한다.
+### 5. 적용
 
-### FastAPI 배포 폴더
+1. 입력을 마쳤으면 화면 하단의 `Apply`를 누른다.
+2. Elastic Beanstalk가 환경 업데이트를 시작한다.
+3. 몇 분 후 상태가 `Ready`이고 Health가 `Green`인지 확인한다.
 
-현재 구조에서 FastAPI 배포 zip 내부 `.env`에 최소한 필요한 값은 아래 하나다.
+주의:
 
-```text
-FASTAPI_IMAGE=<도커허브_이미지:태그>
-```
+- 값을 저장하면 컨테이너가 재시작될 수 있다.
+- 오타가 있으면 앱이 바로 기동 실패할 수 있으니 키 이름을 정확히 맞춘다.
 
-예시:
+### 6. 적용 후 확인
 
-```text
-FASTAPI_IMAGE=kimheejoon91/test-tailtalk-fastapi:b3bba0d
-```
+입력 후에는 아래 항목을 확인하는 편이 좋다.
 
-현재 CI/CD도 이 방식으로 `.env`를 생성해서 zip에 포함한다.
+- Django 홈: `/`
+- Django 헬스 체크: `/health/`
+- FastAPI 홈: `/`
+- FastAPI 헬스 체크: `/health`
+- OAuth 시작 URL: `/auth/google/start/`, `/auth/naver/start/`, `/auth/kakao/start/`
 
-## 2. Elastic Beanstalk 환경에 등록해야 하는 환경변수
+## 환경별 키 정리
 
-아래는 **애플리케이션 실행에 필요한 값**이며, 배포 zip `.env`가 아니라 **Elastic Beanstalk 환경변수**에 넣어 두는 것을 기준으로 정리했다.
+아래 목록은 현재 코드와 테스트 EB 환경을 기준으로 정리했다.
 
----
-
-## Django + nginx 환경에 등록할 변수
+## Django 환경
 
 대상 환경:
 
 - `test-tailtalk-django-env`
 
-### 필수
+코드 기준 참조 위치:
 
-아래 값들은 현재 Django 설정상 사실상 필수다.
+- `services/django/config/settings.py`
+
+### 이미 등록되어 있는 핵심 키
+
+값은 문서에 적지 않지만, 현재 테스트 Django EB에는 아래 키들이 이미 등록되어 있다.
+
+- `DJANGO_SECRET_KEY`
+- `DJANGO_DEBUG`
+- `DJANGO_ALLOWED_HOSTS`
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `FASTAPI_INTERNAL_CHAT_URL`
+- `INTERNAL_SERVICE_TOKEN`
+- `CORS_ALLOWED_ORIGINS`
+
+### 지금 추가 입력이 필요한 키
+
+소셜 로그인과 외부 URL 구성을 위해 아래 키를 입력해야 한다.
+
+- `APP_BASE_URL`
+- `GOOGLE_CLIENT_ID`
+- `GOOGLE_CLIENT_SECRET`
+- `NAVER_CLIENT_ID`
+- `NAVER_CLIENT_SECRET`
+- `KAKAO_CLIENT_ID`
+- `KAKAO_CLIENT_SECRET`
+
+### 선택적으로 입력할 수 있는 키
+
+아래 키는 기능이나 운영 정책에 따라 넣는다.
+
+- `DJANGO_SECURE_SSL_REDIRECT`
+- `DJANGO_SESSION_COOKIE_SECURE`
+- `DJANGO_CSRF_COOKIE_SECURE`
+- `SOCIAL_AUTH_REQUESTS_TIMEOUT`
+- `AWS_S3_BUCKET_NAME`
+- `AWS_S3_REGION_NAME`
+- `AWS_S3_CUSTOM_DOMAIN`
+- `AWS_S3_ENDPOINT_URL`
+- `AWS_ACCESS_KEY_ID`
+- `AWS_SECRET_ACCESS_KEY`
+- `USE_SQLITE`
+- `SQLITE_NAME`
+
+### `APP_BASE_URL` 입력 기준
+
+`APP_BASE_URL`은 OAuth 콜백 URL과 외부 절대 URL 생성에 사용된다.
+
+테스트 EB 기본 URL을 그대로 쓸 경우 예시는 아래와 같다.
 
 ```text
-DJANGO_SECRET_KEY
-POSTGRES_DB
-POSTGRES_USER
-POSTGRES_PASSWORD
-POSTGRES_HOST
-FASTAPI_INTERNAL_CHAT_URL
-INTERNAL_SERVICE_TOKEN
-```
-
-설명:
-
-- `DJANGO_SECRET_KEY`: Django 앱 실행 필수
-- `POSTGRES_DB`: PostgreSQL DB 이름
-- `POSTGRES_USER`: PostgreSQL 사용자명
-- `POSTGRES_PASSWORD`: PostgreSQL 비밀번호
-- `POSTGRES_HOST`: PostgreSQL 호스트
-- `FASTAPI_INTERNAL_CHAT_URL`: Django가 FastAPI 내부 API를 호출할 주소
-- `INTERNAL_SERVICE_TOKEN`: Django와 FastAPI 간 내부 인증 토큰
-
-### 권장
-
-아래 값들은 운영 편의를 위해 넣는 것이 좋다.
-
-```text
-DJANGO_ALLOWED_HOSTS
-POSTGRES_PORT
-APP_BASE_URL
-DJANGO_DEBUG
-CORS_ALLOWED_ORIGINS
-DJANGO_SECURE_SSL_REDIRECT
-DJANGO_SESSION_COOKIE_SECURE
-DJANGO_CSRF_COOKIE_SECURE
-SOCIAL_AUTH_REQUESTS_TIMEOUT
-```
-
-설명:
-
-- `DJANGO_ALLOWED_HOSTS`: 기본값은 `*`지만 명시하는 편이 안전함
-- `POSTGRES_PORT`: 기본값은 `5432`
-- `APP_BASE_URL`: OAuth 콜백 URL 생성에 중요
-- `DJANGO_DEBUG`: 기본값은 `False`
-- `CORS_ALLOWED_ORIGINS`: 프론트엔드 도메인 허용 시 필요
-- `DJANGO_SECURE_SSL_REDIRECT`: HTTPS 리다이렉트 여부
-- `DJANGO_SESSION_COOKIE_SECURE`: 세션 쿠키 보안 설정
-- `DJANGO_CSRF_COOKIE_SECURE`: CSRF 쿠키 보안 설정
-- `SOCIAL_AUTH_REQUESTS_TIMEOUT`: 소셜 로그인 API 타임아웃, 기본값 `10`
-
-### OAuth 사용 시 필수
-
-소셜 로그인 기능을 사용할 경우 아래 값들을 반드시 등록해야 한다.
-
-```text
-GOOGLE_CLIENT_ID
-GOOGLE_CLIENT_SECRET
-NAVER_CLIENT_ID
-NAVER_CLIENT_SECRET
-KAKAO_CLIENT_ID
-KAKAO_CLIENT_SECRET
+http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
 ```
 
 주의:
 
-- OAuth 키가 없으면 `/auth/<provider>/start/`는 라우트는 살아 있어도 정상 로그인 진행이 안 됨
-- `APP_BASE_URL`이 비어 있으면 콜백 URL이 의도와 다르게 생성될 수 있음
+- OAuth provider가 HTTPS redirect URI를 요구하면, EB 기본 HTTP URL 대신 SSL이 붙은 도메인을 사용해야 한다.
+- 그 경우 `APP_BASE_URL`도 반드시 같은 HTTPS 도메인으로 맞춘다.
 
-### S3 업로드 사용 시 필요
+### OAuth callback URL 예시
 
-사용하는 경우에만 넣으면 된다.
-
-```text
-AWS_S3_BUCKET_NAME
-AWS_S3_REGION_NAME
-AWS_S3_CUSTOM_DOMAIN
-AWS_S3_ENDPOINT_URL
-AWS_ACCESS_KEY_ID
-AWS_SECRET_ACCESS_KEY
-```
-
-현재 코드 기준으로는 S3 관련 기능이 항상 강제되지는 않는다.
-
-### 선택
+`APP_BASE_URL`이 위 테스트 URL이라면 callback URL 예시는 아래와 같다.
 
 ```text
-USE_SQLITE
-SQLITE_NAME
+http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com/auth/google/callback/
+http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com/auth/naver/callback/
+http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com/auth/kakao/callback/
 ```
 
-설명:
+위 URL은 AWS Console에 넣는 값이 아니라, Google/Naver/Kakao 개발자 콘솔에 등록해야 하는 redirect URI다.
 
-- 테스트나 임시 환경에서 PostgreSQL 대신 SQLite를 사용할 때만 필요
-- 현재 배포 구조에서는 일반적으로 사용하지 않음
-
----
-
-## FastAPI 환경에 등록할 변수
+## FastAPI 환경
 
 대상 환경:
 
 - `test-tailtalk-fastapi-env`
 
-### 필수
+코드 기준 참조 위치:
 
-현재 Docker Compose 기준으로 최소한 아래 값들은 준비되어 있어야 한다.
+- `deploy/eb/test-fastapi/docker-compose.yml`
+- `services/fastapi/final_ai/core/config.py`
+- `services/fastapi/final_ai/pipeline/utils.py`
 
-```text
-POSTGRES_DB
-POSTGRES_USER
-POSTGRES_PASSWORD
-POSTGRES_HOST
-INTERNAL_SERVICE_TOKEN
-```
+### 이미 등록되어 있는 키
 
-설명:
+현재 테스트 FastAPI EB에는 아래 키들이 등록되어 있다.
 
-- `POSTGRES_DB`: PostgreSQL DB 이름
-- `POSTGRES_USER`: PostgreSQL 사용자명
-- `POSTGRES_PASSWORD`: PostgreSQL 비밀번호
-- `POSTGRES_HOST`: PostgreSQL 호스트
-- `INTERNAL_SERVICE_TOKEN`: Django와 FastAPI 간 내부 인증 토큰
+- `POSTGRES_DB`
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_HOST`
+- `POSTGRES_PORT`
+- `INTERNAL_SERVICE_TOKEN`
+- `QDRANT_HOST`
+- `QDRANT_PORT`
+- `OPENAI_API_KEY`
 
-### 권장
+### 지금 점검 또는 교체가 필요한 키
 
-```text
-POSTGRES_PORT
-OPENAI_API_KEY
-QDRANT_HOST
-QDRANT_PORT
-```
+- `OPENAI_API_KEY`
 
-설명:
+현재 테스트 환경에는 이 키가 존재하지만, 실제 서비스 호출에 쓸 값인지 반드시 확인하고 필요하면 교체해야 한다.
 
-- `POSTGRES_PORT`: 기본값은 `5432`
-- `OPENAI_API_KEY`: OpenAI 호출 기능 사용 시 필요
-- `QDRANT_HOST`: Qdrant 사용 시 필요
-- `QDRANT_PORT`: 기본값은 `6333`
+### 선택적으로 입력할 수 있는 키
 
-주의:
+- `LLM_MODEL`
 
-- 기능에 따라 `OPENAI_API_KEY`, `QDRANT_HOST`, `QDRANT_PORT`가 없으면 일부 API가 정상 동작하지 않을 수 있음
-- 현재 compose 파일에서는 기본값이 있어 컨테이너는 뜰 수 있지만, 실제 기능은 제한될 수 있음
+별도로 지정하지 않으면 코드 기본값이 사용된다.
 
----
+## 레거시 키 메모
 
-## 3. 현재 구조 기준 권장 운영 방식
+이전 배포 흐름에서는 배포 zip 내부 `.env`에 아래 키를 넣어 사용했다.
 
-현재 구조에서는 아래처럼 운영하는 것이 가장 명확하다.
+- `DJANGO_IMAGE`
+- `FASTAPI_IMAGE`
 
-### 배포 zip `.env`
+이 값들은 이미지 태그 전달용이었다. 배포 번들에 앱 설정용 `.env`를 넣지 않는 구조로 정리하면, 앱 비밀값과는 분리해서 관리하는 것이 맞다.
 
-- Django: `DJANGO_IMAGE`만 포함
-- FastAPI: `FASTAPI_IMAGE`만 포함
-- nginx: `.env` 없음
+## 입력 실수 방지 체크리스트
 
-### EB 환경변수
+값을 넣기 전에 아래를 확인한다.
 
-- 앱 실행에 필요한 실제 값 전부 등록
-- DB 접속 정보
-- 내부 인증 토큰
-- OAuth 키
-- OpenAI 키
-- 기타 운영 설정값
+1. 키 이름 오타가 없는지 확인한다.
+2. Django와 FastAPI에 공통으로 들어가는 `INTERNAL_SERVICE_TOKEN` 값이 서로 같은지 확인한다.
+3. `POSTGRES_*` 값이 Django와 FastAPI에서 같은 DB를 바라보는지 확인한다.
+4. `APP_BASE_URL`과 OAuth provider 콘솔의 redirect URI가 서로 일치하는지 확인한다.
+5. `OPENAI_API_KEY`는 테스트용 문자열이 아니라 실제 사용 가능한 키인지 확인한다.
+6. HTTPS가 필요한 provider를 쓰는 경우 SSL 도메인이 준비되어 있는지 확인한다.
 
-## 4. 예시
+## 운영 팁
 
-### Django 배포 zip용 `.env`
+- 비밀값은 문서나 저장소에 적지 말고 AWS Console 또는 AWS CLI에서만 관리한다.
+- 값을 바꾼 뒤에는 환경 상태가 `Ready / Green`으로 돌아올 때까지 기다린다.
+- OAuth는 환경변수만 넣는다고 끝나지 않고, provider 콘솔 redirect URI 등록까지 맞아야 정상 동작한다.
 
-```text
-DJANGO_IMAGE=kimheejoon91/test-tailtalk-django:72a1915
-```
+## 참고 문서
 
-### FastAPI 배포 zip용 `.env`
-
-```text
-FASTAPI_IMAGE=kimheejoon91/test-tailtalk-fastapi:b3bba0d
-```
-
-### Django EB 환경변수 예시
-
-```text
-DJANGO_SECRET_KEY=...
-DJANGO_DEBUG=False
-DJANGO_ALLOWED_HOSTS=*
-APP_BASE_URL=https://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
-POSTGRES_DB=tailtalk
-POSTGRES_USER=tailtalk
-POSTGRES_PASSWORD=...
-POSTGRES_HOST=...
-POSTGRES_PORT=5432
-FASTAPI_INTERNAL_CHAT_URL=http://test-tailtalk-fastapi-env.eba-5ymgtjp9.ap-northeast-2.elasticbeanstalk.com/api/chat/
-INTERNAL_SERVICE_TOKEN=...
-CORS_ALLOWED_ORIGINS=
-GOOGLE_CLIENT_ID=...
-GOOGLE_CLIENT_SECRET=...
-NAVER_CLIENT_ID=...
-NAVER_CLIENT_SECRET=...
-KAKAO_CLIENT_ID=...
-KAKAO_CLIENT_SECRET=...
-```
-
-### FastAPI EB 환경변수 예시
-
-```text
-POSTGRES_DB=tailtalk
-POSTGRES_USER=tailtalk
-POSTGRES_PASSWORD=...
-POSTGRES_HOST=...
-POSTGRES_PORT=5432
-INTERNAL_SERVICE_TOKEN=...
-OPENAI_API_KEY=...
-QDRANT_HOST=...
-QDRANT_PORT=6333
-```
-
-## 5. 한 줄 정리
-
-현재 테스트 배포 구조에서는 **배포 zip 안 `.env`에는 이미지 태그만 넣고**, 실제 앱 실행에 필요한 값은 **Elastic Beanstalk 환경변수에 등록하는 방식**으로 관리하면 된다.
+- AWS Elastic Beanstalk environment properties: <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environments-cfg-softwaresettings.html>
+- AWS Elastic Beanstalk configuration updates after environment creation: <https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/environment-configuration-methods-after.html>

--- a/docs/infra/06_rds_schema_snapshot.md
+++ b/docs/infra/06_rds_schema_snapshot.md
@@ -1,0 +1,364 @@
+# Test RDS 실제 스키마 스냅샷
+
+## 개요
+
+이 문서는 `2026-03-26` 기준 테스트 Django Elastic Beanstalk 환경이 실제로 바라보고 있는 RDS PostgreSQL의 `public` 스키마를 스냅샷한 결과다.
+
+수집 대상:
+
+- EB 환경: `test-tailtalk-django-env`
+- RDS 인스턴스: `test-tailtalk-postgres`
+- DB 엔진: `PostgreSQL`
+
+수집 방식:
+
+- 로컬에서 RDS로 직접 붙는 대신
+- 배포 중인 Django EB 인스턴스의 `current-django-1` 컨테이너 안에서
+- `information_schema.tables`, `information_schema.columns`를 조회해 실제 스키마를 읽어왔다
+
+주의:
+
+- 이 문서는 로컬 `models.py` 기준이 아니라 실제 운영 중인 테스트 RDS 기준이다
+- 따라서 현재 로컬 코드와 차이가 있을 수 있다
+
+## 전체 테이블 수
+
+- 총 `37`개 테이블
+
+## 전체 테이블 목록
+
+### 앱 비즈니스 테이블
+
+- `cart`
+- `cart_item`
+- `chat_message`
+- `chat_session`
+- `order`
+- `order_item`
+- `pet`
+- `pet_allergy`
+- `pet_food_preference`
+- `pet_health_concern`
+- `pet_used_product`
+- `product`
+- `product_admin_config`
+- `product_category_tag`
+- `review`
+- `social_account`
+- `user`
+- `user_interaction`
+- `user_preference`
+- `user_profile`
+- `user_used_product`
+
+### Django/Auth/세션/소셜 로그인 지원 테이블
+
+- `auth_group`
+- `auth_group_permissions`
+- `auth_permission`
+- `django_admin_log`
+- `django_content_type`
+- `django_migrations`
+- `django_session`
+- `social_auth_association`
+- `social_auth_code`
+- `social_auth_nonce`
+- `social_auth_partial`
+- `social_auth_usersocialauth`
+- `token_blacklist_blacklistedtoken`
+- `token_blacklist_outstandingtoken`
+- `user_groups`
+- `user_user_permissions`
+
+## 현재 스냅샷에 없는 테이블
+
+현재 테스트 RDS 스냅샷에는 아래 테이블이 없다.
+
+- `wishlist`
+- `wishlist_item`
+- `domain_qna`
+- `breed_meta`
+
+즉, 로컬 코드나 별도 적재 스크립트 기준으로는 존재를 기대할 수 있어도 현재 테스트 EB가 바라보는 실제 RDS에는 아직 없는 상태다.
+
+## 주요 테이블 컬럼 구조
+
+### `user`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `password` | `character varying` | `NO` |
+| `last_login` | `timestamp with time zone` | `YES` |
+| `is_superuser` | `boolean` | `NO` |
+| `id` | `integer` | `NO` |
+| `email` | `character varying` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `is_active` | `boolean` | `NO` |
+| `is_staff` | `boolean` | `NO` |
+
+### `user_profile`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `user_id` | `integer` | `NO` |
+| `nickname` | `character varying` | `NO` |
+| `age` | `integer` | `YES` |
+| `gender` | `character varying` | `YES` |
+| `address` | `text` | `YES` |
+| `phone` | `character varying` | `YES` |
+| `marketing_consent` | `boolean` | `NO` |
+| `profile_image_url` | `text` | `YES` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+
+### `social_account`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `bigint` | `NO` |
+| `provider` | `character varying` | `NO` |
+| `provider_user_id` | `character varying` | `NO` |
+| `email` | `character varying` | `NO` |
+| `extra_data` | `jsonb` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `user_preference`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `user_id` | `integer` | `NO` |
+| `theme` | `character varying` | `NO` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+
+### `user_used_product`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `product_id` | `character varying` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `pet`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `pet_id` | `uuid` | `NO` |
+| `name` | `character varying` | `NO` |
+| `species` | `character varying` | `NO` |
+| `breed` | `character varying` | `YES` |
+| `gender` | `character varying` | `NO` |
+| `age_years` | `integer` | `NO` |
+| `age_months` | `integer` | `NO` |
+| `weight_kg` | `numeric` | `YES` |
+| `neutered` | `boolean` | `YES` |
+| `vaccination_date` | `date` | `YES` |
+| `budget_range` | `character varying` | `NO` |
+| `special_notes` | `text` | `YES` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `pet_health_concern`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `concern` | `character varying` | `NO` |
+| `pet_id` | `uuid` | `NO` |
+
+### `pet_allergy`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `ingredient` | `character varying` | `NO` |
+| `pet_id` | `uuid` | `NO` |
+
+### `pet_food_preference`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `food_type` | `character varying` | `NO` |
+| `pet_id` | `uuid` | `NO` |
+
+### `pet_used_product`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `pet_id` | `uuid` | `NO` |
+| `product_id` | `character varying` | `NO` |
+
+### `chat_session`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `session_id` | `uuid` | `NO` |
+| `title` | `text` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+| `target_pet_id` | `uuid` | `YES` |
+| `user_id` | `integer` | `NO` |
+
+### `chat_message`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `message_id` | `uuid` | `NO` |
+| `role` | `character varying` | `NO` |
+| `content` | `text` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `session_id` | `uuid` | `NO` |
+
+### `cart`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `cart_id` | `uuid` | `NO` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `cart_item`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `cart_item_id` | `uuid` | `NO` |
+| `quantity` | `integer` | `NO` |
+| `added_at` | `timestamp with time zone` | `NO` |
+| `cart_id` | `uuid` | `NO` |
+| `product_id` | `character varying` | `NO` |
+
+### `order`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `order_id` | `uuid` | `NO` |
+| `recipient_name` | `character varying` | `NO` |
+| `delivery_address` | `text` | `NO` |
+| `total_price` | `integer` | `NO` |
+| `status` | `character varying` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `order_item`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `order_item_id` | `uuid` | `NO` |
+| `quantity` | `integer` | `NO` |
+| `price_at_order` | `integer` | `NO` |
+| `order_id` | `uuid` | `NO` |
+| `product_id` | `character varying` | `NO` |
+
+### `user_interaction`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `session_id` | `uuid` | `YES` |
+| `interaction_type` | `character varying` | `NO` |
+| `weight` | `smallint` | `NO` |
+| `created_at` | `timestamp with time zone` | `NO` |
+| `product_id` | `character varying` | `NO` |
+| `user_id` | `integer` | `NO` |
+
+### `product`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `goods_id` | `character varying` | `NO` |
+| `goods_name` | `text` | `NO` |
+| `brand_name` | `character varying` | `NO` |
+| `price` | `integer` | `NO` |
+| `discount_price` | `integer` | `NO` |
+| `rating` | `numeric` | `YES` |
+| `review_count` | `integer` | `NO` |
+| `thumbnail_url` | `text` | `NO` |
+| `product_url` | `text` | `NO` |
+| `soldout_yn` | `boolean` | `NO` |
+| `soldout_reliable` | `boolean` | `NO` |
+| `pet_type` | `ARRAY` | `NO` |
+| `category` | `ARRAY` | `NO` |
+| `subcategory` | `ARRAY` | `NO` |
+| `health_concern_tags` | `ARRAY` | `NO` |
+| `popularity_score` | `numeric` | `YES` |
+| `sentiment_avg` | `numeric` | `YES` |
+| `repeat_rate` | `numeric` | `YES` |
+| `main_ingredients` | `jsonb` | `YES` |
+| `ingredient_composition` | `jsonb` | `YES` |
+| `nutrition_info` | `jsonb` | `YES` |
+| `ingredient_text_ocr` | `text` | `YES` |
+| `crawled_at` | `timestamp with time zone` | `NO` |
+| `embedding` | `USER-DEFINED` | `YES` |
+| `embedding_text` | `text` | `YES` |
+| `prefix` | `character varying` | `NO` |
+| `search_vector` | `tsvector` | `YES` |
+| `생체반응` | `numeric` | `NO` |
+| `배송/포장` | `numeric` | `NO` |
+| `소화/배변` | `numeric` | `NO` |
+| `성분/원료` | `numeric` | `NO` |
+| `기호성` | `numeric` | `NO` |
+| `가격/구매` | `numeric` | `NO` |
+| `제품 성상` | `numeric` | `NO` |
+| `냄새` | `numeric` | `NO` |
+
+참고:
+
+- `information_schema` 기준으로 `embedding` 타입은 `USER-DEFINED`로 보인다
+- 현재 프로젝트 문맥상 `pgvector`의 `vector` 타입 컬럼으로 해석하는 것이 자연스럽다
+
+### `product_admin_config`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `admin_weight` | `numeric` | `NO` |
+| `pinned` | `boolean` | `NO` |
+| `memo` | `text` | `YES` |
+| `updated_at` | `timestamp with time zone` | `NO` |
+| `product_id` | `character varying` | `NO` |
+
+### `product_category_tag`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `id` | `uuid` | `NO` |
+| `tag` | `character varying` | `NO` |
+| `product_id` | `character varying` | `NO` |
+
+### `review`
+
+| Column | Type | Nullable |
+| --- | --- | --- |
+| `review_id` | `character varying` | `NO` |
+| `score` | `numeric` | `NO` |
+| `content` | `text` | `NO` |
+| `author_nickname` | `character varying` | `NO` |
+| `written_at` | `date` | `NO` |
+| `purchase_label` | `character varying` | `YES` |
+| `sentiment_score` | `numeric` | `YES` |
+| `sentiment_label` | `character varying` | `YES` |
+| `absa_result` | `jsonb` | `YES` |
+| `pet_age_months` | `integer` | `YES` |
+| `pet_weight_kg` | `numeric` | `YES` |
+| `pet_gender` | `character varying` | `YES` |
+| `pet_breed` | `character varying` | `YES` |
+| `product_id` | `character varying` | `NO` |
+| `생체반응` | `integer` | `NO` |
+| `배송/포장` | `integer` | `NO` |
+| `소화/배변` | `integer` | `NO` |
+| `성분/원료` | `integer` | `NO` |
+| `기호성` | `integer` | `NO` |
+| `가격/구매` | `integer` | `NO` |
+| `제품 성상` | `integer` | `NO` |
+| `냄새` | `integer` | `NO` |
+
+## 참고 메모
+
+- 현재 스냅샷에는 `wishlist`, `wishlist_item` 테이블이 없다
+- 현재 스냅샷에는 `domain_qna`, `breed_meta` 테이블도 없다
+- 즉, 로컬 코드나 적재 스크립트와 실제 테스트 RDS가 완전히 같은 상태라고 가정하면 안 된다
+- 스키마 변경 여부를 판단할 때는 이 문서와 함께 `django_migrations` 상태도 같이 확인하는 편이 안전하다


### PR DESCRIPTION
## 요약
test EB 배포 워크플로우를 `develop` 머지 기준으로 맞추고, Elastic Beanstalk 환경변수가 정상 반영되도록 배포 구성을 정리했습니다.

## 변경 사항
- CI/CD 워크플로우의 테스트 EB 배포 트리거를 `main` 머지에서 `develop` 머지로 변경했습니다.
- EB 배포 번들에서 `.env`를 함께 포함하지 않도록 수정하고, 이미지 태그는 compose 파일의 placeholder를 치환하는 방식으로 변경했습니다.
- Django/FastAPI 테스트 EB compose를 `env_file: .env` 기반으로 정리해 EB 환경변수가 런타임에 주입되도록 맞췄습니다.
- FastAPI 서브모듈 포인터를 루트 상태 응답(`/`)이 포함된 커밋으로 갱신했습니다.
- EB 환경변수 입력 가이드와 라이브 RDS 스키마 스냅샷 문서를 추가했습니다.

## 관련 이슈
- 없음
- 선행 PR: skn-ai22-251029/SKN22-Final-2Team-AI#7

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 테스트 EB 배포 트리거를 `develop` 머지 기준으로 전환한 점과, 배포 번들에서 `.env`를 제거한 구성이 현재 운영 방식과 맞는지 확인 부탁드립니다.
- `services/fastapi` 서브모듈 포인터가 AI PR `#7`의 머지 이후 커밋을 가리키도록 갱신된 점도 함께 확인 부탁드립니다.
