### PR TITLE
[feat] 주문 완료 및 장바구니 주문 UX 정리 (#196, #197)

### DIFF
--- a/services/django/orders/page_urls.py
+++ b/services/django/orders/page_urls.py
@@ -3,5 +3,6 @@ from . import page_views
 
 urlpatterns = [
     path("orders/", page_views.order_list, name="order_list"),
+    path("orders/complete/<uuid:order_id>/", page_views.order_complete, name="order_complete"),
     path("products/", page_views.used_products, name="used_products"),
 ]

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.shortcuts import render
+from django.shortcuts import get_object_or_404, render
 
 from products.models import Product
 from .models import Cart, Order, Wishlist
@@ -56,6 +56,16 @@ def _display_delivery_address(value):
     if base_is_placeholder:
         return detail_address or fallback
     return f"{base_address}, {detail_address}"
+
+
+def _split_delivery_address(value):
+    if not value:
+        return "", ""
+
+    parts = [part.strip() for part in value.split("|", 1)]
+    base_address = parts[0] if parts else ""
+    detail_address = parts[1] if len(parts) > 1 else ""
+    return base_address, detail_address
 
 
 def _recommended_note(index):
@@ -160,6 +170,44 @@ def _serialize_order_group(order):
         "payment_method": order.payment_method,
         "item_count": total_quantity,
         "items": items,
+    }
+
+
+def _serialize_order_completion(order):
+    base_address, detail_address = _split_delivery_address(order.delivery_address)
+    items = []
+    total_quantity = 0
+
+    for item in order.items.select_related("product").all():
+        total_quantity += item.quantity
+        items.append(
+            {
+                "name": _display_product_name(item.product.brand_name, item.product.goods_name),
+                "brand": item.product.brand_name,
+                "thumbnail_url": item.product.thumbnail_url,
+                "quantity": item.quantity,
+                "line_total": _format_price(item.price_at_order * item.quantity),
+            }
+        )
+
+    return {
+        "order_id": str(order.order_id),
+        "created_at": order.created_at.strftime("%Y.%m.%d %H:%M"),
+        "recipient_name": order.recipient_name,
+        "recipient_phone": order.recipient_phone,
+        "delivery_base_address": base_address,
+        "delivery_detail_address": detail_address,
+        "delivery_address_display": _display_delivery_address(order.delivery_address),
+        "delivery_message": order.delivery_message or "배송 메시지 없음",
+        "payment_method": order.payment_method,
+        "product_total": _format_price(order.product_total),
+        "coupon_discount": _format_price(order.coupon_discount),
+        "mileage_discount": _format_price(order.mileage_discount),
+        "shipping_fee": "무료" if order.shipping_fee == 0 else _format_price(order.shipping_fee),
+        "total_price": _format_price(order.total_price),
+        "item_count": total_quantity,
+        "items": items,
+        "primary_item_name": items[0]["name"] if items else "주문 상품",
     }
 
 
@@ -575,5 +623,26 @@ def used_products(request):
             "discount_total_raw": discount,
             "shipping_fee_raw": shipping_fee,
             "active_tab": "cart",
+        },
+    )
+
+
+@login_required
+def order_complete(request, order_id):
+    order = get_object_or_404(
+        Order.objects.filter(user=request.user).prefetch_related("items__product"),
+        order_id=order_id,
+    )
+    entry = (request.GET.get("entry") or "cart").strip().lower()
+    if entry not in {"cart", "quick"}:
+        entry = "cart"
+
+    return render(
+        request,
+        "orders/complete.html",
+        {
+            "active_tab": "orders",
+            "order_completion": _serialize_order_completion(order),
+            "order_entry": entry,
         },
     )

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -3088,9 +3088,65 @@
     quickOrderModal.classList.remove('is-open');
   };
 
