### PR TITLE
chore(django): 로컬 DB 스키마 정렬용 migration 추가

### DIFF
--- a/services/django/products/migrations/0003_product_aspect_biological_response_and_more.py
+++ b/services/django/products/migrations/0003_product_aspect_biological_response_and_more.py
@@ -12,23 +12,8 @@ class Migration(migrations.Migration):
     operations = [
         migrations.AddField(
             model_name='product',
-            name='aspect_biological_response',
-            field=models.DecimalField(db_column='생체반응', decimal_places=4, default=0.0, max_digits=5),
-        ),
-        migrations.AddField(
-            model_name='product',
-            name='aspect_delivery_packaging',
-            field=models.DecimalField(db_column='배송/포장', decimal_places=4, default=0.0, max_digits=5),
-        ),
-        migrations.AddField(
-            model_name='product',
-            name='aspect_digestion_stool',
-            field=models.DecimalField(db_column='소화/배변', decimal_places=4, default=0.0, max_digits=5),
-        ),
-        migrations.AddField(
-            model_name='product',
-            name='aspect_ingredients_origin',
-            field=models.DecimalField(db_column='성분/원료', decimal_places=4, default=0.0, max_digits=5),
+            name='aspect_smell',
+            field=models.DecimalField(db_column='냄새', decimal_places=4, default=0.0, max_digits=5),
         ),
         migrations.AddField(
             model_name='product',
@@ -37,8 +22,28 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='product',
+            name='aspect_biological_response',
+            field=models.DecimalField(db_column='생체반응', decimal_places=4, default=0.0, max_digits=5),
+        ),
+        migrations.AddField(
+            model_name='product',
             name='aspect_price_purchase',
             field=models.DecimalField(db_column='가격/구매', decimal_places=4, default=0.0, max_digits=5),
+        ),
+        migrations.AddField(
+            model_name='product',
+            name='aspect_delivery_packaging',
+            field=models.DecimalField(db_column='배송/포장', decimal_places=4, default=0.0, max_digits=5),
+        ),
+        migrations.AddField(
+            model_name='product',
+            name='aspect_ingredients_origin',
+            field=models.DecimalField(db_column='성분/원료', decimal_places=4, default=0.0, max_digits=5),
+        ),
+        migrations.AddField(
+            model_name='product',
+            name='aspect_digestion_stool',
+            field=models.DecimalField(db_column='소화/배변', decimal_places=4, default=0.0, max_digits=5),
         ),
         migrations.AddField(
             model_name='product',
@@ -46,29 +51,9 @@ class Migration(migrations.Migration):
             field=models.DecimalField(db_column='제품 성상', decimal_places=4, default=0.0, max_digits=5),
         ),
         migrations.AddField(
-            model_name='product',
+            model_name='review',
             name='aspect_smell',
-            field=models.DecimalField(db_column='냄새', decimal_places=4, default=0.0, max_digits=5),
-        ),
-        migrations.AddField(
-            model_name='review',
-            name='aspect_biological_response',
-            field=models.IntegerField(db_column='생체반응', default=0),
-        ),
-        migrations.AddField(
-            model_name='review',
-            name='aspect_delivery_packaging',
-            field=models.IntegerField(db_column='배송/포장', default=0),
-        ),
-        migrations.AddField(
-            model_name='review',
-            name='aspect_digestion_stool',
-            field=models.IntegerField(db_column='소화/배변', default=0),
-        ),
-        migrations.AddField(
-            model_name='review',
-            name='aspect_ingredients_origin',
-            field=models.IntegerField(db_column='성분/원료', default=0),
+            field=models.IntegerField(db_column='냄새', default=0),
         ),
         migrations.AddField(
             model_name='review',
@@ -77,17 +62,32 @@ class Migration(migrations.Migration):
         ),
         migrations.AddField(
             model_name='review',
+            name='aspect_biological_response',
+            field=models.IntegerField(db_column='생체반응', default=0),
+        ),
+        migrations.AddField(
+            model_name='review',
             name='aspect_price_purchase',
             field=models.IntegerField(db_column='가격/구매', default=0),
         ),
         migrations.AddField(
             model_name='review',
-            name='aspect_product_appearance',
-            field=models.IntegerField(db_column='제품 성상', default=0),
+            name='aspect_delivery_packaging',
+            field=models.IntegerField(db_column='배송/포장', default=0),
         ),
         migrations.AddField(
             model_name='review',
-            name='aspect_smell',
-            field=models.IntegerField(db_column='냄새', default=0),
+            name='aspect_ingredients_origin',
+            field=models.IntegerField(db_column='성분/원료', default=0),
+        ),
+        migrations.AddField(
+            model_name='review',
+            name='aspect_digestion_stool',
+            field=models.IntegerField(db_column='소화/배변', default=0),
+        ),
+        migrations.AddField(
+            model_name='review',
+            name='aspect_product_appearance',
+            field=models.IntegerField(db_column='제품 성상', default=0),
         ),
     ]

