### PR TITLE
fix: 채팅 오류 처리 및 로딩 상태 UX 정리

### DIFF
--- a/services/django/chat/api_views.py
+++ b/services/django/chat/api_views.py
@@ -29,10 +29,29 @@ def _read_json_body(request):
         raise ValueError("유효한 JSON 요청이 필요합니다.")
 
 
+def _proxy_error_response(detail, status):
+    return JsonResponse({"detail": detail}, status=status)
+
+
+def _stream_error_event(message):
+    payload = {"type": "error", "message": message}
+    return f"data: {json.dumps(payload, ensure_ascii=False)}\n\n"
+
+
+def _map_upstream_exception(exc):
+    if isinstance(exc, httpx.TimeoutException):
+        return "채팅 서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.", 504
+    return "채팅 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.", 502
+
+
 def _proxy_json(method, url, user_id, payload=None):
     headers = _internal_headers(user_id, include_content_type=payload is not None)
-    with httpx.Client(timeout=30.0) as client:
-        response = client.request(method, url, headers=headers, json=payload)
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            response = client.request(method, url, headers=headers, json=payload)
+    except httpx.HTTPError as exc:
+        detail, status = _map_upstream_exception(exc)
+        return _proxy_error_response(detail, status)
 
     try:
         data = response.json()
@@ -45,22 +64,30 @@ def _proxy_json(method, url, user_id, payload=None):
 def _stream_fastapi_response(url, payload, user_id):
     headers = _internal_headers(user_id)
 
-    with httpx.Client(timeout=None) as client:
-        with client.stream("POST", url, headers=headers, json=payload) as response:
-            if response.status_code != 200:
-                detail = "채팅 요청 처리에 실패했습니다."
-                try:
-                    detail = response.json().get("detail", detail)
-                except Exception:
-                    text = response.text.strip()
-                    if text:
-                        detail = text
-                yield f"data: {json.dumps({'type': 'error', 'message': detail}, ensure_ascii=False)}\n\n"
-                return
+    try:
+        with httpx.Client(timeout=None) as client:
+            with client.stream("POST", url, headers=headers, json=payload) as response:
+                if response.status_code != 200:
+                    detail = "채팅 요청 처리에 실패했습니다."
+                    try:
+                        detail = response.json().get("detail", detail)
+                    except Exception:
+                        text = response.text.strip()
+                        if text:
+                            detail = text
+                    yield _stream_error_event(detail)
+                    return
 
-            for chunk in response.iter_bytes():
-                if chunk:
-                    yield chunk
+                try:
+                    for chunk in response.iter_bytes():
+                        if chunk:
+                            yield chunk
+                except httpx.HTTPError as exc:
+                    detail, _ = _map_upstream_exception(exc)
+                    yield _stream_error_event(detail)
+    except httpx.HTTPError as exc:
+        detail, _ = _map_upstream_exception(exc)
+        yield _stream_error_event(detail)
 
 
 def _require_authenticated(request):

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+import httpx
 from django.conf import settings
 from django.test import TestCase
 from django.urls import reverse
@@ -67,6 +68,40 @@ class _FakeJsonResponse:
 
     def json(self):
         return self._payload
+
+
+class _ExplodingHttpxClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, method, url, headers=None, json=None):
+        raise httpx.ConnectError("connection failed")
+
+    def stream(self, method, url, headers=None, json=None):
+        raise httpx.ConnectError("connection failed")
+
+
+class _TimeoutHttpxClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def request(self, method, url, headers=None, json=None):
+        raise httpx.ReadTimeout("timed out")
+
+    def stream(self, method, url, headers=None, json=None):
+        raise httpx.ReadTimeout("timed out")
 
 
 class _FakeHttpxClient:
