### PR TITLE
fix(auth): stabilize social login icon rendering

### DIFF
--- a/services/django/static/css/main.css
+++ b/services/django/static/css/main.css
@@ -71,23 +71,25 @@ input:disabled {
 
 .auth-legacy-remember {
   position: absolute;
-  display: flex;
+  display: inline-flex;
   align-items: center;
   justify-content: flex-start;
-  gap: 7px;
+  gap: 8px;
   border: 0;
   background: transparent;
   padding: 0;
+  font: inherit;
+  line-height: 1;
   appearance: none;
 }
 
 .auth-legacy-checkbox {
-  position: relative;
-  display: block;
-  width: 18px;
-  height: 18px;
-  left: 0;
-  top: 4px;
+  position: static;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
   z-index: 1;
 }
 
@@ -95,15 +97,14 @@ input:disabled {
   display: block;
   white-space: nowrap;
   font-size: 15px;
-  line-height: 18px;
+  line-height: 1;
   letter-spacing: -0.01em;
   color: #5f6b7a;
-  transform: translate(0, 4px);
   z-index: 2;
 }
 
 .auth-legacy-remember .auth-legacy-checkbox {
-  flex: 0 0 18px;
+  flex: 0 0 16px;
   white-space: nowrap;
 }
 

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -27,8 +27,10 @@
             <path fill="#191919" d="M20 8.2c-6.6 0-12 4.25-12 9.5 0 3.39 2.2 6.37 5.52 8.06l-1.4 5.1c-.07.28.23.5.48.36l5.98-3.95c.47.05.94.08 1.42.08 6.63 0 12-4.25 12-9.5s-5.37-9.55-12-9.55Z"/>
           </svg>
         </a>
-        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#03A94D]">
-          <img src="{% static 'images/social/naver_login_icon.png' %}" alt="네이버 로그인" class="pointer-events-none block h-[34px] w-[34px] object-contain" />
+        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#03A94D] text-white">
+          <svg viewBox="0 0 40 40" class="pointer-events-none block h-[22px] w-[22px]" aria-hidden="true">
+            <path fill="currentColor" d="M10.5 9.5h6.2l7.1 10.2V9.5h5.7v21h-6.2l-7.1-10.2v10.2h-5.7V9.5Z"/>
+          </svg>
         </a>
         <a href="/auth/google/start/?remember=on" data-social-link aria-label="구글 로그인" class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#dadce0] bg-white">
           <svg viewBox="0 0 24 24" class="h-[24px] w-[24px]" aria-hidden="true">

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -166,8 +166,10 @@
         </div>
         {% elif social_accounts.naver %}
         <div class="flex items-center gap-3">
-          <div class="flex h-7 w-7 items-center justify-center rounded-full bg-[#03A94D]">
-            <img alt="Naver" class="h-[24px] w-[24px] object-contain" src="{% static 'images/social/naver_login_icon.png' %}" />
+          <div class="flex h-7 w-7 items-center justify-center rounded-full bg-[#03A94D] text-white">
+            <svg viewBox="0 0 40 40" class="h-[19px] w-[19px]" aria-hidden="true">
+              <path fill="currentColor" d="M10.5 9.5h6.2l7.1 10.2V9.5h5.7v21h-6.2l-7.1-10.2v10.2h-5.7V9.5Z"/>
+            </svg>
           </div>
           <div class="flex-1">
             <div class="text-[13px] font-bold text-[#2d3748]">네이버</div>

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -27,8 +27,10 @@
             <path fill="#191919" d="M20 8.2c-6.6 0-12 4.25-12 9.5 0 3.39 2.2 6.37 5.52 8.06l-1.4 5.1c-.07.28.23.5.48.36l5.98-3.95c.47.05.94.08 1.42.08 6.63 0 12-4.25 12-9.5s-5.37-9.55-12-9.55Z"/>
           </svg>
         </a>
-        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#03A94D]">
-          <img src="{% static 'images/social/naver_login_icon.png' %}" alt="네이버 로그인" class="pointer-events-none block h-[34px] w-[34px] object-contain" />
+        <a href="/auth/naver/start/?remember=on" data-social-link aria-label="네이버 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#03A94D] text-white">
+          <svg viewBox="0 0 40 40" class="pointer-events-none block h-[22px] w-[22px]" aria-hidden="true">
+            <path fill="currentColor" d="M10.5 9.5h6.2l7.1 10.2V9.5h5.7v21h-6.2l-7.1-10.2v10.2h-5.7V9.5Z"/>
+          </svg>
         </a>
         <a href="/auth/google/start/?remember=on" data-social-link aria-label="구글 로그인" class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#dadce0] bg-white">
           <svg viewBox="0 0 24 24" class="h-[24px] w-[24px]" aria-hidden="true">


### PR DESCRIPTION
## 요약
로그인/회원가입 auth UI에서 네이버 소셜 아이콘 깨짐과 로그인 상태 유지 정렬 불일치를 브라우저/배포 환경에 덜 민감한 방식으로 정리했습니다.

## 변경 사항
- 로그인/회원가입 화면의 네이버 아이콘을 PNG 대신 inline SVG로 변경했습니다.
- 프로필 화면의 네이버 계정 아이콘도 동일한 SVG로 통일했습니다.
- auth 공통 CSS에서 로그인 상태 유지 체크박스와 텍스트 정렬을 top/transform 오프셋 대신 flex 정렬로 정리했습니다.
- 로컬에서 네이버/카카오 소셜 로그인 후 callback이 정상적으로 /chat/으로 연결되는 것을 확인했습니다.
- `manage.py check` 통과를 확인했습니다.

## 관련 이슈
없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 로그인/회원가입 화면에서 네이버 아이콘과 로그인 상태 유지 정렬이 브라우저/배포 환경에서도 동일하게 보이는지 확인 부탁드립니다.