--- a/services/django/products/migrations/0004_local_db_schema_alignment.py
+++ b/services/django/products/migrations/0004_local_db_schema_alignment.py
@@ -1,0 +1,224 @@
+from django.db import migrations, models
+
+
+DOMAIN_TABLES_SQL = """
+CREATE SEQUENCE IF NOT EXISTS public.breed_meta_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE IF NOT EXISTS public.breed_meta (
+    id integer NOT NULL,
+    species character varying(10),
+    breed_name character varying(100),
+    breed_name_en character varying(100),
+    group_name character varying(50),
+    size_class text[],
+    age_group character varying(20),
+    care_difficulty integer,
+    preferred_food text,
+    health_products text,
+    chunk_text text,
+    embedding public.vector(1024),
+    search_vector tsvector
+);
+
+ALTER SEQUENCE public.breed_meta_id_seq OWNED BY public.breed_meta.id;
+ALTER TABLE ONLY public.breed_meta
+    ALTER COLUMN id SET DEFAULT nextval('public.breed_meta_id_seq'::regclass);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'breed_meta_pkey'
+          AND conrelid = 'public.breed_meta'::regclass
+    ) THEN
+        ALTER TABLE ONLY public.breed_meta
+            ADD CONSTRAINT breed_meta_pkey PRIMARY KEY (id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_breed_meta_breed_age
+    ON public.breed_meta USING btree (breed_name, age_group);
+CREATE INDEX IF NOT EXISTS idx_breed_meta_embedding
+    ON public.breed_meta USING hnsw (embedding public.vector_cosine_ops)
+    WITH (m = '16', ef_construction = '64');
+CREATE INDEX IF NOT EXISTS idx_breed_meta_search_vector
+    ON public.breed_meta USING gin (search_vector);
+CREATE INDEX IF NOT EXISTS idx_breed_meta_species
+    ON public.breed_meta USING btree (species);
+
+CREATE SEQUENCE IF NOT EXISTS public.domain_qna_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+CREATE TABLE IF NOT EXISTS public.domain_qna (
+    id integer NOT NULL,
+    no integer NOT NULL,
+    species character varying(10),
+    category character varying(50),
+    source character varying(20),
+    chunk_text text,
+    embedding public.vector(1024),
+    search_vector tsvector
+);
+
+ALTER SEQUENCE public.domain_qna_id_seq OWNED BY public.domain_qna.id;
+ALTER TABLE ONLY public.domain_qna
+    ALTER COLUMN id SET DEFAULT nextval('public.domain_qna_id_seq'::regclass);
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'domain_qna_pkey'
+          AND conrelid = 'public.domain_qna'::regclass
+    ) THEN
+        ALTER TABLE ONLY public.domain_qna
+            ADD CONSTRAINT domain_qna_pkey PRIMARY KEY (id);
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_domain_qna_embedding
+    ON public.domain_qna USING hnsw (embedding public.vector_cosine_ops)
+    WITH (m = '16', ef_construction = '64');
+CREATE INDEX IF NOT EXISTS idx_domain_qna_search_vector
+    ON public.domain_qna USING gin (search_vector);
+CREATE INDEX IF NOT EXISTS idx_domain_qna_species
+    ON public.domain_qna USING btree (species);
+
+ALTER TABLE public.product ALTER COLUMN "냄새" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "기호성" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "생체반응" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "가격/구매" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "배송/포장" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "성분/원료" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "소화/배변" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "제품 성상" DROP NOT NULL;
+ALTER TABLE public.product ALTER COLUMN "냄새" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "기호성" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "생체반응" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "가격/구매" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "배송/포장" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "성분/원료" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "소화/배변" SET DEFAULT 0;
+ALTER TABLE public.product ALTER COLUMN "제품 성상" SET DEFAULT 0;
+
+ALTER TABLE public.review ALTER COLUMN "냄새" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "기호성" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "생체반응" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "가격/구매" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "배송/포장" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "성분/원료" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "소화/배변" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "제품 성상" DROP NOT NULL;
+ALTER TABLE public.review ALTER COLUMN "냄새" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "기호성" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "생체반응" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "가격/구매" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "배송/포장" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "성분/원료" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "소화/배변" SET DEFAULT 0;
+ALTER TABLE public.review ALTER COLUMN "제품 성상" SET DEFAULT 0;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("products", "0003_product_aspect_biological_response_and_more"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_biological_response",
+            field=models.DecimalField(blank=True, db_column="생체반응", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_delivery_packaging",
+            field=models.DecimalField(blank=True, db_column="배송/포장", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_digestion_stool",
+            field=models.DecimalField(blank=True, db_column="소화/배변", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_ingredients_origin",
+            field=models.DecimalField(blank=True, db_column="성분/원료", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_palatability",
+            field=models.DecimalField(blank=True, db_column="기호성", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_price_purchase",
+            field=models.DecimalField(blank=True, db_column="가격/구매", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_product_appearance",
+            field=models.DecimalField(blank=True, db_column="제품 성상", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="product",
+            name="aspect_smell",
+            field=models.DecimalField(blank=True, db_column="냄새", decimal_places=4, default=0.0, max_digits=5, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_biological_response",
+            field=models.IntegerField(blank=True, db_column="생체반응", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_delivery_packaging",
+            field=models.IntegerField(blank=True, db_column="배송/포장", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_digestion_stool",
+            field=models.IntegerField(blank=True, db_column="소화/배변", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_ingredients_origin",
+            field=models.IntegerField(blank=True, db_column="성분/원료", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_palatability",
+            field=models.IntegerField(blank=True, db_column="기호성", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_price_purchase",
+            field=models.IntegerField(blank=True, db_column="가격/구매", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_product_appearance",
+            field=models.IntegerField(blank=True, db_column="제품 성상", default=0, null=True),
+        ),
+        migrations.AlterField(
+            model_name="review",
+            name="aspect_smell",
+            field=models.IntegerField(blank=True, db_column="냄새", default=0, null=True),
+        ),
+        migrations.RunSQL(DOMAIN_TABLES_SQL, migrations.RunSQL.noop),
+    ]

--- a/services/django/products/models.py
+++ b/services/django/products/models.py
@@ -36,14 +36,14 @@ class Product(models.Model):
     crawled_at             = models.DateTimeField()
 
     # Aspect Scores (Averages)
-    aspect_smell               = models.DecimalField(max_digits=5, decimal_places=4, db_column='냄새', default=0.0)
-    aspect_palatability        = models.DecimalField(max_digits=5, decimal_places=4, db_column='기호성', default=0.0)
-    aspect_biological_response = models.DecimalField(max_digits=5, decimal_places=4, db_column='생체반응', default=0.0)
-    aspect_price_purchase      = models.DecimalField(max_digits=5, decimal_places=4, db_column='가격/구매', default=0.0)
-    aspect_delivery_packaging  = models.DecimalField(max_digits=5, decimal_places=4, db_column='배송/포장', default=0.0)
-    aspect_ingredients_origin  = models.DecimalField(max_digits=5, decimal_places=4, db_column='성분/원료', default=0.0)
-    aspect_digestion_stool     = models.DecimalField(max_digits=5, decimal_places=4, db_column='소화/배변', default=0.0)
-    aspect_product_appearance  = models.DecimalField(max_digits=5, decimal_places=4, db_column='제품 성상', default=0.0)
+    aspect_smell               = models.DecimalField(max_digits=5, decimal_places=4, db_column='냄새', default=0.0, null=True, blank=True)
+    aspect_palatability        = models.DecimalField(max_digits=5, decimal_places=4, db_column='기호성', default=0.0, null=True, blank=True)
+    aspect_biological_response = models.DecimalField(max_digits=5, decimal_places=4, db_column='생체반응', default=0.0, null=True, blank=True)
+    aspect_price_purchase      = models.DecimalField(max_digits=5, decimal_places=4, db_column='가격/구매', default=0.0, null=True, blank=True)
+    aspect_delivery_packaging  = models.DecimalField(max_digits=5, decimal_places=4, db_column='배송/포장', default=0.0, null=True, blank=True)
+    aspect_ingredients_origin  = models.DecimalField(max_digits=5, decimal_places=4, db_column='성분/원료', default=0.0, null=True, blank=True)
+    aspect_digestion_stool     = models.DecimalField(max_digits=5, decimal_places=4, db_column='소화/배변', default=0.0, null=True, blank=True)
+    aspect_product_appearance  = models.DecimalField(max_digits=5, decimal_places=4, db_column='제품 성상', default=0.0, null=True, blank=True)
 
     class Meta:
         db_table = "product"
@@ -102,14 +102,14 @@ class Review(models.Model):
     pet_breed      = models.CharField(max_length=100, null=True, blank=True)
 
     # Aspect Sentiments (-1, 0, 1)
-    aspect_smell               = models.IntegerField(db_column='냄새', default=0)
-    aspect_palatability        = models.IntegerField(db_column='기호성', default=0)
-    aspect_biological_response = models.IntegerField(db_column='생체반응', default=0)
-    aspect_price_purchase      = models.IntegerField(db_column='가격/구매', default=0)
-    aspect_delivery_packaging  = models.IntegerField(db_column='배송/포장', default=0)
-    aspect_ingredients_origin  = models.IntegerField(db_column='성분/원료', default=0)
-    aspect_digestion_stool     = models.IntegerField(db_column='소화/배변', default=0)
-    aspect_product_appearance  = models.IntegerField(db_column='제품 성상', default=0)
+    aspect_smell               = models.IntegerField(db_column='냄새', default=0, null=True, blank=True)
+    aspect_palatability        = models.IntegerField(db_column='기호성', default=0, null=True, blank=True)
+    aspect_biological_response = models.IntegerField(db_column='생체반응', default=0, null=True, blank=True)
+    aspect_price_purchase      = models.IntegerField(db_column='가격/구매', default=0, null=True, blank=True)
+    aspect_delivery_packaging  = models.IntegerField(db_column='배송/포장', default=0, null=True, blank=True)
+    aspect_ingredients_origin  = models.IntegerField(db_column='성분/원료', default=0, null=True, blank=True)
+    aspect_digestion_stool     = models.IntegerField(db_column='소화/배변', default=0, null=True, blank=True)
+    aspect_product_appearance  = models.IntegerField(db_column='제품 성상', default=0, null=True, blank=True)
 
     class Meta:
         db_table = "review"

--- a/services/django/users/migrations/0005_local_db_schema_alignment.py
+++ b/services/django/users/migrations/0005_local_db_schema_alignment.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+LOCAL_DB_ALIGNMENT_SQL = """
+ALTER TABLE public.user_profile
+    DROP CONSTRAINT IF EXISTS user_profile_nickname_9cd44794_uniq;
+DROP INDEX IF EXISTS public.user_profile_nickname_9cd44794_like;
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'user_social_auth_uid_required'
+          AND conrelid = 'public.social_auth_usersocialauth'::regclass
+    ) THEN
+        ALTER TABLE public.social_auth_usersocialauth
+            ADD CONSTRAINT user_social_auth_uid_required
+            CHECK (NOT (uid::text = ''::text));
+    END IF;
+END $$;
+"""
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("social_django", "0016_alter_usersocialauth_extra_data"),
+        ("users", "0004_userprofile_nickname_unique"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                migrations.RunSQL(LOCAL_DB_ALIGNMENT_SQL, migrations.RunSQL.noop),
+            ],
+            state_operations=[
+                migrations.AlterField(
+                    model_name="userprofile",
+                    name="nickname",
+                    field=models.CharField(max_length=100),
+                ),
+            ],
+        ),
+    ]

--- a/services/django/users/models.py
+++ b/services/django/users/models.py
@@ -41,7 +41,7 @@ class User(AbstractBaseUser, PermissionsMixin):
 
 class UserProfile(models.Model):
     user              = models.OneToOneField(User, on_delete=models.CASCADE, primary_key=True, related_name="profile")
-    nickname          = models.CharField(max_length=100, unique=True)
+    nickname          = models.CharField(max_length=100)
     age               = models.IntegerField(null=True, blank=True)
     gender            = models.CharField(max_length=20, null=True, blank=True)
     address           = models.TextField(null=True, blank=True)


### PR DESCRIPTION
## 요약
로컬 PostgreSQL 스키마와 Django migration state가 어긋난 부분을 정리하고, products/users 모델 상태를 현재 로컬 DB 기준으로 맞췄습니다.

## 변경 사항
- `products`의 aspect 필드와 `users.UserProfile.nickname` 필드 상태를 로컬 DB 스키마 기준으로 조정했습니다.
- `products.0004_local_db_schema_alignment`, `users.0005_local_db_schema_alignment`를 추가해 로컬 DB 정렬용 SQL과 state 변경을 분리했습니다.
- 기존 `products.0003` 마이그레이션 정의도 현재 모델 필드 순서와 맞도록 함께 정리했습니다.

## 관련 이슈
- 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- `products.0003` 기존 마이그레이션 수정이 포함되어 있어, 이미 적용된 환경과의 정합성 관점에서 이 접근이 적절한지 우선 확인 부탁드립니다.
- 이번 변경은 로컬 DB 스키마 정렬 목적이 강하므로, 팀 공용 migration으로 가져갈지 여부를 같이 검토 부탁드립니다.