@@ -258,3 +293,36 @@ class ChatProxyTests(TestCase):
             settings.FASTAPI_INTERNAL_CHAT_URL.rstrip("/") + "/sessions/11111111-1111-1111-1111-111111111111/messages/",
         )
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["message"], "hello")
+
+    @patch("chat.api_views.httpx.Client", _ExplodingHttpxClient)
+    def test_sessions_proxy_returns_controlled_error_when_fastapi_is_unreachable(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get("/api/chat/sessions/")
+
+        self.assertEqual(response.status_code, 502)
+        self.assertEqual(response.json()["detail"], "채팅 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.")
+
+    @patch("chat.api_views.httpx.Client", _TimeoutHttpxClient)
+    def test_sessions_proxy_returns_timeout_error_when_fastapi_response_is_delayed(self):
+        self.client.force_login(self.user)
+
+        response = self.client.get("/api/chat/sessions/")
+
+        self.assertEqual(response.status_code, 504)
+        self.assertEqual(response.json()["detail"], "채팅 서버 응답이 지연되고 있습니다. 잠시 후 다시 시도해 주세요.")
+
+    @patch("chat.api_views.httpx.Client", _ExplodingHttpxClient)
+    def test_session_messages_proxy_streams_controlled_error_event_when_fastapi_is_unreachable(self):
+        self.client.force_login(self.user)
+
+        response = self.client.post(
+            "/api/chat/sessions/11111111-1111-1111-1111-111111111111/messages/",
+            data='{"message":"hello"}',
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = b"".join(response.streaming_content).decode("utf-8")
+        self.assertIn('"type": "error"', payload)
+        self.assertIn("채팅 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.", payload)

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -143,6 +143,40 @@
     transition: none;
   }
 
+  #sendBtn.is-busy {
+    cursor: wait;
+    opacity: 0.82;
+  }
+
+  #messageInput:disabled,
+  #sendBtn:disabled {
+    cursor: not-allowed;
+  }
+
+  .chat-system-notice {
+    display: flex;
+    justify-content: center;
+  }
+
+  .chat-system-notice-badge {
+    max-width: 520px;
+    border-radius: 9999px;
+    border: 1px solid #dbe7f5;
+    background: #f8fbff;
+    padding: 10px 14px;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.5;
+    color: #4a5568;
+    text-align: center;
+  }
+
+  #chatNoticeHost {
+    margin-top: 18px;
+    display: flex;
+    justify-content: center;
+  }
+
   .wishlist-heart svg:last-child {
     display: none;
   }
@@ -828,6 +862,7 @@
                   🦷 치석 제거용 껌 추천
                 </button>
               </div>
+              <div id="chatNoticeHost"></div>
               {% else %}
               <p class="mt-[14px] text-[16px] text-[#718096]">로그인 후 AI 비서와 대화를 시작하고 다양한 혜택을 만나보세요.</p>
               {% endif %}
@@ -1216,6 +1251,7 @@
   var sendIcon = document.getElementById('sendIcon');
   var sendBtn = document.getElementById('sendBtn');
   var chatEmptyState = document.getElementById('chatEmptyState');
+  var chatNoticeHost = document.getElementById('chatNoticeHost');
   var chatSection = document.getElementById('chatSection');
   var chatThread = document.getElementById('chatThread');
   var chatMessages = document.getElementById('chatMessages');
@@ -1278,6 +1314,7 @@
   var quickOrderSelectedCouponDiscount = 0;
   var quickOrderSelectedCouponMinTotal = 0;
   var quickOrderSelectedMileage = 0;
+  var isSendingMessage = false;
   // 선택된 펫 프로필 (FastAPI 요청에 사용)
   var activePetProfile = null;
   var activePetHealthConcerns = [];
@@ -1726,6 +1763,59 @@
     return wrapper;
   }
 
