### PR TITLE
ci(actions): fork PR 병합 후 Django 배포가 되도록 트리거 수정

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -3,7 +3,17 @@ name: Django Test EB CI/CD
 on:
   pull_request:
     types:
-      - closed
+      - opened
+      - synchronize
+      - reopened
+    branches:
+      - develop
+    paths:
+      - ".github/workflows/ci-cd.yml"
+      - "deploy/eb/test-django/**"
+      - "infra/**"
+      - "services/django/**"
+  push:
     branches:
       - develop
     paths:
@@ -31,23 +41,21 @@ jobs:
     name: CI - Build & Test
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: github.event.pull_request.merged == true
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
           submodules: recursive
 
       - name: Create test env file
         run: |
           cat <<'EOF' > infra/.env
-          DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
+          DJANGO_SECRET_KEY=test-secret
           DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1,testserver
-          POSTGRES_DB=${{ secrets.POSTGRES_DB }}
-          POSTGRES_USER=${{ secrets.POSTGRES_USER }}
-          POSTGRES_PASSWORD=${{ secrets.POSTGRES_PASSWORD }}
+          POSTGRES_DB=test_db
+          POSTGRES_USER=test_user
+          POSTGRES_PASSWORD=test_password
           POSTGRES_HOST=postgres
           POSTGRES_PORT=5432
           FASTAPI_INTERNAL_CHAT_URL=http://fastapi:8001/api/chat/
@@ -106,12 +114,13 @@ jobs:
     timeout-minutes: 30
     needs:
       - ci
+    if: github.event_name == 'push'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.merge_commit_sha }}
+          ref: ${{ github.sha }}
           submodules: recursive
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
변경 내용\n- pull_request 에서는 Django CI만 실행\n- Docker Hub/AWS secret이 필요한 배포 단계는 develop push 에서만 실행\n- PR CI에서 secret 없이도 돌 수 있도록 테스트용 env 값을 placeholder 로 정리\n\n해결하려는 문제\n- fork PR merge 후 pull_request.closed 이벤트에서는 secret이 주입되지 않아 Docker Hub 로그인과 EB 배포가 실패할 수 있음\n- 배포를 push 이벤트로 옮겨 secret 접근 문제를 제거함\n\n검증\n- workflow YAML 파싱 확인\n- trigger/job 조건 diff 검토\n- Web과 AI 배포 구조 재점검