+  function normalizeQuickOrderPaymentMethod(value) {
+    var normalized = String(value || '').trim();
+    if (!normalized || normalized.indexOf('없습니다') !== -1) {
+      return '';
+    }
+    if (normalized.indexOf('카카오') !== -1) {
+      return '카카오페이 / 일시불';
+    }
+    if (normalized.indexOf('네이버') !== -1) {
+      return '네이버페이 / 일시불';
+    }
+    return '우리카드 1234 / 일시불';
+  }
+
+  function buildQuickOrderPayload() {
+    var addressText = quickOrderAddressSummary ? quickOrderAddressSummary.textContent.trim() : '';
+    var paymentMethod = quickOrderCardSummary ? quickOrderCardSummary.textContent.trim() : '';
+
+    try {
+      var savedAddress = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
+      if (savedAddress && (savedAddress.addressMain || savedAddress.addressDetail)) {
+        addressText = [savedAddress.addressMain || '', savedAddress.addressDetail || ''].filter(Boolean).join(' | ');
+      }
+    } catch (e) {}
+
+    try {
+      var savedPayment = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
+      if (savedPayment && savedPayment.cardName && savedPayment.maskedCard) {
+        paymentMethod = savedPayment.cardName + ' / ' + savedPayment.maskedCard;
+      }
+    } catch (e) {}
+
+    return {
+      recipient_name: quickOrderRecipientSummary ? quickOrderRecipientSummary.textContent.trim() : '',
+      recipient_phone: quickOrderPhoneSummary ? quickOrderPhoneSummary.textContent.trim() : '',
+      delivery_address: addressText,
+      delivery_message: '',
+      payment_method: normalizeQuickOrderPaymentMethod(paymentMethod),
+      coupon_id: quickOrderSelectedCouponId || 'none',
+      mileage_amount: quickOrderSelectedMileage || 0,
+    };
+  }
+
   window.submitQuickOrder = function () {
-    closeQuickOrderModal();
-    clearCartPanel();
+    var payload = buildQuickOrderPayload();
+    requestJson('/api/orders/', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    }).then(function (data) {
+      var orderId = data && data.order && data.order.order_id;
+      if (!orderId) {
+        throw new Error('주문 완료 정보를 확인하지 못했습니다.');
+      }
+      closeQuickOrderModal();
+      window.location.href = '/orders/complete/' + orderId + '/?entry=quick';
+    }).catch(function (error) {
+      showChatNotice(error.message || '빠른 주문을 완료하지 못했습니다.');
+      renderQuickOrderSummary();
+    });
   };
 
   window.goToCartPage = function () {

--- a/services/django/templates/orders/complete.html
+++ b/services/django/templates/orders/complete.html
@@ -1,0 +1,156 @@
+{% extends "base.html" %}
+{% block title %}주문 완료 — TailTalk{% endblock %}
+
+{% block head %}
+<style>
+  .order-complete-shell {
+    background:
+      radial-gradient(circle at top left, rgba(125, 211, 252, 0.2), transparent 28%),
+      radial-gradient(circle at top right, rgba(196, 181, 253, 0.16), transparent 24%),
+      linear-gradient(180deg, #f8fbff 0%, #f7fafc 100%);
+  }
+
+  .order-complete-items {
+    max-height: min(560px, calc(100vh - 280px));
+    overflow-y: auto;
+    scrollbar-gutter: stable;
+    padding-right: 4px;
+  }
+
+  @media (max-width: 1023px) {
+    .order-complete-sticky {
+      position: static;
+    }
+
+    .order-complete-items {
+      max-height: none;
+      overflow: visible;
+      padding-right: 0;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="order-complete-shell min-h-screen">
+  <div class="mx-auto max-w-[1120px] px-4 py-8 md:px-6">
+    <div class="flex items-center justify-start">
+      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
+        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+      </a>
+    </div>
+
+    <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
+      <section class="overflow-hidden rounded-[32px] border border-[#dbe7f5] bg-white shadow-[0_14px_40px_rgba(45,55,72,0.08)]">
+        <div class="border-b border-[#edf2f7] bg-[linear-gradient(140deg,#ebf8ff_0%,#eff6ff_48%,#ffffff_100%)] px-6 py-7 md:px-8 md:py-8">
+          <div class="flex items-center gap-4">
+            <div class="inline-flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-full bg-[#2b6cb0] text-[28px] text-white shadow-[0_10px_24px_rgba(43,108,176,0.24)]">
+              <span class="relative top-[-1px]">✓</span>
+            </div>
+            <p class="text-[30px] font-bold tracking-[-0.03em] text-[#1f2937]">주문이 정상적으로 접수되었어요</p>
+          </div>
+        </div>
+
+        <div class="px-6 py-6 md:px-8 md:py-7">
+          <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
+            <p class="mb-3 text-[12px] font-semibold text-[#90a4b8]">총 {{ order_completion.item_count }}개 상품</p>
+            <div class="order-complete-items space-y-3">
+              {% for item in order_completion.items %}
+              <div class="flex items-center gap-3 rounded-[18px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-3">
+                <div class="flex h-[54px] w-[54px] shrink-0 items-center justify-center overflow-hidden rounded-[16px] bg-[#f1f5f9]">
+                  {% if item.thumbnail_url %}
+                  <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+                  {% else %}
+                  <span class="text-[18px] font-bold text-[#90a4b8]">?</span>
+                  {% endif %}
+                </div>
+                <div class="min-w-0 flex-1">
+                  <p class="truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
+                  <p class="truncate text-[14px] font-bold text-[#2d3748]">{{ item.name }}</p>
+                </div>
+                <div class="shrink-0 text-right">
+                  <p class="text-[12px] font-semibold text-[#7aa6e9]">x {{ item.quantity }}</p>
+                  <p class="mt-1 text-[13px] font-bold text-[#2d3748]">{{ item.line_total }}</p>
+                </div>
+              </div>
+              {% endfor %}
+            </div>
+          </div>
+
+          <div class="mt-6 grid gap-4 lg:grid-cols-2">
+            <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
+              <p class="text-[18px] font-bold tracking-[-0.02em] text-[#2563eb]">배송 정보</p>
+              <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+                <div>
+                  <p class="font-semibold text-[#90a4b8]">주문번호</p>
+                  <p class="mt-1 break-all font-semibold text-[#2d3748]">{{ order_completion.order_id }}</p>
+                </div>
+                <div>
+                  <p class="font-semibold text-[#90a4b8]">수령인 / 연락처</p>
+                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.recipient_name }} / {{ order_completion.recipient_phone }}</p>
+                </div>
+                <div>
+                  <p class="font-semibold text-[#90a4b8]">상세 배송지</p>
+                  <p class="mt-1 font-semibold leading-[1.7] text-[#2d3748]">
+                    {{ order_completion.delivery_base_address }}
+                    {% if order_completion.delivery_detail_address %}
+                    <br>{{ order_completion.delivery_detail_address }}
+                    {% endif %}
+                  </p>
+                </div>
+                <div>
+                  <p class="font-semibold text-[#90a4b8]">배송 메시지</p>
+                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.delivery_message }}</p>
+                </div>
+              </div>
+            </div>
+
+            <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
+              <p class="text-[18px] font-bold tracking-[-0.02em] text-[#2563eb]">결제 요약</p>
+              <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+                <div>
+                  <p class="font-semibold text-[#90a4b8]">결제 수단</p>
+                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.payment_method }}</p>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>상품 금액</span>
+                  <span class="font-semibold text-[#2d3748]">{{ order_completion.product_total }}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>쿠폰 할인</span>
+                  <span class="font-semibold text-[#2563eb]">- {{ order_completion.coupon_discount }}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>마일리지</span>
+                  <span class="font-semibold text-[#2563eb]">- {{ order_completion.mileage_discount }}</span>
+                </div>
+                <div class="flex items-center justify-between">
+                  <span>배송비</span>
+                  <span class="font-semibold text-[#2d3748]">{{ order_completion.shipping_fee }}</span>
+                </div>
+                <div class="border-t border-[#edf2f7] pt-3">
+                  <div class="flex items-center justify-between">
+                    <span class="text-[14px] font-semibold text-[#4a5568]">최종 결제 금액</span>
+                    <span class="text-[20px] font-bold text-[#2563eb]">{{ order_completion.total_price }}</span>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <aside class="order-complete-sticky self-start rounded-[28px] border border-[#dbe7f5] bg-white p-6 shadow-[0_12px_32px_rgba(45,55,72,0.06)] lg:sticky lg:top-8">
+        <div class="space-y-3">
+          <a href="/orders/" class="inline-flex h-[48px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[14px] font-semibold text-white">
+            주문 내역 보러가기
+          </a>
+          <a href="/chat/" class="inline-flex h-[48px] w-full items-center justify-center rounded-[16px] border border-[#dbe7f5] bg-[#f8fbff] text-[14px] font-semibold text-[#2d3748]">
+            메인 채팅으로 돌아가기
+          </a>
+        </div>
+      </aside>
+    </div>
+  </div>
+</div>
+{% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -926,11 +926,14 @@
     if (!checkoutConfirmModal) return;
     if (event && event.target !== checkoutConfirmModal) return;
     checkoutConfirmModal.classList.remove('is-open');
+    setConfirmCheckoutLoading(false);
   };
 
   function submitOrderRequest() {
     if (!orderSummaryPanel) return;
+    if (confirmCheckoutSubmitBtn && confirmCheckoutSubmitBtn.disabled) return;
     setOrderSubmitLoading(true);
+    setConfirmCheckoutLoading(true);
     requestJson('/api/orders/', {
       method: 'POST',
       body: JSON.stringify({
@@ -952,6 +955,7 @@
     }).catch(function (error) {
       showProductToast(error.message || '주문을 완료하지 못했습니다.');
       setOrderSubmitLoading(false);
+      setConfirmCheckoutLoading(false);
     });
   }
 
@@ -1185,6 +1189,17 @@
     submitOrderBtn.textContent = isLoading ? '주문 처리 중...' : submitOrderBtn.dataset.defaultLabel;
     submitOrderBtn.classList.toggle('opacity-60', isLoading);
     submitOrderBtn.classList.toggle('cursor-not-allowed', isLoading);
+  }
+
+  function setConfirmCheckoutLoading(isLoading) {
+    if (!confirmCheckoutSubmitBtn) return;
+    if (!confirmCheckoutSubmitBtn.dataset.defaultLabel) {
+      confirmCheckoutSubmitBtn.dataset.defaultLabel = confirmCheckoutSubmitBtn.textContent.trim();
+    }
+    confirmCheckoutSubmitBtn.disabled = isLoading;
+    confirmCheckoutSubmitBtn.textContent = isLoading ? '주문 처리 중...' : confirmCheckoutSubmitBtn.dataset.defaultLabel;
+    confirmCheckoutSubmitBtn.classList.toggle('opacity-60', isLoading);
+    confirmCheckoutSubmitBtn.classList.toggle('cursor-not-allowed', isLoading);
   }
 
   function updateDiscountPreview() {

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -29,6 +29,14 @@
     display: flex;
   }
 
+  .checkout-confirm-modal {
+    display: none;
+  }
+
+  .checkout-confirm-modal.is-open {
+    display: flex;
+  }
+
   .product-feedback-toast {
     opacity: 0;
     visibility: hidden;
@@ -579,6 +587,48 @@
   오류가 발생했습니다.
 </div>
 
+<div id="checkoutConfirmModal" class="checkout-confirm-modal fixed inset-0 z-[60] items-center justify-center bg-black/10 px-4"
+     onclick="closeCheckoutConfirmModal(event)">
+  <div class="w-full max-w-[420px] rounded-[20px] border border-[#dbe7f5] bg-white px-8 pb-7 pt-8 shadow-[0_14px_36px_rgba(45,55,72,0.10)]"
+       onclick="event.stopPropagation()">
+    <div class="mx-auto flex h-[81px] w-[81px] items-center justify-center rounded-full border-[4px] border-[#3182ce]">
+      <span class="relative top-[-1px] text-[44px] font-bold leading-none text-[#3182ce]">?</span>
+    </div>
+    <p class="mt-6 text-center text-[19px] font-bold leading-none text-[#2d3748]">주문을 진행할까요?</p>
+    <p class="mt-4 text-center text-[14px] leading-[1.6] text-[#718096]">
+      배송 정보와 결제 금액을 확인한 뒤<br>주문이 접수됩니다.
+    </p>
+    <div class="mt-6 rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-3">
+      <div class="flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">최종 결제 금액</span>
+        <span id="checkoutConfirmAmount" class="font-bold text-[#2563eb]">0원</span>
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">수령인</span>
+        <span id="checkoutConfirmRecipient" class="text-right font-semibold text-[#2d3748]"></span>
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">연락처</span>
+        <span id="checkoutConfirmPhone" class="text-right font-semibold text-[#2d3748]"></span>
+      </div>
+      <div class="mt-2 flex items-start justify-between gap-3 text-[13px]">
+        <span class="shrink-0 font-semibold text-[#90a4b8]">배송지</span>
+        <span id="checkoutConfirmAddress" class="text-right font-semibold leading-[1.6] text-[#2d3748]"></span>
+      </div>
+    </div>
+    <div class="mt-6 flex h-[42px] items-center justify-between gap-3">
+      <button type="button" onclick="closeCheckoutConfirmModal()"
+              class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">
+        취소
+      </button>
+      <button type="button" id="confirmCheckoutSubmitBtn"
+              class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#3182ce] text-[14px] font-bold text-white">
+        주문하기
+      </button>
+    </div>
+  </div>
+</div>
+
 <div id="discountBenefitModal" class="discount-modal fixed inset-0 z-50 items-center justify-center bg-[rgba(15,23,42,0.46)] px-4" onclick="closeDiscountModal(event)">
   <div class="w-full max-w-[520px] rounded-[24px] bg-white px-6 py-6 shadow-[0_20px_60px_rgba(15,23,42,0.24)]">
     <div class="flex items-start justify-between gap-4">
@@ -677,6 +727,12 @@
   var deliveryMessageCustomField = document.getElementById('deliveryMessageCustomField');
   var deliveryMessageInput = document.getElementById('deliveryMessageInput');
   var submitOrderBtn = document.getElementById('submitOrderBtn');
+  var checkoutConfirmModal = document.getElementById('checkoutConfirmModal');
+  var checkoutConfirmAmount = document.getElementById('checkoutConfirmAmount');
+  var checkoutConfirmRecipient = document.getElementById('checkoutConfirmRecipient');
+  var checkoutConfirmPhone = document.getElementById('checkoutConfirmPhone');
+  var checkoutConfirmAddress = document.getElementById('checkoutConfirmAddress');
+  var confirmCheckoutSubmitBtn = document.getElementById('confirmCheckoutSubmitBtn');
   var productFeedbackToast = document.getElementById('productFeedbackToast');
   var checkoutStatusNotice = document.getElementById('checkoutStatusNotice');
   var checkoutStatusTitle = document.getElementById('checkoutStatusTitle');
@@ -849,6 +905,56 @@
     }
   }
 
