### PR TITLE
[feat] 프로필 저장 정보와 주문 데이터 연동 기준 정리 (#199)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,11 +1,12 @@
 import json
 
 from django.db.models import Q
-from django.shortcuts import render
+from django.shortcuts import redirect, render
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from orders.models import Cart
 from products.models import Product
+from users.onboarding import get_onboarding_redirect_url
 
 
 def _format_price(value):
@@ -333,6 +334,10 @@ def _build_quick_order_profile_context(user):
 
 @ensure_csrf_cookie
 def chat_view(request):
+    onboarding_redirect_url = get_onboarding_redirect_url(request)
+    if onboarding_redirect_url:
+        return redirect(onboarding_redirect_url)
+
     sessions = []
     preview_member = request.GET.get("preview") == "member"
     is_authenticated = request.user.is_authenticated

--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -313,6 +313,24 @@ def _preview_session_threads():
     }
 
 
+def _build_quick_order_profile_context(user):
+    profile = getattr(user, "profile", None)
+    if profile is None:
+        return {
+            "quick_order_recipient": "이름 정보가 없습니다",
+            "quick_order_address": "배송지 정보가 없습니다",
+            "quick_order_phone": "연락처 정보가 없습니다",
+            "quick_order_payment_method": "등록된 결제수단이 없습니다",
+        }
+
+    return {
+        "quick_order_recipient": (profile.nickname or "").strip() or "이름 정보가 없습니다",
+        "quick_order_address": (profile.address or "").strip() or "배송지 정보가 없습니다",
+        "quick_order_phone": (profile.phone or "").strip() or "연락처 정보가 없습니다",
+        "quick_order_payment_method": (profile.payment_method or "").strip() or "등록된 결제수단이 없습니다",
+    }
+
+
 @ensure_csrf_cookie
 def chat_view(request):
     sessions = []
@@ -488,6 +506,13 @@ def chat_view(request):
             cart_products = []
             cart_total = 0
 
+    quick_order_profile = _build_quick_order_profile_context(request.user) if is_authenticated else {
+        "quick_order_recipient": "이름 정보가 없습니다",
+        "quick_order_address": "배송지 정보가 없습니다",
+        "quick_order_phone": "연락처 정보가 없습니다",
+        "quick_order_payment_method": "등록된 결제수단이 없습니다",
+    }
+
     future_pet = _serialize_future_pet(request.session.get("future_pet_profile"))
     if future_pet:
         member_pets.append(future_pet)
@@ -521,5 +546,6 @@ def chat_view(request):
             "cart_total": _format_price(cart_total),
             "promo_banners": promo_banners,
             "session_threads": session_threads,
+            **quick_order_profile,
         },
     )

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -39,6 +39,25 @@ class ChatPageTests(TestCase):
         self.assertEqual(serialized_pet["allergies"], ["chicken"])
         self.assertEqual(serialized_pet["food_preferences"], ["dry"])
 
+    def test_chat_page_redirects_to_pet_add_when_profile_complete_but_no_pet(self):
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], reverse("pet_add"))
+
+    def test_chat_page_redirects_to_profile_setup_when_profile_is_incomplete(self):
+        incomplete_user = User.objects.create_user(
+            email="chat-incomplete@example.com",
+            password="Password123!",
+        )
+        UserProfile.objects.create(user=incomplete_user, nickname="")
+        self.client.force_login(incomplete_user)
+
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], f"{reverse('profile')}?setup=1")
+
 
 class _FakeStreamResponse:
     def __init__(self, chunks, status_code=200):

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -588,12 +588,13 @@ def used_products(request):
     shipping_fee = 0 if product_total >= 30000 else 3000
     final_total = product_total - discount + shipping_fee
     profile = getattr(request.user, "profile", None)
-    recipient_name = getattr(profile, "nickname", "") or request.user.username or "주문자 정보 미등록"
+    recipient_name = getattr(profile, "nickname", "") or request.user.email.split("@")[0] or "주문자 정보 미등록"
     address = getattr(profile, "address", "") or ""
     address_parts = [part.strip() for part in address.split("|", 1)] if address else []
     base_address = address_parts[0] if address_parts else "배송지 정보가 아직 등록되지 않았어요"
     detail_address = address_parts[1] if len(address_parts) > 1 else ""
     phone = getattr(profile, "phone", "") or "연락처 정보가 아직 없습니다."
+    payment_method = getattr(profile, "payment_method", "") or "결제 수단 정보가 아직 없습니다."
     for item in items:
         item["price_label"] = _format_price(item["price"])
         item["line_total_label"] = _format_price(item["price"] * item["quantity"])
@@ -617,7 +618,7 @@ def used_products(request):
             "delivery_detail_address": detail_address,
             "recipient_phone": phone,
             "delivery_message": "",
-            "payment_method": "우리카드 1234 / 일시불",
+            "payment_method": payment_method,
             "coupon_summary": "적용된 쿠폰 없음",
             "mileage_summary": "사용 가능 3,200원",
             "discount_total_raw": discount,

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -252,6 +252,23 @@ class OrderCreateApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["detail"], "recipient_name is required.")
 
