### PR TITLE
chore(deploy): pgvector 기준 런타임 설정 정리

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,8 @@ DJANGO_DEBUG=False
 DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
 APP_BASE_URL=http://localhost
 CORS_ALLOWED_ORIGINS=https://yourdomain.com
+FASTAPI_INTERNAL_CHAT_URL=http://fastapi:8001/api/chat/
+INTERNAL_SERVICE_TOKEN=changeme
 AWS_S3_BUCKET_NAME=your-s3-bucket
 AWS_S3_REGION_NAME=ap-northeast-2
 AWS_S3_CUSTOM_DOMAIN=
@@ -19,12 +21,7 @@ AWS_ACCESS_KEY_ID=your-aws-access-key-id
 AWS_SECRET_ACCESS_KEY=your-aws-secret-access-key
 
 # ── LLM ──────────────────────────────────────────────────────
-ANTHROPIC_API_KEY=your_anthropic_api_key_here
 OPENAI_API_KEY=your_openai_api_key_here
-
-# ── Qdrant ────────────────────────────────────────────────────
-QDRANT_HOST=qdrant
-QDRANT_PORT=6333
 
 # ── GCP (OCR) ─────────────────────────────────────────────────
 GOOGLE_APPLICATION_CREDENTIALS=.secrets/gcp_api_key.json

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -6,12 +6,19 @@ on:
       - closed
     branches:
       - develop