+  function updateCheckoutConfirmSummary() {
+    if (checkoutConfirmAmount) {
+      var finalTotalNode = document.getElementById('finalTotalAmount');
+      checkoutConfirmAmount.textContent = finalTotalNode ? finalTotalNode.textContent : '0원';
+    }
+    if (checkoutConfirmRecipient) {
+      checkoutConfirmRecipient.textContent = orderSummaryPanel ? ((orderSummaryPanel.dataset.recipientName || '').trim() || '수령인 정보가 아직 없습니다') : '';
+    }
+    if (checkoutConfirmPhone) {
+      checkoutConfirmPhone.textContent = orderSummaryPanel ? ((orderSummaryPanel.dataset.recipientPhone || '').trim() || '연락처 정보가 아직 없습니다') : '';
+    }
+    if (checkoutConfirmAddress) {
+      var addressParts = splitAddressParts(orderSummaryPanel ? (orderSummaryPanel.dataset.deliveryAddress || '') : '');
+      checkoutConfirmAddress.textContent = [addressParts.base, addressParts.detail].filter(Boolean).join(', ') || '배송지 정보가 아직 없습니다';
+    }
+  }
+
+  window.closeCheckoutConfirmModal = function (event) {
+    if (!checkoutConfirmModal) return;
+    if (event && event.target !== checkoutConfirmModal) return;
+    checkoutConfirmModal.classList.remove('is-open');
+  };
+
+  function submitOrderRequest() {
+    if (!orderSummaryPanel) return;
+    setOrderSubmitLoading(true);
+    requestJson('/api/orders/', {
+      method: 'POST',
+      body: JSON.stringify({
+        recipient_name: orderSummaryPanel.dataset.recipientName || '',
+        recipient_phone: orderSummaryPanel.dataset.recipientPhone || '',
+        delivery_address: orderSummaryPanel.dataset.deliveryAddress || '',
+        delivery_message: getDeliveryMessageValue(),
+        payment_method: normalizeCheckoutPaymentMethod(orderSummaryPanel.dataset.paymentMethod || ''),
+        coupon_id: selectedCouponId || 'none',
+        mileage_amount: selectedMileageValue || 0,
+      }),
+    }).then(function (data) {
+      var orderId = data && data.order && data.order.order_id;
+      if (!orderId) {
+        throw new Error('주문 완료 정보를 확인하지 못했습니다.');
+      }
+      window.closeCheckoutConfirmModal();
+      window.location.href = '/orders/complete/' + orderId + '/?entry=cart';
+    }).catch(function (error) {
+      showProductToast(error.message || '주문을 완료하지 못했습니다.');
+      setOrderSubmitLoading(false);
+    });
+  }
+
   function parsePrice(value) {
     return Number(String(value || '0').replace(/[^\d]/g, '')) || 0;
   }