+  function ensureChatThreadVisible() {
+    if (chatEmptyState) chatEmptyState.classList.add('hidden');
+    if (chatThread) chatThread.classList.remove('hidden');
+    updateChatSectionState(true);
+  }
+
+  function appendSystemNotice(message) {
+    if (!chatMessages) return;
+    ensureChatThreadVisible();
+    var wrapper = document.createElement('div');
+    wrapper.className = 'chat-system-notice';
+
+    var badge = document.createElement('div');
+    badge.className = 'chat-system-notice-badge';
+    badge.textContent = message;
+
+    wrapper.appendChild(badge);
+    chatMessages.appendChild(wrapper);
+    scrollToBottom();
+    return wrapper;
+  }
+
+  function showChatNotice(message) {
+    if (!message) return;
+    if (activeSessionId) {
+      appendSystemNotice(message);
+      return;
+    }
+    if (!chatNoticeHost) return;
+    chatNoticeHost.innerHTML = '';
+    var badge = document.createElement('div');
+    badge.className = 'chat-system-notice-badge';
+    badge.textContent = message;
+    chatNoticeHost.appendChild(badge);
+    window.setTimeout(function () {
+      if (chatNoticeHost && chatNoticeHost.contains(badge)) {
+        chatNoticeHost.removeChild(badge);
+      }
+    }, 3200);
+  }
+
+  function setComposerBusy(nextBusy) {
+    isSendingMessage = !!nextBusy;
+    if (messageInput) {
+      messageInput.disabled = isSendingMessage;
+    }
+    if (sendBtn) {
+      sendBtn.disabled = isSendingMessage;
+      sendBtn.classList.toggle('is-busy', isSendingMessage);
+      sendBtn.setAttribute('aria-label', isSendingMessage ? '답변 생성 중' : (messageInput && messageInput.value.trim().length > 0 ? '메시지 전송' : '음성 입력'));
+    }
+  }
+
   function updateChatSectionState(hasSession) {
     if (!chatSection) return;
     chatSection.classList.toggle('is-empty', !hasSession);
@@ -1781,7 +1871,10 @@
         renderSessionThread(sessionId);
       }
     }).catch(function (error) {
-      window.alert(error.message || '대화 기록을 불러오지 못했습니다.');
+      if (activeSessionId === sessionId) {
+        renderSessionThread(sessionId);
+        showChatNotice(error.message || '대화 기록을 불러오지 못했습니다.');
+      }
     });
   }
 
@@ -1939,6 +2032,7 @@
   function performResetState(showEmptyWithFade) {
       if (composerStage) composerStage.classList.add('no-transition');
       if (chatMessages) chatMessages.innerHTML = '';
+      if (chatNoticeHost) chatNoticeHost.innerHTML = '';
       if (chatThread) chatThread.classList.add('hidden');
       if (showEmptyWithFade) {
         showEmptyStateWithFade();
@@ -1987,7 +2081,9 @@
   window.sendMessage = function () {
     if (!messageInput) return;
     var msg = messageInput.value.trim();
-    if (!msg) return;
+    if (!msg || isSendingMessage) return;
+
+    setComposerBusy(true);
 
     var ensureSessionPromise;
     if (activeSessionId) {
@@ -2051,6 +2147,7 @@
               var errorText = assistantEl.querySelector('.assistant-text');
               if (errorText) errorText.textContent = message;
             }
+            setComposerBusy(false);
           });
         }
 
@@ -2064,7 +2161,10 @@
 
         function read() {
           reader.read().then(function (result) {
-            if (result.done) return;
+            if (result.done) {
+              setComposerBusy(false);
+              return;
+            }
             buf += decoder.decode(result.value, { stream: true });
             var lines = buf.split('\n\n');
             buf = lines.pop();
@@ -2085,12 +2185,14 @@
                   renderProductCards(evt.cards);
                 } else if (evt.type === 'done') {
                   ensureSessionState(sessionId).messages.push({ role: 'assistant', text: assistantText });
+                  setComposerBusy(false);
                 } else if (evt.type === 'error') {
                   assistantText = evt.message || '죄송합니다, 오류가 발생했습니다.';
                   if (assistantEl) {
                     var errorNode = assistantEl.querySelector('.assistant-text');
                     if (errorNode) errorNode.textContent = assistantText;
                   }
+                  setComposerBusy(false);
                 }
               } catch(e) {}
             });
@@ -2103,9 +2205,11 @@
           var p = assistantEl.querySelector('.assistant-text');
           if (p) p.textContent = '서버 연결에 실패했습니다.';
         }
+        setComposerBusy(false);
       });
     }).catch(function (error) {
-      window.alert(error.message || '세션 생성에 실패했습니다.');
+      showChatNotice(error.message || '세션 생성에 실패했습니다.');
+      setComposerBusy(false);
     });
   };
 
@@ -3158,7 +3262,7 @@
           pendingDeleteId = null;
         });
       }).catch(function () {
-        window.alert('대화 기록 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+        showChatNotice('대화 기록 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.');
       });
     });
   }