+    paths:
+      - .github/workflows/ci-cd.yml
+      - .gitmodules
+      - deploy/eb/**
+      - infra/**
+      - services/django/**
+      - services/fastapi
 
 permissions:
   contents: read
 
 concurrency:
-  group: test-eb-deploy-${{ github.ref }}
+  group: test-eb-deploy-develop
   cancel-in-progress: true
 
 env:
@@ -27,6 +34,7 @@ jobs:
   ci:
     name: CI - Build & Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     if: github.event.pull_request.merged == true
 
     steps:
@@ -36,24 +44,14 @@ jobs:
           ref: ${{ github.event.pull_request.merge_commit_sha }}
           submodules: recursive
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Create test env file
         run: |
           cat <<'EOF' > infra/.env
           DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
-          DJANGO_DEBUG=False
-          DJANGO_ALLOWED_HOSTS=localhost
+          DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,testserver
           POSTGRES_DB=${{ secrets.POSTGRES_DB }}
           POSTGRES_USER=${{ secrets.POSTGRES_USER }}
           POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
-          POSTGRES_HOST=postgres
-          POSTGRES_PORT=5432
-          CORS_ALLOWED_ORIGINS=http://localhost
-          QDRANT_HOST=qdrant
-          QDRANT_PORT=6333
-          INTERNAL_SERVICE_TOKEN=test-internal-token
           EOF
 
       - name: Build local test stack
@@ -64,13 +62,13 @@ jobs:
 
       - name: Teardown
         if: always()
-        run: docker compose -f infra/docker-compose.yml down -v
+        run: docker compose -f infra/docker-compose.yml down -v --remove-orphans
 
   deploy-fastapi:
     name: CD - FastAPI Test EB
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs: ci
-    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout
@@ -133,10 +131,10 @@ jobs:
   deploy-django:
     name: CD - Django Test EB
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     needs:
       - ci
       - deploy-fastapi
-    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
     │
 [Nginx]  ──── /api/chat/*  ────► [FastAPI + LangGraph]
     │                                   │
-    └────── 그 외  ────► [Django]    Qdrant Hybrid Search
+    └────── 그 외  ────► [Django]   PostgreSQL + pgvector
                             │           │
                         PostgreSQL    LLM (GPT-4o-mini)
 ```
@@ -21,8 +21,8 @@
 |------|------|
 | Frontend | Django Template (MVT), Tailwind CSS, Vanilla JS |
 | Backend | Django (Auth/User/Pet/Order), FastAPI (챗봇/추천) |
-| AI | LangGraph 멀티에이전트, GPT-4o-mini, Qdrant Hybrid Search |
-| DB | PostgreSQL 16, Qdrant (Dense + Sparse BM25 + RRF) |
+| AI | LangGraph 멀티에이전트, GPT-4o-mini, PostgreSQL Hybrid Search |
+| DB | PostgreSQL 16, pgvector, Full-text Search |
 | Infra | Docker Compose, Nginx, AWS EC2, GitHub Actions CI/CD |
 
 ## 로컬 실행
@@ -42,7 +42,7 @@ services/
   fastapi/    # 챗봇 · 추천 마이크로서비스 (LangGraph 파이프라인 포함)
 infra/        # Docker Compose, Nginx 설정
 notebooks/    # 데이터 파이프라인 실험, LangGraph 테스트
-scripts/      # ETL, Qdrant 적재 스크립트
+scripts/      # ETL, PostgreSQL 적재/복원 스크립트
 docs/         # 기획/설계 문서
 ```
 

--- a/deploy/eb/test-django/docker-compose.yml
+++ b/deploy/eb/test-django/docker-compose.yml
@@ -17,8 +17,29 @@ services:
       sh -c "python manage.py migrate --noinput &&
              python manage.py collectstatic --noinput &&
              gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
-    env_file:
-      - .env
+    environment:
+      DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
+      DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
+      DJANGO_ALLOWED_HOSTS: ${DJANGO_ALLOWED_HOSTS:-*}
+      APP_BASE_URL: ${APP_BASE_URL:-}
+      FASTAPI_INTERNAL_CHAT_URL: ${FASTAPI_INTERNAL_CHAT_URL:-http://fastapi:8001/api/chat/}
+      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      CORS_ALLOWED_ORIGINS: ${CORS_ALLOWED_ORIGINS:-}
+      GOOGLE_CLIENT_ID: ${GOOGLE_CLIENT_ID:-}
+      GOOGLE_CLIENT_SECRET: ${GOOGLE_CLIENT_SECRET:-}
+      NAVER_CLIENT_ID: ${NAVER_CLIENT_ID:-}
+      NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET:-}
+      KAKAO_CLIENT_ID: ${KAKAO_CLIENT_ID:-}
+      KAKAO_CLIENT_SECRET: ${KAKAO_CLIENT_SECRET:-}
+      SOCIAL_AUTH_REQUESTS_TIMEOUT: ${SOCIAL_AUTH_REQUESTS_TIMEOUT:-10}
+      DJANGO_SECURE_SSL_REDIRECT: ${DJANGO_SECURE_SSL_REDIRECT:-False}
+      DJANGO_SESSION_COOKIE_SECURE: ${DJANGO_SESSION_COOKIE_SECURE:-False}
+      DJANGO_CSRF_COOKIE_SECURE: ${DJANGO_CSRF_COOKIE_SECURE:-False}
     expose:
       - "8000"
     restart: unless-stopped

--- a/deploy/eb/test-fastapi/docker-compose.yml
+++ b/deploy/eb/test-fastapi/docker-compose.yml
@@ -3,8 +3,13 @@ services:
     image: __FASTAPI_IMAGE__
     platform: linux/amd64
     command: uvicorn main:app --host 0.0.0.0 --port 8001 --workers 2
-    env_file:
-      - .env
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB}
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_HOST: ${POSTGRES_HOST}
+      POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     ports:
       - "80:8001"
     restart: unless-stopped

--- a/docs/infra/01_local_setup.md
+++ b/docs/infra/01_local_setup.md
@@ -87,8 +87,8 @@ docker compose down -v && docker compose up -d
 > `infra/.env`의 `POSTGRES_HOST=postgres` → `POSTGRES_HOST=localhost`로 변경 후 실행
 
 ```bash
-# DB/Qdrant만 Docker로 실행
-cd infra && docker compose up -d postgres qdrant
+# DB만 Docker로 실행
+cd infra && docker compose up -d postgres
 
 # Django (터미널 1)
 cd services/django

--- a/docs/infra/05_eb_env_var_guide.md
+++ b/docs/infra/05_eb_env_var_guide.md
@@ -30,7 +30,7 @@
 
 1. EB 배포 번들에는 앱 비밀값이 들어 있는 `.env` 파일을 넣지 않는다.
 2. EB 환경 속성(`Environment properties`)에 값을 저장한다.
-3. 배포 시 EB가 런타임 환경변수를 컨테이너에 전달하도록 사용한다.
+3. 배포 시 EB가 제공하는 `.env` 값을 Docker Compose 변수 치환에 사용하고, 배포 compose에 명시한 키만 컨테이너에 전달한다.
 
 AWS 공식 문서도 Elastic Beanstalk 환경변수를 `Environment properties`에서 관리하도록 안내한다.
 
@@ -167,14 +167,11 @@ Value: 실제 OpenAI API key
 - `DJANGO_SESSION_COOKIE_SECURE`
 - `DJANGO_CSRF_COOKIE_SECURE`
 - `SOCIAL_AUTH_REQUESTS_TIMEOUT`
-- `AWS_S3_BUCKET_NAME`
-- `AWS_S3_REGION_NAME`
-- `AWS_S3_CUSTOM_DOMAIN`
-- `AWS_S3_ENDPOINT_URL`
-- `AWS_ACCESS_KEY_ID`
-- `AWS_SECRET_ACCESS_KEY`
-- `USE_SQLITE`
-- `SQLITE_NAME`
+
+주의:
+
+- 현재 테스트 EB 배포 compose에는 `AWS_S3_*`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `USE_SQLITE`, `SQLITE_NAME`를 전달하지 않는다.
+- 위 값들은 현재 코드의 테스트 EB 배포 경로에서는 사용하지 않는다.
 
 ### `APP_BASE_URL` 입력 기준
 
@@ -224,9 +221,6 @@ http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
 - `POSTGRES_PASSWORD`
 - `POSTGRES_HOST`
 - `POSTGRES_PORT`
-- `INTERNAL_SERVICE_TOKEN`
-- `QDRANT_HOST`
-- `QDRANT_PORT`
 - `OPENAI_API_KEY`
 
 ### 지금 점검 또는 교체가 필요한 키
@@ -235,11 +229,10 @@ http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
 
 현재 테스트 환경에는 이 키가 존재하지만, 실제 서비스 호출에 쓸 값인지 반드시 확인하고 필요하면 교체해야 한다.
 
-### 선택적으로 입력할 수 있는 키
+주의:
 
-- `LLM_MODEL`
-
-별도로 지정하지 않으면 코드 기본값이 사용된다.
+- 현재 FastAPI 테스트 EB 배포 compose는 `POSTGRES_*`와 `OPENAI_API_KEY`만 컨테이너에 전달한다.
+- 즉 레거시 벡터 DB 관련 키, `INTERNAL_SERVICE_TOKEN`, `LLM_MODEL`은 현재 테스트 EB 배포 경로에서 사용하지 않는다.
 
 ## 레거시 키 메모
 
@@ -255,11 +248,10 @@ http://test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com
 값을 넣기 전에 아래를 확인한다.
 
 1. 키 이름 오타가 없는지 확인한다.
-2. Django와 FastAPI에 공통으로 들어가는 `INTERNAL_SERVICE_TOKEN` 값이 서로 같은지 확인한다.
-3. `POSTGRES_*` 값이 Django와 FastAPI에서 같은 DB를 바라보는지 확인한다.
-4. `APP_BASE_URL`과 OAuth provider 콘솔의 redirect URI가 서로 일치하는지 확인한다.
-5. `OPENAI_API_KEY`는 테스트용 문자열이 아니라 실제 사용 가능한 키인지 확인한다.
-6. HTTPS가 필요한 provider를 쓰는 경우 SSL 도메인이 준비되어 있는지 확인한다.
+2. `APP_BASE_URL`과 OAuth provider 콘솔의 redirect URI가 서로 일치하는지 확인한다.
+3. `OPENAI_API_KEY`는 테스트용 문자열이 아니라 실제 사용 가능한 키인지 확인한다.
+4. `POSTGRES_*` 값이 현재 FastAPI 런타임이 접근 가능한 PostgreSQL을 가리키는지 확인한다.
+5. HTTPS가 필요한 provider를 쓰는 경우 SSL 도메인이 준비되어 있는지 확인한다.
 
 ## 운영 팁
 

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -72,7 +72,6 @@ services:
       POSTGRES_HOST: ${POSTGRES_HOST:-postgres}
       POSTGRES_PORT: ${POSTGRES_PORT:-5432}
       OPENAI_API_KEY: ${OPENAI_API_KEY}
-      INTERNAL_SERVICE_TOKEN: ${INTERNAL_SERVICE_TOKEN:-dev-internal-token}
     expose:
       - "8001"
     depends_on:


### PR DESCRIPTION
## 요약
pgvector 전환 이후 남아 있던 테스트 EB 배포 설정과 문서를 현재 런타임 구조에 맞게 정리했습니다.

## 변경 사항
- 테스트 EB CI/CD에서 불필요한 트리거와 테스트용 환경변수를 줄이고, 공유 테스트 환경 기준으로 동시 배포 제어를 정리했습니다.
- Django/FastAPI 테스트 EB compose를 필요한 환경변수만 전달하는 whitelist 방식으로 정리했습니다.
- 로컬 compose, `.env.example`, README, 운영 가이드를 현재 PostgreSQL/pgvector 기반 구조에 맞게 수정했습니다.
- `services/fastapi` 서브모듈 포인터를 Qdrant 잔여 설정 정리 커밋으로 갱신했습니다.

## 관련 이슈
- 없음
- 선행 PR: skn-ai22-251029/SKN22-Final-2Team-AI#9

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 테스트 EB compose에서 환경변수를 whitelist 방식으로 제한한 구성이 현재 운영 방식과 맞는지 확인 부탁드립니다.
- `services/fastapi` 서브모듈 포인터가 AI PR `#9` 머지 이후 커밋을 가리키는 점도 함께 확인 부탁드립니다.