@@ -983,9 +1089,13 @@
       cartCountBadge.classList.toggle('hidden', cartCount === 0);
     }
 
-    var compactEmptyCart = cartItemCount === 0 && cartPanel.classList.contains('is-active');
-    var compactEmptyWishlist = wishlistCount === 0 && wishlistPanel.classList.contains('is-active');
-    var compactEmptyPanel = compactEmptyCart || compactEmptyWishlist;
+    var cartActive = cartPanel.classList.contains('is-active');
+    var wishlistActive = wishlistPanel.classList.contains('is-active');
+    var compactEmptyCart = cartItemCount === 0 && cartActive;
+    var compactEmptyWishlist = wishlistCount === 0 && wishlistActive;
+    var showOrderSummaryPanel = cartActive && cartItemCount > 0;
+    var showPromoPanel = wishlistActive || compactEmptyCart;
+    var compactPromoPanel = compactEmptyCart || compactEmptyWishlist;
 
     if (wishlistCountBadge) {
       wishlistCountBadge.textContent = String(wishlistCount);
@@ -1009,17 +1119,16 @@
     }
 
     if (orderSummaryPanel) {
-      orderSummaryPanel.classList.toggle('hidden', compactEmptyPanel);
+      orderSummaryPanel.classList.toggle('hidden', !showOrderSummaryPanel);
     }
 
     if (cartPromoPanel) {
-      var showPromoPanel = compactEmptyPanel;
       cartPromoPanel.classList.toggle('hidden', !showPromoPanel);
       cartPromoPanel.classList.toggle('flex', showPromoPanel);
-      cartPromoPanel.classList.toggle('product-promo-compact', compactEmptyPanel);
+      cartPromoPanel.classList.toggle('product-promo-compact', compactPromoPanel);
     }
     if (productsMainSection) {
-      productsMainSection.classList.toggle('product-empty-compact', compactEmptyPanel);
+      productsMainSection.classList.toggle('product-empty-compact', compactPromoPanel);
     }
     if (cartPanel) {
       cartPanel.classList.toggle('product-empty-compact', compactEmptyCart);
@@ -1541,30 +1650,15 @@
         showProductToast(validation.message || '주문 전에 필수 정보를 먼저 확인해 주세요.');
         return;
       }