@@ -3233,7 +3337,7 @@
             if (data && data.title) span.textContent = data.title;
           });
         }).catch(function () {
-          window.alert('제목 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
+          showChatNotice('제목 수정에 실패했습니다. 잠시 후 다시 시도해 주세요.');
         });
       }
       {% endif %}

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -36,14 +36,14 @@
     visibility: visible;
   }
 
-  #quickOrderToast {
+  #chatActionToast {
     opacity: 0;
     visibility: hidden;
     transform: translate(-50%, 10px) scale(0.98);
     transition: opacity 180ms ease, transform 180ms ease;
   }
 
-  #quickOrderToast.is-open {
+  #chatActionToast.is-open {
     opacity: 1;
     visibility: visible;
     transform: translate(-50%, 0) scale(1);
@@ -625,10 +625,9 @@
       </div>
     </div>
 
-    <div id="quickOrderToast"
-         class="pointer-events-none absolute left-1/2 top-[88px] z-[70] flex h-[44px] min-w-[232px] -translate-x-1/2 items-center justify-center gap-[8px] rounded-full bg-[#1f2937] px-[18px] text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
-      <span aria-hidden="true" class="text-[14px]">✓</span>
-      <span>주문이 완료되었습니다</span>
+    <div id="chatActionToast"
+         class="pointer-events-none absolute left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+      오류가 발생했습니다.
     </div>
     {% endif %}
 
@@ -1304,7 +1303,6 @@
   var SHARED_CART_COUNT_STORAGE_KEY = 'tailtalk_shared_cart_count';
   var SHARED_CART_ITEMS_STORAGE_KEY = 'tailtalk_shared_cart_items';
   var previewWishlistItems = [];
-  var quickOrderToastTimer = null;
   var quickOrderSlideEnabled = false;
   var quickOrderSlideDragging = false;
   var quickOrderSlideStartX = 0;
@@ -1315,6 +1313,7 @@
   var quickOrderSelectedCouponMinTotal = 0;
   var quickOrderSelectedMileage = 0;
   var isSendingMessage = false;
+  var chatActionToastTimer = null;
   // 선택된 펫 프로필 (FastAPI 요청에 사용)
   var activePetProfile = null;
   var activePetHealthConcerns = [];
@@ -1804,6 +1803,21 @@
     }, 3200);
   }
 
+  function showChatActionToast(message) {
+    var toast = document.getElementById('chatActionToast');
+    if (!toast || !message) return;
+    toast.textContent = message;
+    toast.classList.add('is-open');
+    if (chatActionToastTimer) {
+      window.clearTimeout(chatActionToastTimer);
+      chatActionToastTimer = null;
+    }
+    chatActionToastTimer = window.setTimeout(function () {
+      toast.classList.remove('is-open');
+      chatActionToastTimer = null;
+    }, 2600);
+  }
+
   function setComposerBusy(nextBusy) {
     isSendingMessage = !!nextBusy;
     if (messageInput) {
@@ -1989,7 +2003,7 @@
       })
       .catch(function (error) {
         if (!config.silent) {
-          window.alert(error.message || '관심 상품 정보를 불러오지 못했습니다.');
+          showChatActionToast(error.message || '관심 상품 정보를 불러오지 못했습니다.');
         }
         return [];
       });
@@ -2525,7 +2539,7 @@
       })
       .catch(function (error) {
         if (!config.silent) {
-          window.alert(error.message || '관심 상품 정보를 불러오지 못했습니다.');
+          showChatActionToast(error.message || '관심 상품 정보를 불러오지 못했습니다.');
         }
         return [];
       });
@@ -2544,7 +2558,7 @@
       })
       .catch(function (error) {
         if (!config.silent) {
-          window.alert(error.message || '장바구니 정보를 불러오지 못했습니다.');
+          showChatActionToast(error.message || '장바구니 정보를 불러오지 못했습니다.');
         }
       });
   }
@@ -2655,7 +2669,7 @@
     }).then(function () {
       return refreshCartPanelFromApi({ silent: true, syncShared: true });
     }).catch(function (error) {
-      window.alert(error.message || '장바구니 수량을 변경하지 못했습니다.');
+      showChatActionToast(error.message || '장바구니 수량을 변경하지 못했습니다.');
     });
   };
 