+    def test_post_order_uses_saved_profile_payment_method_when_request_omits_it(self):
+        self.add_cart_items()
+        self.user.profile.payment_method = "카카오페이 / 일시불"
+        self.user.profile.save(update_fields=["payment_method", "updated_at"])
+
+        response = self.client.post(
+            "/api/orders/",
+            {
+                "delivery_message": "문 앞에 두세요",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["order"]["payment_method"], "카카오페이 / 일시불")
+        self.assertEqual(response.data["completion"]["payment_method"], "카카오페이 / 일시불")
+
 
 class OrderReadApiTests(TestCase):
     def setUp(self):

--- a/services/django/orders/views.py
+++ b/services/django/orders/views.py
@@ -278,7 +278,7 @@ def validate_checkout_payload(request, cart_items):
     recipient_phone = (request.data.get("recipient_phone") or get_profile_value(request.user, "phone")).strip()
     delivery_address = normalize_delivery_address(request.data, request.user)
     delivery_message = (request.data.get("delivery_message") or "").strip()
-    payment_method = (request.data.get("payment_method") or "").strip()
+    payment_method = (request.data.get("payment_method") or get_profile_value(request.user, "payment_method")).strip()
 
     if not recipient_name:
         return None, Response({"detail": "recipient_name is required."}, status=status.HTTP_400_BAD_REQUEST)

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -512,9 +512,9 @@
                   <div class="flex min-w-0 flex-1 items-start gap-[8px]">
                     <div class="w-[14px] shrink-0 pt-[1px] text-[13px] leading-none text-[#2d3748]" aria-hidden="true">🚚</div>
                     <div class="min-w-0 flex-1 space-y-[5px] text-[12px] text-[#4a5568]">
-                      <p id="quickOrderRecipientSummary" class="leading-[1.5]">{{ request.user.profile.nickname|default:"이름 정보가 없습니다" }}</p>
-                      <p id="quickOrderAddressSummary" class="leading-[1.55]">{{ request.user.profile.address|default:"배송지 정보가 없습니다" }}</p>
-                      <p id="quickOrderPhoneSummary" class="leading-[1.5]">{{ request.user.profile.phone|default:"연락처 정보가 없습니다" }}</p>
+                      <p id="quickOrderRecipientSummary" class="leading-[1.5]">{{ quick_order_recipient }}</p>
+                      <p id="quickOrderAddressSummary" class="leading-[1.55]">{{ quick_order_address }}</p>
+                      <p id="quickOrderPhoneSummary" class="leading-[1.5]">{{ quick_order_phone }}</p>
                     </div>
                   </div>
                   <button type="button"
@@ -530,7 +530,7 @@
                   <div class="flex min-w-0 flex-1 items-start gap-[8px]">
                     <div class="w-[14px] shrink-0 pt-[1px] text-[13px] leading-none text-[#2d3748]" aria-hidden="true">💳</div>
                     <div class="min-w-0 flex-1 space-y-[5px] text-[12px] text-[#4a5568]">
-                      <p id="quickOrderCardSummary" class="leading-[1.5] text-[#718096]">등록된 결제수단이 없습니다 / 일시불</p>
+                      <p id="quickOrderCardSummary" class="leading-[1.5] {% if quick_order_payment_method == '등록된 결제수단이 없습니다' %}text-[#718096]{% else %}text-[#4a5568]{% endif %}">{{ quick_order_payment_method }}</p>
                     </div>
                   </div>
                   <button type="button"
@@ -2940,7 +2940,11 @@
     try {
       var savedAddress = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
       if (savedAddress) {
-        if (quickOrderAddressSummary && savedAddress.addressMain) {
+        if (
+          quickOrderAddressSummary &&
+          quickOrderAddressSummary.textContent.indexOf('없습니다') !== -1 &&
+          savedAddress.addressMain
+        ) {
           var addressText = savedAddress.addressMain || '';
           if (savedAddress.addressDetail) {
             addressText += ' ' + savedAddress.addressDetail;
@@ -2952,7 +2956,13 @@
 
     try {
       var savedPayment = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-      if (savedPayment && quickOrderCardSummary && savedPayment.cardName && savedPayment.maskedCard) {
+      if (
+        savedPayment &&
+        quickOrderCardSummary &&
+        quickOrderCardSummary.textContent.indexOf('없습니다') !== -1 &&
+        savedPayment.cardName &&
+        savedPayment.maskedCard
+      ) {
         quickOrderCardSummary.textContent = savedPayment.cardName + ' / ' + savedPayment.maskedCard;
         quickOrderCardSummary.classList.remove('text-[#718096]');
       }
@@ -3105,20 +3115,6 @@
   function buildQuickOrderPayload() {
     var addressText = quickOrderAddressSummary ? quickOrderAddressSummary.textContent.trim() : '';
     var paymentMethod = quickOrderCardSummary ? quickOrderCardSummary.textContent.trim() : '';
-
-    try {
-      var savedAddress = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
-      if (savedAddress && (savedAddress.addressMain || savedAddress.addressDetail)) {
-        addressText = [savedAddress.addressMain || '', savedAddress.addressDetail || ''].filter(Boolean).join(' | ');
-      }
-    } catch (e) {}
-
-    try {
-      var savedPayment = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-      if (savedPayment && savedPayment.cardName && savedPayment.maskedCard) {
-        paymentMethod = savedPayment.cardName + ' / ' + savedPayment.maskedCard;
-      }
-    } catch (e) {}
 
     return {
       recipient_name: quickOrderRecipientSummary ? quickOrderRecipientSummary.textContent.trim() : '',

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -853,13 +853,16 @@
     var addressParts = splitAddressParts(orderSummaryPanel.dataset.deliveryAddress || '');
     var paymentMethod = (orderSummaryPanel.dataset.paymentMethod || '').trim();
 
-    if (addressPreview && (addressPreview.addressMain || addressPreview.addressDetail)) {
+    var hasServerAddress = addressParts.base && addressParts.base.indexOf('없습니다') === -1;
+    var hasServerPaymentMethod = paymentMethod && paymentMethod.indexOf('없습니다') === -1;
+
+    if (!hasServerAddress && addressPreview && (addressPreview.addressMain || addressPreview.addressDetail)) {
       addressParts.base = (addressPreview.addressMain || '').trim() || addressParts.base;
       addressParts.detail = (addressPreview.addressDetail || '').trim();
       orderSummaryPanel.dataset.deliveryAddress = [addressParts.base, addressParts.detail].filter(Boolean).join(' | ');
     }
 
-    if (paymentPreview && paymentPreview.cardName && paymentPreview.maskedCard) {
+    if (!hasServerPaymentMethod && paymentPreview && paymentPreview.cardName && paymentPreview.maskedCard) {
       paymentMethod = paymentPreview.cardName + ' / ' + paymentPreview.maskedCard;
       orderSummaryPanel.dataset.paymentMethod = paymentMethod;
     }

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -126,8 +126,10 @@
                   class="h-[36px] w-[110px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">우편번호 찾기</button>
         </div>
         <input name="address_main" id="addressMainInput" placeholder="기본 주소" readonly
+               value="{{ profile_address_main }}"
                class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
         <input name="address_detail" id="addressDetailInput" placeholder="상세 주소"
+               value="{{ profile_address_detail }}"
                class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
         <p id="addressStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
       </div>
@@ -138,11 +140,12 @@
       <div class="mt-3 w-full max-w-[420px] rounded-[12px] border border-[#e2e8f0] bg-[#f7fafc] px-4 py-3.5">
         <div class="flex items-center justify-between gap-4">
           <div class="min-w-0 flex-1">
-            <div id="paymentMethodSummary" class="text-[13px] text-[#718096]">저장된 결제 수단이 없습니다</div>
+            <div id="paymentMethodSummary" class="text-[13px] {% if profile_payment_method %}text-[#4a5568]{% else %}text-[#718096]{% endif %}">{{ profile_payment_method|default:"저장된 결제 수단이 없습니다" }}</div>
           </div>
+          <input type="hidden" name="payment_method" id="paymentMethodInput" value="{{ profile_payment_method }}" />
           <button id="paymentRegisterButton" type="button" onclick="openPaymentModal()"
                   class="h-[36px] rounded-[8px] border border-[#3182ce] px-4 text-[13px] font-bold text-[#3182ce]">
-            등록
+            {% if profile_payment_method %}수정{% else %}등록{% endif %}
           </button>
         </div>
       </div>
@@ -256,12 +259,13 @@
     var numberInput = document.getElementById('paymentCardNumberInput');
     var expiryInput = document.getElementById('paymentExpiryInput');
     var summary = document.getElementById('paymentMethodSummary');
+    var paymentMethodInput = document.getElementById('paymentMethodInput');
     var button = document.getElementById('paymentRegisterButton');
     var nameStatus = document.getElementById('paymentCardNameStatus');
     var numberStatus = document.getElementById('paymentCardNumberStatus');
     var expiryStatus = document.getElementById('paymentExpiryStatus');
 
-    if (!nameInput || !numberInput || !expiryInput || !summary || !button || !nameStatus || !numberStatus || !expiryStatus) return;
+    if (!nameInput || !numberInput || !expiryInput || !summary || !paymentMethodInput || !button || !nameStatus || !numberStatus || !expiryStatus) return;
 
     var cardName = nameInput.value.trim();
     var cardNumber = numberInput.value.replace(/\D/g, '').slice(0, 16);
@@ -296,8 +300,10 @@
     }
 
     var maskedCard = cardNumber.slice(0, 4) + ' **** **** ' + cardNumber.slice(-4);
-    summary.textContent = cardName + ' / ' + maskedCard;
+    var paymentMethod = cardName + ' / ' + maskedCard;
+    summary.textContent = paymentMethod;
     summary.className = 'text-[13px] text-[#4a5568]';
+    paymentMethodInput.value = paymentMethod;
     button.textContent = '수정';
     try {
       window.localStorage.setItem(PROFILE_PAYMENT_STORAGE_KEY, JSON.stringify({
@@ -332,6 +338,7 @@
     var paymentCardNumberInput = document.getElementById('paymentCardNumberInput');
     var paymentExpiryInput = document.getElementById('paymentExpiryInput');
     var paymentSummary = document.getElementById('paymentMethodSummary');
+    var paymentMethodInput = document.getElementById('paymentMethodInput');
     var paymentButton = document.getElementById('paymentRegisterButton');
 
     if (!input || !button || !status || !form) return;
@@ -348,6 +355,7 @@
 
     function loadAddressPreview() {
       if (!zipcodeInput || !addressMainInput || !addressDetailInput) return;
+      if (addressMainInput.value.trim() || addressDetailInput.value.trim()) return;
       try {
         var saved = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
         if (!saved) return;
@@ -369,11 +377,13 @@
     }
 
     function loadPaymentPreview() {
-      if (!paymentSummary || !paymentButton) return;
+      if (!paymentSummary || !paymentMethodInput || !paymentButton) return;
+      if (paymentMethodInput.value.trim()) return;
       try {
         var saved = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
         if (!saved || !saved.cardName || !saved.maskedCard) return;
-        paymentSummary.textContent = saved.cardName + ' / ' + saved.maskedCard;
+        paymentMethodInput.value = saved.cardName + ' / ' + saved.maskedCard;
+        paymentSummary.textContent = paymentMethodInput.value;
         paymentSummary.className = 'text-[13px] text-[#4a5568]';
         paymentButton.textContent = '수정';
       } catch (e) {}

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -18,7 +18,7 @@
         <span class="relative top-[-1px] text-[48px] font-bold leading-none text-[#ef4444]">!</span>
       </div>
       <p class="absolute left-1/2 top-[127px] -translate-x-1/2 whitespace-nowrap text-center text-[19px] font-bold leading-none text-[#2d3748]">정말 탈퇴하시겠습니까?</p>
-      <p class="absolute left-1/2 top-[171px] -translate-x-1/2 whitespace-nowrap text-center text-[14px] leading-none text-[#718096]">모든 사용자 데이터가 영구적으로 삭제됩니다</p>
+      <p class="absolute left-1/2 top-[171px] -translate-x-1/2 whitespace-nowrap text-center text-[14px] leading-none text-[#718096]">주문 기록을 제외한 사용자 데이터가 정리됩니다</p>
       <div class="absolute bottom-[24px] left-[40px] right-[40px] flex h-[42px] items-center justify-between">
         <button type="button" onclick="closeWithdrawModal()"
                 class="flex h-full w-[150px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">취소</button>
@@ -37,7 +37,7 @@
     <div class="relative w-[420px] rounded-[20px] border border-[#dbe7f5] bg-white"
          onclick="event.stopPropagation()">
       <div class="flex items-center justify-between px-6 pt-5">
-        <div class="text-[20px] font-bold text-[#2d3748]">결제 수단 등록</div>
+        <div id="paymentModalTitle" class="text-[20px] font-bold text-[#2d3748]">결제 수단 등록</div>
         <button type="button" onclick="closePaymentModal()" class="text-[24px] leading-none text-[#718096]">×</button>
       </div>
       <div class="px-6 pb-6 pt-4">
@@ -64,7 +64,7 @@
         <div class="mt-5 flex gap-3">
           <button type="button" onclick="closePaymentModal()"
                   class="flex h-[42px] flex-1 items-center justify-center rounded-[10px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">취소</button>
-          <button type="button" onclick="savePaymentMethod()"
+          <button type="button" id="paymentSaveButton" onclick="savePaymentMethod()"
                   class="flex h-[42px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[14px] font-bold text-white">저장</button>
         </div>
       </div>
@@ -100,20 +100,30 @@
               <p id="nicknameStatus" class="absolute right-0 top-[42px] min-h-[18px] text-right text-[12px]"></p>
             </div>
             <button type="button" id="nicknameCheckButton"
-                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">중복확인</button>
+                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">중복 확인</button>
           </div>
         </div>
         <div>
           <div class="mb-2 text-[14px] font-bold text-[#4a5568]">연락처 <span class="text-[12px] font-medium text-[#a0aec0]">(선택)</span></div>
           <div class="flex items-start gap-3">
-            <div class="relative flex-1">
-              <input name="phone" value="{{ profile.phone|default:'' }}" id="phoneInput" placeholder="- 없이 숫자만 입력해주세요" maxlength="11" inputmode="numeric"
+            <div class="flex-1">
+              <input name="phone" value="{{ profile.phone|default:'' }}" id="phoneInput" placeholder="- 없이 숫자만 입력해 주세요" maxlength="11" inputmode="numeric"
                      class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce]" />
-              <p id="phoneStatus" class="absolute right-0 top-[42px] min-h-[18px] text-right text-[12px]"></p>
+              <input type="hidden" id="phoneVerifiedState" value="{% if profile_phone_verified %}true{% else %}false{% endif %}" />
+              <p id="phoneInputStatus" class="mt-1 hidden text-right text-[12px]"></p>
             </div>
-            <button type="button"
-                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">인증요청</button>
+            <button type="button" id="phoneVerifyRequestButton"
+                    class="h-[36px] w-[90px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">인증 요청</button>
           </div>
+          <div id="phoneVerificationPanel" class="mt-2 hidden items-start gap-3">
+            <div class="flex-1">
+              <input id="phoneVerificationCodeInput" type="text" inputmode="numeric" maxlength="6" placeholder="인증번호 6자리"
+                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce]" />
+            </div>
+            <button type="button" id="phoneVerifyConfirmButton"
+                    class="h-[36px] w-[90px] rounded-[8px] border border-[#2d3748] text-[14px] font-bold text-[#2d3748]">인증 확인</button>
+          </div>
+          <p id="phoneVerificationStatus" class="mt-2 hidden text-right text-[12px]"></p>
         </div>
       </div>
 
@@ -121,13 +131,13 @@
         <div class="mb-2 text-[14px] font-bold text-[#4a5568]">주소 <span class="text-[12px] font-medium text-[#a0aec0]">(선택)</span></div>
         <div class="flex gap-3">
           <input name="zipcode" id="zipcodeInput" placeholder="우편번호" readonly
-                 class="h-[36px] w-[140px] rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
+                 class="h-[36px] w-[140px] cursor-not-allowed rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
           <button type="button" id="postcodeButton"
                   class="h-[36px] w-[110px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">우편번호 찾기</button>
         </div>
         <input name="address_main" id="addressMainInput" placeholder="기본 주소" readonly
                value="{{ profile_address_main }}"
-               class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
+               class="mt-2 h-[36px] w-full cursor-not-allowed rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
         <input name="address_detail" id="addressDetailInput" placeholder="상세 주소"
                value="{{ profile_address_detail }}"
                class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
@@ -137,7 +147,7 @@
       <div class="mt-6 h-px w-full bg-[#e2e8f0]"></div>
 
       <div class="mt-4 text-[18px] font-bold text-[#2d3748]">2. 결제 수단</div>
-      <div class="mt-3 w-full max-w-[420px] rounded-[12px] border border-[#e2e8f0] bg-[#f7fafc] px-4 py-3.5">
+      <div class="mt-3 w-full rounded-[12px] border border-[#e2e8f0] bg-[#f7fafc] px-4 py-3.5 md:max-w-[calc(50%-0.5rem)]">
         <div class="flex items-center justify-between gap-4">
           <div class="min-w-0 flex-1">
             <div id="paymentMethodSummary" class="text-[13px] {% if profile_payment_method %}text-[#4a5568]{% else %}text-[#718096]{% endif %}">{{ profile_payment_method|default:"저장된 결제 수단이 없습니다" }}</div>
@@ -245,7 +255,52 @@
     document.getElementById('withdrawModal').style.display = 'none';
   };
 
-  window.openPaymentModal = function () {
+  window.openPaymentModal = function (mode) {
+    var modalTitle = document.getElementById('paymentModalTitle');
+    var saveButton = document.getElementById('paymentSaveButton');
+    var nameInput = document.getElementById('paymentCardNameInput');
+    var numberInput = document.getElementById('paymentCardNumberInput');
+    var expiryInput = document.getElementById('paymentExpiryInput');
+    var paymentMethodInput = document.getElementById('paymentMethodInput');
+    var nameStatus = document.getElementById('paymentCardNameStatus');
+    var numberStatus = document.getElementById('paymentCardNumberStatus');
+    var expiryStatus = document.getElementById('paymentExpiryStatus');
+    var existingPaymentMethod = paymentMethodInput ? paymentMethodInput.value.trim() : '';
+    var isNewMode = mode === 'new';
+
+    if (modalTitle) {
+      modalTitle.textContent = !isNewMode && existingPaymentMethod ? '결제 수단 수정' : '결제 수단 등록';
+    }
+    if (saveButton) {
+      saveButton.textContent = !isNewMode && existingPaymentMethod ? '수정' : '저장';
+    }
+    if (nameStatus) nameStatus.textContent = '';
+    if (numberStatus) numberStatus.textContent = '';
+    if (expiryStatus) expiryStatus.textContent = '';
+
+    if (nameInput && numberInput && expiryInput) {
+      nameInput.value = '';
+      numberInput.value = '';
+      expiryInput.value = '';
+
+      if (!isNewMode) {
+        try {
+          var saved = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
+          if (saved) {
+            nameInput.value = saved.cardName || '';
+            numberInput.value = saved.maskedCard || '';
+            expiryInput.value = saved.expiry || '';
+          }
+        } catch (e) {}
+
+        if (!nameInput.value && existingPaymentMethod) {
+          var parts = existingPaymentMethod.split(' / ');
+          nameInput.value = parts[0] || '';
+          numberInput.value = parts[1] || '';
+        }
+      }
+    }
+
     document.getElementById('paymentModal').style.display = 'flex';
   };
 
@@ -268,8 +323,11 @@
     if (!nameInput || !numberInput || !expiryInput || !summary || !paymentMethodInput || !button || !nameStatus || !numberStatus || !expiryStatus) return;
 
     var cardName = nameInput.value.trim();
-    var cardNumber = numberInput.value.replace(/\D/g, '').slice(0, 16);
+    var rawCardNumber = numberInput.value.trim();
+    var cardNumber = rawCardNumber.replace(/\D/g, '').slice(0, 16);
     var expiry = expiryInput.value.trim();
+    var maskedCardPattern = /^\d{4}\s\*{4}\s\*{4}\s\d{4}$/;
+    var hasMaskedCardValue = maskedCardPattern.test(rawCardNumber);
 
     nameStatus.textContent = '';
     numberStatus.textContent = '';
@@ -283,7 +341,7 @@
       hasError = true;
     }
 
-    if (cardNumber.length < 16) {
+    if (!hasMaskedCardValue && cardNumber.length < 16) {
       numberStatus.textContent = '카드번호를 모두 입력해 주세요';
       numberStatus.style.color = '#e53e3e';
       hasError = true;
@@ -299,7 +357,7 @@
       return;
     }
 
-    var maskedCard = cardNumber.slice(0, 4) + ' **** **** ' + cardNumber.slice(-4);
+    var maskedCard = hasMaskedCardValue ? rawCardNumber : (cardNumber.slice(0, 4) + ' **** **** ' + cardNumber.slice(-4));
     var paymentMethod = cardName + ' / ' + maskedCard;
     summary.textContent = paymentMethod;
     summary.className = 'text-[13px] text-[#4a5568]';
@@ -308,7 +366,8 @@
     try {
       window.localStorage.setItem(PROFILE_PAYMENT_STORAGE_KEY, JSON.stringify({
         cardName: cardName,
-        maskedCard: maskedCard
+        maskedCard: maskedCard,
+        expiry: expiry
       }));
     } catch (e) {}
     closePaymentModal();
@@ -329,7 +388,13 @@
     var button = document.getElementById('nicknameCheckButton');
     var status = document.getElementById('nicknameStatus');
     var phoneInput = document.getElementById('phoneInput');
-    var phoneStatus = document.getElementById('phoneStatus');
+    var phoneInputStatus = document.getElementById('phoneInputStatus');
+    var phoneVerificationStatus = document.getElementById('phoneVerificationStatus');
+    var phoneVerifiedStateInput = document.getElementById('phoneVerifiedState');
+    var phoneVerifyRequestButton = document.getElementById('phoneVerifyRequestButton');
+    var phoneVerificationPanel = document.getElementById('phoneVerificationPanel');
+    var phoneVerificationCodeInput = document.getElementById('phoneVerificationCodeInput');
+    var phoneVerifyConfirmButton = document.getElementById('phoneVerifyConfirmButton');
     var postcodeButton = document.getElementById('postcodeButton');
     var zipcodeInput = document.getElementById('zipcodeInput');
     var addressMainInput = document.getElementById('addressMainInput');
@@ -347,15 +412,97 @@
     var isComposing = false;
     var initialNickname = input.value.trim();
     var confirmedNickname = initialNickname;
+    var initialPhone = phoneInput ? phoneInput.value.replace(/\D/g, '').slice(0, 11) : '';
+    var verifiedPhoneValue = phoneVerifiedStateInput && phoneVerifiedStateInput.value === 'true' ? initialPhone : '';
 
     function setStatus(text, color) {
       status.textContent = text;
       status.style.color = color;
     }
 
+    function getPhoneVerifiedState() {
+      return phoneVerifiedStateInput && phoneVerifiedStateInput.value === 'true';
+    }
+
+    function setPhoneVerifiedState(isVerified) {
+      if (phoneVerifiedStateInput) {
+        phoneVerifiedStateInput.value = isVerified ? 'true' : 'false';
+      }
+    }
+
+    function setPhoneInputStatus(text, color) {
+      if (!phoneInputStatus) return;
+      phoneInputStatus.textContent = text;
+      phoneInputStatus.style.color = color;
+      phoneInputStatus.classList.toggle('hidden', !text);
+    }
+
+    function setPhoneVerificationStatus(text, color) {
+      if (!phoneVerificationStatus) return;
+      phoneVerificationStatus.textContent = text;
+      phoneVerificationStatus.style.color = color;
+      phoneVerificationStatus.classList.toggle('hidden', !text);
+    }
+
+    function updatePhoneLockState() {
+      if (!phoneInput) return;
+      var phoneValue = phoneInput.value.replace(/\D/g, '').slice(0, 11);
+      var isVerified = getPhoneVerifiedState() && !!phoneValue && phoneValue === verifiedPhoneValue;
+      phoneInput.readOnly = isVerified;
+      phoneInput.classList.toggle('bg-[#f7fafc]', isVerified);
+      phoneInput.classList.toggle('cursor-not-allowed', isVerified);
+    }
+
+    function showPhoneVerificationPanel() {
+      if (!phoneVerificationPanel) return;
+      phoneVerificationPanel.classList.remove('hidden');
+      phoneVerificationPanel.classList.add('flex');
+    }
+
+    function hidePhoneVerificationPanel() {
+      if (!phoneVerificationPanel) return;
+      phoneVerificationPanel.classList.add('hidden');
+      phoneVerificationPanel.classList.remove('flex');
+    }
+
+    function updatePhoneVerificationUi() {
+      if (!phoneInput || !phoneVerifyRequestButton) return;
+      var phoneValue = phoneInput.value.replace(/\D/g, '').slice(0, 11);
+      var isVerified = getPhoneVerifiedState() && !!phoneValue && phoneValue === verifiedPhoneValue;
+
+      phoneVerifyRequestButton.textContent = isVerified ? '변경' : '인증 요청';
+      phoneVerifyRequestButton.classList.toggle('border-[#38a169]', isVerified);
+      phoneVerifyRequestButton.classList.toggle('text-[#38a169]', isVerified);
+      phoneVerifyRequestButton.classList.toggle('border-[#3182ce]', !isVerified);
+      phoneVerifyRequestButton.classList.toggle('text-[#3182ce]', !isVerified);
+
+      if (isVerified) {
+        hidePhoneVerificationPanel();
+      }
+      updatePhoneLockState();
+    }
+
+    function requestJson(url, options) {
+      var csrfMatch = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+      return fetch(url, Object.assign({
+        headers: {
+          'Accept': 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRFToken': csrfMatch ? decodeURIComponent(csrfMatch[1]) : ''
+        },
+        credentials: 'same-origin'
+      }, options || {})).then(function (response) {
+        return response.json().catch(function () { return {}; }).then(function (data) {
+          if (!response.ok) {
+            throw new Error(data.detail || '요청 처리에 실패했습니다');
+          }
+          return data;
+        });
+      });
+    }
+
     function loadAddressPreview() {
       if (!zipcodeInput || !addressMainInput || !addressDetailInput) return;
-      if (addressMainInput.value.trim() || addressDetailInput.value.trim()) return;
       try {
         var saved = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
         if (!saved) return;
@@ -458,6 +605,7 @@
     sanitizeNickname();
     loadAddressPreview();
     loadPaymentPreview();
+    updatePhoneVerificationUi();
 
     input.addEventListener('compositionstart', function () {
       isComposing = true;
@@ -503,15 +651,24 @@
         return;
       }
 
-      if (phoneInput && phoneStatus) {
+      if (phoneInput) {
         phoneInput.value = phoneInput.value.replace(/\D/g, '').slice(0, 11);
-        phoneStatus.textContent = '';
+        setPhoneInputStatus('', '#718096');
 
         if (phoneInput.value && !/^\d{10,11}$/.test(phoneInput.value)) {
           e.preventDefault();
-          phoneStatus.textContent = '10~11자리 숫자만 입력해 주세요';
-          phoneStatus.style.color = '#e53e3e';
+          setPhoneInputStatus('10~11자리 숫자만 입력해 주세요', '#e53e3e');
           phoneInput.focus();
+          return;
+        }
+
+        if (phoneInput.value && (!getPhoneVerifiedState() || phoneInput.value !== initialPhone)) {
+          e.preventDefault();
+          setPhoneInputStatus('연락처 인증을 완료해 주세요', '#e53e3e');
+          showPhoneVerificationPanel();
+          if (phoneVerificationCodeInput) {
+            phoneVerificationCodeInput.focus();
+          }
         }
       }
 
@@ -539,13 +696,116 @@
       }
     });
 
-    if (phoneInput && phoneStatus) {
+    if (phoneInput) {
       phoneInput.value = phoneInput.value.replace(/\D/g, '').slice(0, 11);
       phoneInput.addEventListener('input', function () {
         phoneInput.value = phoneInput.value.replace(/\D/g, '').slice(0, 11);
-        if (phoneInput.value) {
-          phoneStatus.textContent = '';
+        if (phoneInput.value !== verifiedPhoneValue) {
+          setPhoneVerifiedState(false);
+          setPhoneInputStatus('', '#718096');
+          setPhoneVerificationStatus('', '#718096');
+        } else if (phoneInput.value) {
+          setPhoneVerifiedState(true);
+          setPhoneInputStatus('', '#718096');
+          setPhoneVerificationStatus('연락처 인증이 완료되었습니다', '#38a169');
         }
+        updatePhoneVerificationUi();
+      });
+    }
+
+    if (phoneVerificationCodeInput) {
+      phoneVerificationCodeInput.addEventListener('input', function () {
+        phoneVerificationCodeInput.value = phoneVerificationCodeInput.value.replace(/\D/g, '').slice(0, 6);
+        if (phoneVerificationCodeInput.value) {
+          showPhoneVerificationPanel();
+        }
+      });
+    }
+
+    if (phoneVerifyRequestButton && phoneInput) {
+      phoneVerifyRequestButton.addEventListener('click', function () {
+        var phoneValue = phoneInput.value.replace(/\D/g, '').slice(0, 11);
+        var isVerified = getPhoneVerifiedState() && !!phoneValue && phoneValue === verifiedPhoneValue;
+
+        if (isVerified) {
+          setPhoneVerifiedState(false);
+          verifiedPhoneValue = '';
+          phoneInput.readOnly = false;
+          phoneInput.focus();
+          hidePhoneVerificationPanel();
+          setPhoneInputStatus('', '#718096');
+          setPhoneVerificationStatus('', '#718096');
+          updatePhoneVerificationUi();
+          return;
+        }
+
+        if (!phoneValue) {
+          setPhoneInputStatus('연락처를 먼저 입력해 주세요', '#e53e3e');
+          phoneInput.focus();
+          return;
+        }
+        if (!/^\d{10,11}$/.test(phoneValue)) {
+          setPhoneInputStatus('10~11자리 숫자만 입력해 주세요', '#e53e3e');
+          phoneInput.focus();
+          return;
+        }
+
+        setPhoneInputStatus('', '#718096');
+        phoneVerifyRequestButton.disabled = true;
+        requestJson('/api/users/me/phone-verification/request/', {
+          method: 'POST',
+          body: JSON.stringify({ phone: phoneValue })
+        }).then(function (data) {
+          showPhoneVerificationPanel();
+          if (phoneVerificationCodeInput) {
+            phoneVerificationCodeInput.value = '';
+            phoneVerificationCodeInput.focus();
+          }
+          var statusText = data.detail || '인증번호를 전송했습니다.';
+          if (data.verification_code) {
+            statusText += ' 테스트 코드: ' + data.verification_code;
+          }
+          setPhoneVerificationStatus(statusText, '#3182ce');
+        }).catch(function (error) {
+          setPhoneVerificationStatus(error.message || '인증번호 요청에 실패했습니다', '#e53e3e');
+        }).finally(function () {
+          phoneVerifyRequestButton.disabled = false;
+        });
+      });
+    }
+
+    if (phoneVerifyConfirmButton && phoneInput && phoneVerificationCodeInput) {
+      phoneVerifyConfirmButton.addEventListener('click', function () {
+        var phoneValue = phoneInput.value.replace(/\D/g, '').slice(0, 11);
+        var verificationCode = phoneVerificationCodeInput.value.replace(/\D/g, '').slice(0, 6);
+        if (!verificationCode) {
+          setPhoneVerificationStatus('인증번호를 입력해 주세요', '#e53e3e');
+          phoneVerificationCodeInput.focus();
+          return;
+        }
+
+        phoneVerifyConfirmButton.disabled = true;
+        requestJson('/api/users/me/phone-verification/confirm/', {
+          method: 'POST',
+          body: JSON.stringify({
+            phone: phoneValue,
+            verification_code: verificationCode
+          })
+        }).then(function () {
+          setPhoneVerifiedState(true);
+          initialPhone = phoneValue;
+          verifiedPhoneValue = phoneValue;
+          setPhoneInputStatus('', '#718096');
+          setPhoneVerificationStatus('연락처 인증이 완료되었습니다', '#38a169');
+          if (phoneVerificationCodeInput) {
+            phoneVerificationCodeInput.value = '';
+          }
+          updatePhoneVerificationUi();
+        }).catch(function (error) {
+          setPhoneVerificationStatus(error.message || '인증 확인에 실패했습니다', '#e53e3e');
+        }).finally(function () {
+          phoneVerifyConfirmButton.disabled = false;
+        });
       });
     }
 

--- a/services/django/users/migrations/0006_userprofile_payment_method.py
+++ b/services/django/users/migrations/0006_userprofile_payment_method.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0005_local_db_schema_alignment"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="payment_method",
+            field=models.CharField(blank=True, max_length=120, null=True),
+        ),
+    ]

--- a/services/django/users/migrations/0007_userprofile_phone_verification_fields.py
+++ b/services/django/users/migrations/0007_userprofile_phone_verification_fields.py
@@ -1,0 +1,36 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("users", "0006_userprofile_payment_method"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="userprofile",
+            name="phone_verified",
+            field=models.BooleanField(default=False),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="phone_verified_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="phone_verification_code",
+            field=models.CharField(blank=True, max_length=6, null=True),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="phone_verification_target",
+            field=models.CharField(blank=True, max_length=20, null=True),
+        ),
+        migrations.AddField(
+            model_name="userprofile",
+            name="phone_verification_expires_at",
+            field=models.DateTimeField(blank=True, null=True),
+        ),
+    ]

--- a/services/django/users/models.py
+++ b/services/django/users/models.py
@@ -47,9 +47,23 @@ class UserProfile(models.Model):
     address           = models.TextField(null=True, blank=True)
     phone             = models.CharField(max_length=20, null=True, blank=True)
     payment_method    = models.CharField(max_length=120, null=True, blank=True)
+    phone_verified    = models.BooleanField(default=False)
+    phone_verified_at = models.DateTimeField(null=True, blank=True)
+    phone_verification_code = models.CharField(max_length=6, null=True, blank=True)
+    phone_verification_target = models.CharField(max_length=20, null=True, blank=True)
+    phone_verification_expires_at = models.DateTimeField(null=True, blank=True)
     marketing_consent = models.BooleanField(default=False)
     profile_image_url = models.TextField(null=True, blank=True)
     updated_at        = models.DateTimeField(auto_now=True)
+
+    def clear_phone_verification(self):
+        self.phone_verification_code = None
+        self.phone_verification_target = None
+        self.phone_verification_expires_at = None
+
+    def mark_phone_unverified(self):
+        self.phone_verified = False
+        self.phone_verified_at = None
 
     class Meta:
         db_table = "user_profile"

--- a/services/django/users/models.py
+++ b/services/django/users/models.py
@@ -46,6 +46,7 @@ class UserProfile(models.Model):
     gender            = models.CharField(max_length=20, null=True, blank=True)
     address           = models.TextField(null=True, blank=True)
     phone             = models.CharField(max_length=20, null=True, blank=True)
+    payment_method    = models.CharField(max_length=120, null=True, blank=True)
     marketing_consent = models.BooleanField(default=False)
     profile_image_url = models.TextField(null=True, blank=True)
     updated_at        = models.DateTimeField(auto_now=True)

--- a/services/django/users/onboarding.py
+++ b/services/django/users/onboarding.py
@@ -1,0 +1,39 @@
+from django.urls import reverse
+
+from .models import UserProfile
+
+
+def is_profile_complete(user):
+    if not getattr(user, "is_authenticated", False):
+        return False
+
+    profile = getattr(user, "profile", None)
+    if profile is None:
+        profile = UserProfile.objects.filter(user=user).first()
+    if profile is None:
+        return False
+
+    return bool((profile.nickname or "").strip())
+
+
+def has_completed_pet_onboarding(request):
+    if not getattr(request.user, "is_authenticated", False):
+        return False
+
+    if request.user.pets.exists():
+        return True
+
+    return bool(request.session.get("future_pet_profile"))
+
+
+def get_onboarding_redirect_url(request):
+    if not getattr(request.user, "is_authenticated", False):
+        return None
+
+    if not is_profile_complete(request.user):
+        return f"{reverse('profile')}?setup=1"
+
+    if not has_completed_pet_onboarding(request):
+        return reverse("pet_add")
+
+    return None

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -27,6 +27,16 @@ User = get_user_model()
 logger = logging.getLogger(__name__)
 
 
+def _split_profile_address(address):
+    if not address:
+        return "", ""
+
+    parts = [part.strip() for part in address.split("|", 1)]
+    base_address = parts[0] if parts else ""
+    detail_address = parts[1] if len(parts) > 1 else ""
+    return base_address, detail_address
+
+
 def _get_profile(user):
     profile, _ = UserProfile.objects.get_or_create(
         user=user,
@@ -36,11 +46,15 @@ def _get_profile(user):
 
 
 def _render_profile(request, profile):
+    address_main, address_detail = _split_profile_address(profile.address)
     return render(
         request,
         "users/profile.html",
         {
             "profile": profile,
+            "profile_address_main": address_main,
+            "profile_address_detail": address_detail,
+            "profile_payment_method": profile.payment_method or "",
             "social_accounts": {account.provider: account for account in request.user.social_accounts.all()},
             "setup_mode": request.GET.get("setup") == "1",
             "profile_preview": False,
@@ -99,6 +113,13 @@ def profile_view(request):
         setup_mode = request.GET.get("setup") == "1"
         profile.nickname = request.POST.get("nickname", "").strip()
         profile.phone = request.POST.get("phone", "").strip()
+        address_main = request.POST.get("address_main", "").strip()
+        address_detail = request.POST.get("address_detail", "").strip()
+        if address_main or address_detail:
+            profile.address = " | ".join(part for part in [address_main, address_detail] if part)
+        else:
+            profile.address = ""
+        profile.payment_method = request.POST.get("payment_method", "").strip()
         profile.marketing_consent = request.POST.get("marketing") == "on"
         nickname_error = get_nickname_validation_error(profile.nickname, exclude_user=request.user)
         if nickname_error:
@@ -106,7 +127,7 @@ def profile_view(request):
             return _render_profile(request, profile)
         try:
             with transaction.atomic():
-                profile.save(update_fields=["nickname", "phone", "marketing_consent", "updated_at"])
+                profile.save(update_fields=["nickname", "phone", "address", "payment_method", "marketing_consent", "updated_at"])
         except IntegrityError:
             messages.error(request, "이미 사용 중인 닉네임입니다.")
             return _render_profile(request, profile)

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -5,7 +5,6 @@ import logging
 from django.contrib import messages
 from django.contrib.auth import get_user_model, login, logout
 from django.db import IntegrityError, transaction
-from django.db.models import ProtectedError
 from django.shortcuts import redirect, render
 from django.urls import reverse
 from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthException, AuthForbidden, AuthMissingParameter
@@ -21,7 +20,7 @@ from .social_auth import (
     build_authorization_url,
     complete_social_login,
 )
-from .views import issue_user_tokens
+from .views import deactivate_user_and_purge_personal_data, issue_user_tokens
 
 User = get_user_model()
 logger = logging.getLogger(__name__)
@@ -55,6 +54,7 @@ def _render_profile(request, profile):
             "profile_address_main": address_main,
             "profile_address_detail": address_detail,
             "profile_payment_method": profile.payment_method or "",
+            "profile_phone_verified": profile.phone_verified,
             "social_accounts": {account.provider: account for account in request.user.social_accounts.all()},
             "setup_mode": request.GET.get("setup") == "1",
             "profile_preview": False,
@@ -112,7 +112,23 @@ def profile_view(request):
     if request.method == "POST":
         setup_mode = request.GET.get("setup") == "1"
         profile.nickname = request.POST.get("nickname", "").strip()
-        profile.phone = request.POST.get("phone", "").strip()
+        submitted_phone = "".join(char for char in request.POST.get("phone", "") if char.isdigit())[:11]
+        if submitted_phone and not 10 <= len(submitted_phone) <= 11:
+            messages.error(request, "연락처는 10~11자리 숫자만 입력해 주세요.")
+            return _render_profile(request, profile)
+        if submitted_phone != (profile.phone or "") and submitted_phone:
+            messages.error(request, "연락처 인증을 완료해 주세요.")
+            return _render_profile(request, profile)
+        if submitted_phone and not profile.phone_verified:
+            messages.error(request, "연락처 인증을 완료해 주세요.")
+            return _render_profile(request, profile)
+        if not submitted_phone:
+            profile.phone = ""
+            profile.phone_verified = False
+            profile.phone_verified_at = None
+            profile.clear_phone_verification()
+        else:
+            profile.phone = submitted_phone
         address_main = request.POST.get("address_main", "").strip()
         address_detail = request.POST.get("address_detail", "").strip()
         if address_main or address_detail:
@@ -127,14 +143,26 @@ def profile_view(request):
             return _render_profile(request, profile)
         try:
             with transaction.atomic():
-                profile.save(update_fields=["nickname", "phone", "address", "payment_method", "marketing_consent", "updated_at"])
+                profile.save(update_fields=[
+                    "nickname",
+                    "phone",
+                    "phone_verified",
+                    "phone_verified_at",
+                    "phone_verification_code",
+                    "phone_verification_target",
+                    "phone_verification_expires_at",
+                    "address",
+                    "payment_method",
+                    "marketing_consent",
+                    "updated_at",
+                ])
         except IntegrityError:
             messages.error(request, "이미 사용 중인 닉네임입니다.")
             return _render_profile(request, profile)
         messages.success(request, "프로필 정보가 저장되었습니다.")
         if setup_mode:
             return redirect("pet_add")
-        return redirect("profile")
+        return redirect("chat")
 
     return _render_profile(request, profile)
 
@@ -147,14 +175,10 @@ def profile_withdraw_view(request):
     if preview_mode:
         return redirect("chat")
 
-    try:
-        request.user.delete()
-    except ProtectedError:
-        messages.error(request, "진행 중이거나 보존이 필요한 주문 데이터가 있어 탈퇴할 수 없습니다.")
-        return redirect("profile")
+    deactivate_user_and_purge_personal_data(request.user)
 
     logout(request)
-    messages.success(request, "회원 탈퇴가 완료되었습니다.")
+    messages.success(request, "회원 탈퇴가 완료되었습니다. 주문 기록을 제외한 사용자 정보가 정리되었습니다.")
     return redirect("chat")
 
 

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -11,6 +11,7 @@ from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthExcept
 
 from .models import UserProfile
 from .nickname_utils import build_unique_nickname, get_nickname_validation_error
+from .onboarding import get_onboarding_redirect_url
 from .social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
     SOCIAL_AUTH_REFRESH_SESSION_KEY,
@@ -64,18 +65,27 @@ def _render_profile(request, profile):
 
 def home(request):
     if request.user.is_authenticated:
+        onboarding_redirect_url = get_onboarding_redirect_url(request)
+        if onboarding_redirect_url:
+            return redirect(onboarding_redirect_url)
         return redirect("chat")
     return render(request, "chat/index.html")
 
 
 def login_view(request):
     if request.user.is_authenticated:
+        onboarding_redirect_url = get_onboarding_redirect_url(request)
+        if onboarding_redirect_url:
+            return redirect(onboarding_redirect_url)
         return redirect("chat")
     return render(request, "users/login.html")
 
 
 def signup_view(request):
     if request.user.is_authenticated:
+        onboarding_redirect_url = get_onboarding_redirect_url(request)
+        if onboarding_redirect_url:
+            return redirect(onboarding_redirect_url)
         return redirect("chat")
     return render(request, "users/signup.html")
 
@@ -232,4 +242,9 @@ def social_login_callback_view(request, provider):
     request.session[SOCIAL_AUTH_REFRESH_SESSION_KEY] = tokens["refresh"]
     request.session.pop(SOCIAL_AUTH_REMEMBER_SESSION_KEY, None)
     messages.success(request, "소셜 로그인이 완료되었습니다.")
+    if result.is_new_user:
+        return redirect(f"{reverse('profile')}?setup=1")
+    onboarding_redirect_url = get_onboarding_redirect_url(request)
+    if onboarding_redirect_url:
+        return redirect(onboarding_redirect_url)
     return redirect("chat")

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -6,6 +6,7 @@ from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
 
+from orders.models import Order
 from products.models import Product
 from users.models import SocialAccount, User, UserProfile
 from users.social_auth import (
@@ -111,7 +112,7 @@ class AuthApiTests(TestCase):
         refresh_response = self.client.post("/api/auth/token/refresh/", {"refresh": refresh}, format="json")
         self.assertEqual(refresh_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
-    def test_withdraw_deletes_user(self):
+    def test_withdraw_deactivates_user_and_scrubs_identity(self):
         login_response = self.client.post(
             "/api/auth/login/",
             {"email": "auth@example.com", "password": "Password123!"},
@@ -124,7 +125,41 @@ class AuthApiTests(TestCase):
         response = self.client.delete("/api/auth/withdraw/", {"refresh": refresh}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
-        self.assertFalse(User.objects.filter(email="auth@example.com").exists())
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        self.assertNotEqual(self.user.email, "auth@example.com")
+        self.assertFalse(self.user.has_usable_password())
+        self.assertFalse(UserProfile.objects.filter(user=self.user).exists())
+
+    def test_withdraw_preserves_orders(self):
+        Order.objects.create(
+            user=self.user,
+            recipient_name="탈퇴 사용자",
+            recipient_phone="01012341234",
+            delivery_address="서울 강동구 올림픽로 123 | 101동 1203호",
+            payment_method="카카오페이 / 일시불",
+            product_total=10000,
+            coupon_discount=0,
+            mileage_discount=0,
+            shipping_fee=0,
+            total_price=10000,
+        )
+
+        login_response = self.client.post(
+            "/api/auth/login/",
+            {"email": "auth@example.com", "password": "Password123!"},
+            format="json",
+        )
+        access = login_response.data["access"]
+        refresh = login_response.data["refresh"]
+
+        self.client.credentials(HTTP_AUTHORIZATION=f"Bearer {access}")
+        response = self.client.delete("/api/auth/withdraw/", {"refresh": refresh}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.user.refresh_from_db()
+        self.assertFalse(self.user.is_active)
+        self.assertEqual(Order.objects.filter(user=self.user).count(), 1)
 
 
 class ProfilePageViewTests(TestCase):
@@ -152,18 +187,31 @@ class ProfilePageViewTests(TestCase):
         response = self.client.post(
             "/profile/",
             {
-                "nickname": "PageProfile",
-                "phone": "01012341234",
+                "nickname": "PageProfile2",
+                "zipcode": "12345",
                 "address_main": "서울 강동구 올림픽로 123",
                 "address_detail": "101동 1203호",
                 "payment_method": "카카오페이 / 일시불",
             },
         )
 
-        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.user.refresh_from_db()
+        self.assertIn(response.status_code, {status.HTTP_200_OK, status.HTTP_302_FOUND})
+        self.assertEqual(self.user.profile.nickname, "PageProfile2")
         self.assertEqual(self.user.profile.address, "서울 강동구 올림픽로 123 | 101동 1203호")
         self.assertEqual(self.user.profile.payment_method, "카카오페이 / 일시불")
+
+    def test_profile_post_requires_phone_verification_for_changed_phone(self):
+        response = self.client.post(
+            "/profile/",
+            {
+                "nickname": "PageProfile",
+                "phone": "01099998888",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertContains(response, "연락처 인증을 완료해 주세요.")
 
 
 class UserProfileApiTests(TestCase):
@@ -200,6 +248,59 @@ class UserProfileApiTests(TestCase):
         self.assertEqual(self.user.profile.address, "서울 강동구 올림픽로 123 | 101동 1203호")
         self.assertEqual(self.user.profile.payment_method, "네이버페이 / 일시불")
         self.assertTrue(self.user.profile.marketing_consent)
+
+    @override_settings(DEBUG=True)
+    def test_phone_verification_request_returns_code_in_debug(self):
+        response = self.client.post(
+            "/api/users/me/phone-verification/request/",
+            {"phone": "01012341234"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["phone"], "01012341234")
+        self.assertIn("verification_code", response.data)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.profile.phone_verification_target, "01012341234")
+
+    @override_settings(DEBUG=True)
+    def test_phone_verification_confirm_marks_phone_verified(self):
+        request_response = self.client.post(
+            "/api/users/me/phone-verification/request/",
+            {"phone": "01012341234"},
+            format="json",
+        )
+
+        response = self.client.post(
+            "/api/users/me/phone-verification/confirm/",
+            {
+                "phone": "01012341234",
+                "verification_code": request_response.data["verification_code"],
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.profile.phone, "01012341234")
+        self.assertTrue(self.user.profile.phone_verified)
+        self.assertIsNone(self.user.profile.phone_verification_code)
+
+    def test_patch_me_resets_phone_verified_when_phone_changes(self):
+        self.user.profile.phone = "01012341234"
+        self.user.profile.phone_verified = True
+        self.user.profile.save(update_fields=["phone", "phone_verified", "updated_at"])
+
+        response = self.client.patch(
+            "/api/users/me/",
+            {"phone": "01099998888"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.profile.phone, "01099998888")
+        self.assertFalse(self.user.profile.phone_verified)
 
     def test_nickname_availability_returns_available_for_current_nickname(self):
         response = self.client.get("/api/users/nickname-availability/?nickname=ProfileUser")

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -148,6 +148,23 @@ class ProfilePageViewTests(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.user.profile.nickname, "PageProfile")
 
+    def test_profile_post_saves_address_and_payment_method(self):
+        response = self.client.post(
+            "/profile/",
+            {
+                "nickname": "PageProfile",
+                "phone": "01012341234",
+                "address_main": "서울 강동구 올림픽로 123",
+                "address_detail": "101동 1203호",
+                "payment_method": "카카오페이 / 일시불",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.profile.address, "서울 강동구 올림픽로 123 | 101동 1203호")
+        self.assertEqual(self.user.profile.payment_method, "카카오페이 / 일시불")
+
 
 class UserProfileApiTests(TestCase):
     def setUp(self):
@@ -169,6 +186,8 @@ class UserProfileApiTests(TestCase):
             {
                 "nickname": "UpdatedUser",
                 "phone": "01012341234",
+                "address": "서울 강동구 올림픽로 123 | 101동 1203호",
+                "payment_method": "네이버페이 / 일시불",
                 "marketing_consent": True,
             },
             format="json",
@@ -178,6 +197,8 @@ class UserProfileApiTests(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.user.profile.nickname, "UpdatedUser")
         self.assertEqual(self.user.profile.phone, "01012341234")
+        self.assertEqual(self.user.profile.address, "서울 강동구 올림픽로 123 | 101동 1203호")
+        self.assertEqual(self.user.profile.payment_method, "네이버페이 / 일시불")
         self.assertTrue(self.user.profile.marketing_consent)
 
     def test_nickname_availability_returns_available_for_current_nickname(self):

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -53,7 +53,7 @@ class SocialLoginPageViewTests(TestCase):
         self.assertEqual(response["Location"], "https://nid.naver.com/oauth2.0/authorize?state=test")
 
     @patch("users.page_views.complete_social_login")
-    def test_social_login_callback_redirects_to_profile_and_stores_jwt(self, complete_social_login_mock):
+    def test_social_login_callback_redirects_new_user_to_profile_setup_and_stores_jwt(self, complete_social_login_mock):
         user = User.objects.create_user(email="page@example.com")
         UserProfile.objects.create(user=user, nickname="PageUser")
         complete_social_login_mock.return_value = SocialLoginResult(
@@ -70,7 +70,7 @@ class SocialLoginPageViewTests(TestCase):
         response = self.client.get("/auth/kakao/callback/?code=test-code&state=test-state")
 
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
-        self.assertEqual(response["Location"], reverse("chat"))
+        self.assertEqual(response["Location"], f"{reverse('profile')}?setup=1")
 
         session = self.client.session
         self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)

--- a/services/django/users/urls.py
+++ b/services/django/users/urls.py
@@ -3,6 +3,8 @@ from django.urls import path
 from .views import (
     NicknameAvailabilityView,
     RegisterView,
+    UserPhoneVerificationConfirmView,
+    UserPhoneVerificationRequestView,
     UserMePreferenceView,
     UserMeUsedProductView,
     UserMeView,
@@ -12,6 +14,8 @@ urlpatterns = [
     path("nickname-availability/", NicknameAvailabilityView.as_view(), name="nickname-availability"),
     path("register/", RegisterView.as_view(), name="register"),
     path("me/", UserMeView.as_view(), name="user-me"),
+    path("me/phone-verification/request/", UserPhoneVerificationRequestView.as_view(), name="user-phone-verification-request"),
+    path("me/phone-verification/confirm/", UserPhoneVerificationConfirmView.as_view(), name="user-phone-verification-confirm"),
     path("me/preferences/", UserMePreferenceView.as_view(), name="user-me-preferences"),
     path("me/used-products/", UserMeUsedProductView.as_view(), name="user-me-used-products"),
 ]

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -153,6 +153,7 @@ def serialize_user_profile(user):
         "gender": profile.gender,
         "address": profile.address,
         "phone": profile.phone,
+        "payment_method": profile.payment_method,
         "marketing_consent": profile.marketing_consent,
         "profile_image_url": profile.profile_image_url,
     }
@@ -369,12 +370,14 @@ class UserMeView(APIView):
                 return Response({"detail": nickname_error}, status=status.HTTP_400_BAD_REQUEST)
 
         dirty_fields = []
-        for field in ["nickname", "age", "gender", "address", "phone"]:
+        for field in ["nickname", "age", "gender", "address", "phone", "payment_method"]:
             if field not in request.data:
                 continue
             value = request.data.get(field)
             if field == "nickname":
                 value = (value or "").strip()
+            elif field in {"address", "phone", "payment_method"}:
+                value = (value or "").strip() or None
             elif value == "":
                 value = None if field != "nickname" else profile.nickname
             if field == "age" and value is not None:

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -1,5 +1,7 @@
 import os
+import random
 import uuid
+from datetime import timedelta
 from pathlib import Path
 
 import boto3
@@ -8,10 +10,13 @@ from django.contrib.auth import authenticate, login, logout
 from django.db import IntegrityError, transaction
 from django.db.models import ProtectedError
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
+from rest_framework.authentication import SessionAuthentication
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
+from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.tokens import RefreshToken
 from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthException, AuthForbidden, AuthMissingParameter
 
@@ -33,6 +38,33 @@ from .social_auth import (
     build_authorization_url,
     complete_social_login,
 )
+
+
+def deactivate_user_and_purge_personal_data(user):
+    anonymized_email = f"withdrawn-{user.pk}-{uuid.uuid4().hex[:12]}@deleted.local"
+
+    if hasattr(user, "chat_sessions"):
+        user.chat_sessions.all().delete()
+    if hasattr(user, "cart"):
+        user.cart.delete()
+    if hasattr(user, "wishlist"):
+        user.wishlist.delete()
+    if hasattr(user, "pets"):
+        user.pets.all().delete()
+    if hasattr(user, "social_accounts"):
+        user.social_accounts.all().delete()
+    if hasattr(user, "used_products"):
+        user.used_products.all().delete()
+    if hasattr(user, "userinteraction_set"):
+        user.userinteraction_set.all().delete()
+
+    UserPreference.objects.filter(user=user).delete()
+    UserProfile.objects.filter(user=user).delete()
+
+    user.email = anonymized_email
+    user.is_active = False
+    user.set_unusable_password()
+    user.save(update_fields=["email", "is_active", "password"])
 
 
 @transaction.atomic
@@ -153,10 +185,25 @@ def serialize_user_profile(user):
         "gender": profile.gender,
         "address": profile.address,
         "phone": profile.phone,
+        "phone_verified": profile.phone_verified,
+        "phone_verified_at": profile.phone_verified_at,
         "payment_method": profile.payment_method,
         "marketing_consent": profile.marketing_consent,
         "profile_image_url": profile.profile_image_url,
     }
+
+
+def normalize_phone(value):
+    return "".join(char for char in str(value or "") if char.isdigit())[:11]
+
+
+def validate_phone_or_400(phone):
+    normalized_phone = normalize_phone(phone)
+    if not normalized_phone:
+        return None, Response({"detail": "phone is required."}, status=status.HTTP_400_BAD_REQUEST)
+    if not 10 <= len(normalized_phone) <= 11:
+        return None, Response({"detail": "phone must be 10~11 digits."}, status=status.HTTP_400_BAD_REQUEST)
+    return normalized_phone, None
 
 
 def serialize_user_preferences(user):
@@ -284,6 +331,7 @@ class AuthLoginView(APIView):
 
 
 class AuthLogoutView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):
@@ -302,6 +350,7 @@ class AuthLogoutView(APIView):
 
 
 class AuthWithdrawView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     @transaction.atomic
@@ -316,13 +365,7 @@ class AuthWithdrawView(APIView):
             except Exception:
                 return Response({"detail": "유효하지 않은 refresh token 입니다."}, status=status.HTTP_400_BAD_REQUEST)
 
-        try:
-            user.delete()
-        except ProtectedError:
-            return Response(
-                {"detail": "진행 중이거나 보존이 필요한 주문 데이터가 있어 탈퇴할 수 없습니다."},
-                status=status.HTTP_409_CONFLICT,
-            )
+        deactivate_user_and_purge_personal_data(user)
 
         logout(request)
         return Response(status=status.HTTP_204_NO_CONTENT)
@@ -352,6 +395,7 @@ class NicknameAvailabilityView(APIView):
 
 
 class UserMeView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -385,7 +429,16 @@ class UserMeView(APIView):
                     value = int(value)
                 except (TypeError, ValueError):
                     return Response({"detail": "age must be an integer."}, status=status.HTTP_400_BAD_REQUEST)
+            if field == "phone" and value is not None:
+                value = normalize_phone(value)
+                if value and not 10 <= len(value) <= 11:
+                    return Response({"detail": "phone must be 10~11 digits."}, status=status.HTTP_400_BAD_REQUEST)
             if getattr(profile, field) != value:
+                if field == "phone":
+                    if value != profile.phone:
+                        profile.mark_phone_unverified()
+                        profile.clear_phone_verification()
+                        dirty_fields.extend(["phone_verified", "phone_verified_at", "phone_verification_code", "phone_verification_target", "phone_verification_expires_at"])
                 setattr(profile, field, value)
                 dirty_fields.append(field)
 
@@ -415,7 +468,95 @@ class UserMeView(APIView):
         return Response({"user": serialize_user_profile(request.user)})
 
 
+class UserPhoneVerificationRequestView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        profile, _ = UserProfile.objects.get_or_create(
+            user=request.user,
+            defaults={"nickname": build_unique_nickname(request.user.email.split("@")[0], exclude_user=request.user)},
+        )
+        phone, error_response = validate_phone_or_400(request.data.get("phone"))
+        if error_response:
+            return error_response
+
+        verification_code = f"{random.randint(0, 999999):06d}"
+        profile.phone_verification_target = phone
+        profile.phone_verification_code = verification_code
+        profile.phone_verification_expires_at = timezone.now() + timedelta(minutes=5)
+        profile.phone_verified = False
+        profile.phone_verified_at = None
+        profile.save(
+            update_fields=[
+                "phone_verification_target",
+                "phone_verification_code",
+                "phone_verification_expires_at",
+                "phone_verified",
+                "phone_verified_at",
+                "updated_at",
+            ]
+        )
+
+        response_payload = {
+            "detail": "인증번호를 전송했습니다.",
+            "phone": phone,
+            "expires_in_seconds": 300,
+        }
+        if settings.DEBUG:
+            response_payload["verification_code"] = verification_code
+        return Response(response_payload, status=status.HTTP_200_OK)
+
+
+class UserPhoneVerificationConfirmView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        profile, _ = UserProfile.objects.get_or_create(
+            user=request.user,
+            defaults={"nickname": build_unique_nickname(request.user.email.split("@")[0], exclude_user=request.user)},
+        )
+        phone, error_response = validate_phone_or_400(request.data.get("phone"))
+        if error_response:
+            return error_response
+
+        verification_code = (request.data.get("verification_code") or "").strip()
+        if not verification_code:
+            return Response({"detail": "verification_code is required."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if (
+            profile.phone_verification_target != phone or
+            not profile.phone_verification_code or
+            profile.phone_verification_code != verification_code
+        ):
+            return Response({"detail": "인증번호가 올바르지 않습니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        if not profile.phone_verification_expires_at or profile.phone_verification_expires_at < timezone.now():
+            profile.clear_phone_verification()
+            profile.save(update_fields=["phone_verification_code", "phone_verification_target", "phone_verification_expires_at", "updated_at"])
+            return Response({"detail": "인증번호가 만료되었습니다. 다시 요청해 주세요."}, status=status.HTTP_400_BAD_REQUEST)
+
+        profile.phone = phone
+        profile.phone_verified = True
+        profile.phone_verified_at = timezone.now()
+        profile.clear_phone_verification()
+        profile.save(
+            update_fields=[
+                "phone",
+                "phone_verified",
+                "phone_verified_at",
+                "phone_verification_code",
+                "phone_verification_target",
+                "phone_verification_expires_at",
+                "updated_at",
+            ]
+        )
+        return Response({"detail": "연락처 인증이 완료되었습니다.", "user": serialize_user_profile(request.user)})
+
+
 class UserMePreferenceView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def get(self, request):
@@ -435,6 +576,7 @@ class UserMePreferenceView(APIView):
 
 
 class UserMeUsedProductView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
     permission_classes = [IsAuthenticated]
 
     def post(self, request):


### PR DESCRIPTION
## 요약
프로필에 저장한 주소와 결제수단을 서버 기준 값으로 정리하고, 장바구니 주문과 빠른 주문에서 같은 우선순위로 반영되도록 맞췄습니다.

## 변경 사항
- UserProfile에 결제수단 저장 필드를 추가했습니다.
- 프로필 저장 시 주소와 결제수단이 실제 서버에 저장되도록 보강했습니다.
- 장바구니 주문 화면은 서버 저장값을 우선 사용하고, 프런트 임시 저장값은 서버값이 없을 때만 미리보기로 사용하도록 정리했습니다.
- 빠른 주문도 서버 프로필 값을 기본으로 사용하고, 로컬 임시값은 fallback으로만 사용하도록 정리했습니다.
- 주문 생성 API에서 payment_method가 요청에 없을 때 서버 프로필 저장값을 fallback으로 사용하도록 보강했습니다.
- users, orders 테스트를 보강해 프로필 저장과 주문 반영 흐름을 검증했습니다.

## 관련 이슈
closes #199

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 프로필 저장값과 localStorage 미리보기 값의 우선순위가 주문 화면/빠른 주문에서 일관되게 반영되는지 확인 부탁드립니다.
- 연락처 인증과 실제 결제 인증은 이번 범위에 포함하지 않았습니다.