-
-      setOrderSubmitLoading(true);
-      requestJson('/api/orders/', {
-        method: 'POST',
-        body: JSON.stringify({
-          recipient_name: orderSummaryPanel.dataset.recipientName || '',
-          recipient_phone: orderSummaryPanel.dataset.recipientPhone || '',
-          delivery_address: orderSummaryPanel.dataset.deliveryAddress || '',
-          delivery_message: getDeliveryMessageValue(),
-          payment_method: normalizeCheckoutPaymentMethod(orderSummaryPanel.dataset.paymentMethod || ''),
-          coupon_id: selectedCouponId || 'none',
-          mileage_amount: selectedMileageValue || 0,
-        }),
-      }).then(function (data) {
-        var orderId = data && data.order && data.order.order_id;
-        if (!orderId) {
-          throw new Error('주문 완료 정보를 확인하지 못했습니다.');
-        }
-        window.location.href = '/orders/complete/' + orderId + '/?entry=cart';
-      }).catch(function (error) {
-        showProductToast(error.message || '주문을 완료하지 못했습니다.');
-        setOrderSubmitLoading(false);
-      });
+      updateCheckoutConfirmSummary();
+      if (checkoutConfirmModal) {
+        checkoutConfirmModal.classList.add('is-open');
+      }
     });
+  }
+
+  if (confirmCheckoutSubmitBtn) {
+    confirmCheckoutSubmitBtn.addEventListener('click', submitOrderRequest);
   }
 
   var cartListViewport = document.getElementById('cartListViewport');

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -29,6 +29,19 @@
     display: flex;
   }
 