@@ -2673,7 +2687,7 @@
     }).then(function () {
       return refreshCartPanelFromApi({ silent: true, syncShared: true });
     }).catch(function (error) {
-      window.alert(error.message || '장바구니 상품을 삭제하지 못했습니다.');
+      showChatActionToast(error.message || '장바구니 상품을 삭제하지 못했습니다.');
     });
   };
 
@@ -2709,7 +2723,7 @@
     return;
     {% endif %}
     if (!product.goodsId) {
-      window.alert('현재 추천 상품은 장바구니 연동 준비 중입니다.');
+      showChatActionToast('현재 추천 상품은 장바구니 연동 준비 중입니다.');
       return;
     }
     requestJson('/api/orders/cart/', {
@@ -2721,7 +2735,7 @@
     }).then(function () {
       return refreshCartPanelFromApi({ silent: true, syncShared: true });
     }).catch(function (error) {
-      window.alert(error.message || '장바구니에 상품을 담지 못했습니다.');
+      showChatActionToast(error.message || '장바구니에 상품을 담지 못했습니다.');
     });
   };
 
@@ -2729,7 +2743,7 @@
     if (!button) return;
     var productId = button.getAttribute('data-product-id');
     if (!productId) {
-      window.alert('상품 식별 정보를 찾을 수 없습니다.');
+      showChatActionToast('상품 식별 정보를 찾을 수 없습니다.');
       return;
     }
 
@@ -2768,7 +2782,7 @@
     }).then(function () {
       return refreshRecommendedWishlistState({ silent: true });
     }).catch(function (error) {
-      window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+      showChatActionToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
     });
   };
 
@@ -2798,7 +2812,7 @@
     }).then(function () {
       return refreshRecommendedWishlistState({ silent: true });
     }).catch(function (error) {
-      window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+      showChatActionToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
     });
   };
 
@@ -2843,7 +2857,7 @@
       switchProductTab('cart');
       return refreshCartPanelFromApi({ silent: true, syncShared: true });
     }).catch(function (error) {
-      window.alert(error.message || '장바구니에 상품을 담지 못했습니다.');
+      showChatActionToast(error.message || '장바구니에 상품을 담지 못했습니다.');
     });
   };
 
@@ -2972,20 +2986,6 @@
     }
   }
 
-  function showQuickOrderToast() {
-    var toast = document.getElementById('quickOrderToast');
-    if (!toast) return;
-    if (quickOrderToastTimer) {
-      window.clearTimeout(quickOrderToastTimer);
-      quickOrderToastTimer = null;
-    }
-    toast.classList.add('is-open');
-    quickOrderToastTimer = window.setTimeout(function () {
-      toast.classList.remove('is-open');
-      quickOrderToastTimer = null;
-    }, 2200);
-  }
-
   function updateQuickOrderSlideState(enabled) {
     var slide = document.getElementById('quickOrderSlide');
     var thumb = document.getElementById('quickOrderSlideThumb');
@@ -3087,7 +3087,6 @@
   window.submitQuickOrder = function () {
     closeQuickOrderModal();
     clearCartPanel();
-    showQuickOrderToast();
   };
 
   window.goToCartPage = function () {


### PR DESCRIPTION
## 요약
- 채팅 프록시 예외 처리를 정리해 FastAPI 연결 실패가 Django 500으로 바로 터지지 않도록 수정했습니다.
- 채팅 화면의 오류 안내를 alert 대신 시스템 안내와 토스트로 통일했습니다.
- 전송 중 중복 입력과 불필요한 완료 토스트를 정리했습니다.

## 변경 사항
- FastAPI 연결 실패 및 타임아웃 시 제어된 502/504 응답 반환
- 메시지 스트림 실패 시 SSE 에러 이벤트로 처리
- 세션 생성/대화 기록 로드 실패를 채팅 화면 내 시스템 안내로 변경
- 상품 패널 관련 실패 안내를 공용 토스트로 통일
- 메시지 전송 중 입력/버튼 중복 동작 방지
- 빠른 주문 완료 토스트 제거
- 채팅 프록시 예외 처리 테스트 추가

## 검증
- `docker compose -f infra/docker-compose.yml exec -T django python manage.py test chat.tests`

## 관련 이슈
- closes #188
- closes #191