+  .product-feedback-toast {
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 10px) scale(0.98);
+    transition: opacity 180ms ease, transform 180ms ease;
+  }
+
+  .product-feedback-toast.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0) scale(1);
+  }
+
   .product-list-viewport {
     scrollbar-gutter: stable;
   }
@@ -452,15 +465,23 @@
              class="{% if item_count == 0 %}hidden{% else %}flex{% endif %} min-h-[720px] flex-col rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
         <h2 class="text-[22px] font-bold text-[#2d3748]">주문 정보</h2>
 
+        <div id="checkoutStatusNotice" class="mt-4 hidden rounded-[18px] border border-[#fed7d7] bg-[#fff5f5] px-4 py-4">
+          <p id="checkoutStatusTitle" class="text-[13px] font-semibold text-[#c53030]">주문 전에 확인이 필요해요</p>
+          <p id="checkoutStatusBody" class="mt-1 text-[13px] leading-[1.6] text-[#9b2c2c]">배송지와 결제 수단을 먼저 확인해 주세요.</p>
+          <a href="/profile/" class="mt-3 inline-flex h-[34px] items-center justify-center rounded-full bg-white px-4 text-[12px] font-semibold text-[#c53030]">
+            프로필 보완하기
+          </a>
+        </div>
+
         <div class="mt-5 grid gap-3 md:grid-cols-2">
           <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0 flex-1">
                 <p class="text-[13px] font-semibold text-[#2563eb]">배송 정보</p>
-                <p class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
-                <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
-                <p class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
-                <p class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
+                <p id="checkoutRecipientName" class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
+                <p id="checkoutDeliveryBaseAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
+                <p id="checkoutDeliveryDetailAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
+                <p id="checkoutRecipientPhone" class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
               </div>
               <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
             </div>
@@ -469,7 +490,7 @@
             <div class="flex items-start justify-between gap-4">
               <div class="min-w-0 flex-1">
                 <p class="text-[13px] font-semibold text-[#2563eb]">결제 수단</p>
-                <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
+                <p id="checkoutPaymentMethod" class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
               </div>
               <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
             </div>
@@ -551,6 +572,11 @@
       </aside>
     </div>
   </div>
+</div>
+
+<div id="productFeedbackToast"
+     class="product-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+  오류가 발생했습니다.
 </div>
 
 <div id="discountBenefitModal" class="discount-modal fixed inset-0 z-50 items-center justify-center bg-[rgba(15,23,42,0.46)] px-4" onclick="closeDiscountModal(event)">
@@ -651,6 +677,15 @@
   var deliveryMessageCustomField = document.getElementById('deliveryMessageCustomField');
   var deliveryMessageInput = document.getElementById('deliveryMessageInput');
   var submitOrderBtn = document.getElementById('submitOrderBtn');
+  var productFeedbackToast = document.getElementById('productFeedbackToast');
+  var checkoutStatusNotice = document.getElementById('checkoutStatusNotice');
+  var checkoutStatusTitle = document.getElementById('checkoutStatusTitle');
+  var checkoutStatusBody = document.getElementById('checkoutStatusBody');
+  var checkoutRecipientName = document.getElementById('checkoutRecipientName');
+  var checkoutDeliveryBaseAddress = document.getElementById('checkoutDeliveryBaseAddress');
+  var checkoutDeliveryDetailAddress = document.getElementById('checkoutDeliveryDetailAddress');
+  var checkoutRecipientPhone = document.getElementById('checkoutRecipientPhone');
+  var checkoutPaymentMethod = document.getElementById('checkoutPaymentMethod');
   var discountTabCoupon = document.getElementById('discountTabCoupon');
   var discountTabMileage = document.getElementById('discountTabMileage');
   var discountPanelCoupon = document.getElementById('discountPanelCoupon');
@@ -666,6 +701,9 @@
   var selectedMileageValue = 0;
   var discountMode = 'coupon';
   var viewportSyncFrame = null;
+  var productToastTimer = null;
+  var PROFILE_ADDRESS_STORAGE_KEY = 'tailtalk_profile_address_preview';
+  var PROFILE_PAYMENT_STORAGE_KEY = 'tailtalk_profile_payment_preview';
 
   if (!cartTab || !wishlistTab || !cartPanel || !wishlistPanel) return;
 
@@ -706,6 +744,109 @@
         return data;
       });
     });
+  }
+
+  function showProductToast(message) {
+    if (!productFeedbackToast) return;
+    productFeedbackToast.textContent = message || '요청 처리에 실패했습니다.';
+    productFeedbackToast.classList.add('is-open');
+    if (productToastTimer) {
+      window.clearTimeout(productToastTimer);
+    }
+    productToastTimer = window.setTimeout(function () {
+      productFeedbackToast.classList.remove('is-open');
+    }, 2400);
+  }
+
+  function splitAddressParts(value) {
+    var parts = String(value || '').split('|');
+    return {
+      base: (parts[0] || '').trim(),
+      detail: (parts[1] || '').trim(),
+    };
+  }
+
+  function normalizeCheckoutPaymentMethod(value) {
+    var normalized = String(value || '').trim();
+    if (!normalized || normalized.indexOf('없습니다') !== -1) {
+      return '';
+    }
+    if (normalized.indexOf('카카오') !== -1) {
+      return '카카오페이 / 일시불';
+    }
+    if (normalized.indexOf('네이버') !== -1) {
+      return '네이버페이 / 일시불';
+    }
+    return '우리카드 1234 / 일시불';
+  }
+
+  function syncCheckoutSummaryPreview() {
+    if (!orderSummaryPanel) return;
+
+    var addressPreview = null;
+    var paymentPreview = null;
+    try {
+      addressPreview = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
+    } catch (e) {}
+    try {
+      paymentPreview = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
+    } catch (e) {}
+
+    var recipientName = (orderSummaryPanel.dataset.recipientName || '').trim();
+    var recipientPhone = (orderSummaryPanel.dataset.recipientPhone || '').trim();
+    var addressParts = splitAddressParts(orderSummaryPanel.dataset.deliveryAddress || '');
+    var paymentMethod = (orderSummaryPanel.dataset.paymentMethod || '').trim();
+
+    if (addressPreview && (addressPreview.addressMain || addressPreview.addressDetail)) {
+      addressParts.base = (addressPreview.addressMain || '').trim() || addressParts.base;
+      addressParts.detail = (addressPreview.addressDetail || '').trim();
+      orderSummaryPanel.dataset.deliveryAddress = [addressParts.base, addressParts.detail].filter(Boolean).join(' | ');
+    }
+
+    if (paymentPreview && paymentPreview.cardName && paymentPreview.maskedCard) {
+      paymentMethod = paymentPreview.cardName + ' / ' + paymentPreview.maskedCard;
+      orderSummaryPanel.dataset.paymentMethod = paymentMethod;
+    }
+
+    if (checkoutRecipientName) checkoutRecipientName.textContent = recipientName || '수령인 정보가 아직 없습니다';
+    if (checkoutRecipientPhone) checkoutRecipientPhone.textContent = recipientPhone || '연락처 정보가 아직 없습니다';
+    if (checkoutDeliveryBaseAddress) checkoutDeliveryBaseAddress.textContent = addressParts.base || '배송지 정보가 아직 없습니다';
+    if (checkoutDeliveryDetailAddress) {
+      checkoutDeliveryDetailAddress.textContent = addressParts.detail || (addressParts.base ? '' : '상세 주소 정보가 아직 없습니다');
+    }
+    if (checkoutPaymentMethod) checkoutPaymentMethod.textContent = paymentMethod || '결제 수단 정보가 아직 없습니다';
+  }
+
+  function validateCheckoutState() {
+    if (!orderSummaryPanel) {
+      return { valid: false, message: '주문 정보를 불러오지 못했습니다.' };
+    }
+
+    var recipientName = (orderSummaryPanel.dataset.recipientName || '').trim();
+    var recipientPhone = (orderSummaryPanel.dataset.recipientPhone || '').trim();
+    var addressParts = splitAddressParts(orderSummaryPanel.dataset.deliveryAddress || '');
+    var paymentMethod = (orderSummaryPanel.dataset.paymentMethod || '').trim();
+    var missing = [];
+
+    if (!recipientName) missing.push('수령인');
+    if (!recipientPhone || recipientPhone.indexOf('없습니다') !== -1) missing.push('연락처');
+    if (!addressParts.base || addressParts.base.indexOf('없습니다') !== -1) missing.push('배송지');
+    if (!paymentMethod || paymentMethod.indexOf('없습니다') !== -1) missing.push('결제 수단');
+
+    return {
+      valid: missing.length === 0,
+      message: missing.length ? (missing.join(', ') + ' 정보를 먼저 확인해 주세요.') : '',
+    };
+  }
+
+  function syncCheckoutNotice() {
+    if (!checkoutStatusNotice) return;
+    var validation = validateCheckoutState();
+    checkoutStatusNotice.classList.toggle('hidden', validation.valid);
+    if (!validation.valid) {
+      if (checkoutStatusTitle) checkoutStatusTitle.textContent = '필수 정보가 아직 부족해요';
+      if (checkoutStatusBody) checkoutStatusBody.textContent = validation.message;
+    }
   }
 
   function parsePrice(value) {
@@ -1208,6 +1349,8 @@
       });
 
       renderWishlistFromState(wishlistData.items || []);
+      syncCheckoutSummaryPreview();
+      syncCheckoutNotice();
       updateCartSummary();
       updateTabCounts();
       scheduleViewportSync();
@@ -1221,7 +1364,7 @@
         window.scrollTo(0, preservedWindowScrollY);
       });
     }).catch(function (error) {
-      window.alert(error.message || '장바구니 정보를 불러오지 못했습니다.');
+      showProductToast(error.message || '장바구니 정보를 불러오지 못했습니다.');
     });
   }
 
@@ -1233,7 +1376,7 @@
     if (cartItem) {
       var goodsId = cartItem.getAttribute('data-goods-id');
       if (!goodsId) {
-        window.alert('상품 식별 정보를 찾을 수 없습니다.');
+        showProductToast('상품 식별 정보를 찾을 수 없습니다.');
         return;
       }
       var nextActive = !button.classList.contains('is-active');
@@ -1243,7 +1386,7 @@
       }).then(function () {
         return refreshProductsData();
       }).catch(function (error) {
-        window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+        showProductToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
       });
       return;
     }
@@ -1251,7 +1394,7 @@
     if (wishlistItem) {
       var goodsId = wishlistItem.getAttribute('data-goods-id');
       if (!goodsId) {
-        window.alert('상품 식별 정보를 찾을 수 없습니다.');
+        showProductToast('상품 식별 정보를 찾을 수 없습니다.');
         return;
       }
       requestJson('/api/orders/wishlist/', {
@@ -1260,7 +1403,7 @@
       }).then(function () {
         return refreshProductsData();
       }).catch(function (error) {
-        window.alert(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+        showProductToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
       });
     }
   };
@@ -1292,7 +1435,7 @@
       updateCartSummary();
       updateCartQuantityBadge();
     }).catch(function (error) {
-      window.alert(error.message || '장바구니 수량을 변경하지 못했습니다.');
+      showProductToast(error.message || '장바구니 수량을 변경하지 못했습니다.');
     });
   };
 
@@ -1305,7 +1448,7 @@
     }).then(function () {
       return refreshProductsData();
     }).catch(function (error) {
-      window.alert(error.message || '장바구니 상품을 삭제하지 못했습니다.');
+      showProductToast(error.message || '장바구니 상품을 삭제하지 못했습니다.');
     });
   };
 
@@ -1321,7 +1464,7 @@
     }).then(function () {
       return refreshProductsData();
     }).catch(function (error) {
-      window.alert(error.message || '장바구니에 상품을 담지 못했습니다.');
+      showProductToast(error.message || '장바구니에 상품을 담지 못했습니다.');
     });
   };
 
@@ -1392,6 +1535,12 @@
   if (submitOrderBtn) {
     submitOrderBtn.addEventListener('click', function () {
       if (!orderSummaryPanel) return;
+      var validation = validateCheckoutState();
+      syncCheckoutNotice();
+      if (!validation.valid) {
+        showProductToast(validation.message || '주문 전에 필수 정보를 먼저 확인해 주세요.');
+        return;
+      }
 
       setOrderSubmitLoading(true);
       requestJson('/api/orders/', {
@@ -1401,14 +1550,18 @@
           recipient_phone: orderSummaryPanel.dataset.recipientPhone || '',
           delivery_address: orderSummaryPanel.dataset.deliveryAddress || '',
           delivery_message: getDeliveryMessageValue(),
-          payment_method: orderSummaryPanel.dataset.paymentMethod || '',
+          payment_method: normalizeCheckoutPaymentMethod(orderSummaryPanel.dataset.paymentMethod || ''),
           coupon_id: selectedCouponId || 'none',
           mileage_amount: selectedMileageValue || 0,
         }),
-      }).then(function () {
-        window.location.href = '/orders/';
+      }).then(function (data) {
+        var orderId = data && data.order && data.order.order_id;
+        if (!orderId) {
+          throw new Error('주문 완료 정보를 확인하지 못했습니다.');
+        }
+        window.location.href = '/orders/complete/' + orderId + '/?entry=cart';
       }).catch(function (error) {
-        window.alert(error.message || '주문을 완료하지 못했습니다.');
+        showProductToast(error.message || '주문을 완료하지 못했습니다.');
         setOrderSubmitLoading(false);
       });
     });
@@ -1444,6 +1597,8 @@
   updateDiscountSummaryTexts();
   updateDiscountPreview();
   syncDeliveryMessageField();
+  syncCheckoutSummaryPreview();
+  syncCheckoutNotice();
   refreshProductsData();
   window.addEventListener('resize', scheduleViewportSync);
 })();


### PR DESCRIPTION
## 요약
주문 완료 흐름을 완료 페이지 중심으로 정리하고, 장바구니 주문 확인/실패 UX를 화면 내 안내 중심으로 정리했습니다.

## 변경 사항
- 장바구니 주문과 빠른 주문이 모두 동일한 주문 완료 페이지로 진입하도록 연결했습니다.
- 주문 완료 페이지 UI를 정리하고 주문 내역 이동, 메인 채팅 이동 CTA를 구성했습니다.
- 장바구니 주문 실패 안내를 토스트 및 화면 내 안내로 정리하고 프로필 이동 CTA를 연결했습니다.
- 장바구니 주문 전 확인 모달을 추가하고 중복 클릭/중복 제출 방지 상태를 보완했습니다.
- 관심 상품 탭에서는 상품이 있어도 우측 프로모션 패널이 유지되도록 패널 전환 로직을 수정했습니다.

## 관련 이슈
closes #196
closes #197

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 주문 완료 페이지 레이아웃과 장바구니 주문 확인 모달의 UX 흐름 위주로 확인 부탁드립니다.
- 결제수단 저장/연동 구조는 후속 이슈(#198, #199)에서 정리할 예정이라 이번 PR에서는 프론트 흐름 기준으로 봐주시면 됩니다.