### PR TITLE
[feat] 프로필 저장값 주문 연동 정리 (#199)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -314,6 +314,24 @@ def _preview_session_threads():
     }
 
 
+def _build_quick_order_profile_context(user):
+    profile = getattr(user, "profile", None)
+    if profile is None:
+        return {
+            "quick_order_recipient": "이름 정보가 없습니다",
+            "quick_order_address": "배송지 정보가 없습니다",
+            "quick_order_phone": "연락처 정보가 없습니다",
+            "quick_order_payment_method": "등록된 결제수단이 없습니다",
+        }
+
+    return {
+        "quick_order_recipient": (profile.nickname or "").strip() or "이름 정보가 없습니다",
+        "quick_order_address": (profile.address or "").strip() or "배송지 정보가 없습니다",
+        "quick_order_phone": (profile.phone or "").strip() or "연락처 정보가 없습니다",
+        "quick_order_payment_method": (profile.payment_method or "").strip() or "등록된 결제수단이 없습니다",
+    }
+
+
 @ensure_csrf_cookie
 def chat_view(request):
     onboarding_redirect_url = get_onboarding_redirect_url(request)
@@ -493,6 +511,13 @@ def chat_view(request):
             cart_products = []
             cart_total = 0
 
+    quick_order_profile = _build_quick_order_profile_context(request.user) if is_authenticated else {
+        "quick_order_recipient": "이름 정보가 없습니다",
+        "quick_order_address": "배송지 정보가 없습니다",
+        "quick_order_phone": "연락처 정보가 없습니다",
+        "quick_order_payment_method": "등록된 결제수단이 없습니다",
+    }
+
     future_pet = _serialize_future_pet(request.session.get("future_pet_profile"))
     if future_pet:
         member_pets.append(future_pet)
@@ -526,5 +551,6 @@ def chat_view(request):
             "cart_total": _format_price(cart_total),
             "promo_banners": promo_banners,
             "session_threads": session_threads,
+            **quick_order_profile,
         },
     )

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -588,12 +588,13 @@ def used_products(request):
     shipping_fee = 0 if product_total >= 30000 else 3000
     final_total = product_total - discount + shipping_fee
     profile = getattr(request.user, "profile", None)
-    recipient_name = getattr(profile, "nickname", "") or request.user.username or "주문자 정보 미등록"
+    recipient_name = getattr(profile, "nickname", "") or request.user.email.split("@")[0] or "주문자 정보 미등록"
     address = getattr(profile, "address", "") or ""
     address_parts = [part.strip() for part in address.split("|", 1)] if address else []
     base_address = address_parts[0] if address_parts else "배송지 정보가 아직 등록되지 않았어요"
     detail_address = address_parts[1] if len(address_parts) > 1 else ""
     phone = getattr(profile, "phone", "") or "연락처 정보가 아직 없습니다."
+    payment_method = getattr(profile, "payment_method", "") or "결제 수단 정보가 아직 없습니다."
     for item in items:
         item["price_label"] = _format_price(item["price"])
         item["line_total_label"] = _format_price(item["price"] * item["quantity"])
@@ -617,7 +618,7 @@ def used_products(request):
             "delivery_detail_address": detail_address,
             "recipient_phone": phone,
             "delivery_message": "",
-            "payment_method": "우리카드 1234 / 일시불",
+            "payment_method": payment_method,
             "coupon_summary": "적용된 쿠폰 없음",
             "mileage_summary": "사용 가능 3,200원",
             "discount_total_raw": discount,

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -313,6 +313,23 @@ class OrderCreateApiTests(TestCase):
         self.assertEqual(response.data["code"], "invalid_phone_number")
         self.assertEqual(response.data["field"], "recipient_phone")
 
+    def test_post_order_uses_saved_profile_payment_method_when_request_omits_it(self):
+        self.add_cart_items()
+        self.user.profile.payment_method = "카카오페이 / 일시불"
+        self.user.profile.save(update_fields=["payment_method", "updated_at"])
+
+        response = self.client.post(
+            "/api/orders/",
+            {
+                "delivery_message": "문 앞에 두세요",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["order"]["payment_method"], "카카오페이 / 일시불")
+        self.assertEqual(response.data["completion"]["payment_method"], "카카오페이 / 일시불")
+
 
 class OrderReadApiTests(TestCase):
     def setUp(self):

--- a/services/django/orders/views.py
+++ b/services/django/orders/views.py
@@ -368,7 +368,7 @@ def validate_checkout_payload(request, cart_items):
     recipient_phone = (request.data.get("recipient_phone") or get_profile_value(request.user, "phone")).strip()
     delivery_address = normalize_delivery_address(request.data, request.user)
     delivery_message = (request.data.get("delivery_message") or "").strip()
-    payment_method = (request.data.get("payment_method") or "").strip()
+    payment_method = (request.data.get("payment_method") or get_profile_value(request.user, "payment_method")).strip()
     missing_fields = []
 
     if not recipient_name:

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -512,9 +512,9 @@
                   <div class="flex min-w-0 flex-1 items-start gap-[8px]">
                     <div class="w-[14px] shrink-0 pt-[1px] text-[13px] leading-none text-[#2d3748]" aria-hidden="true">🚚</div>
                     <div class="min-w-0 flex-1 space-y-[5px] text-[12px] text-[#4a5568]">
-                      <p id="quickOrderRecipientSummary" class="leading-[1.5]">{{ request.user.profile.nickname|default:"이름 정보가 없습니다" }}</p>
-                      <p id="quickOrderAddressSummary" class="leading-[1.55]">{{ request.user.profile.address|default:"배송지 정보가 없습니다" }}</p>
-                      <p id="quickOrderPhoneSummary" class="leading-[1.5]">{{ request.user.profile.phone|default:"연락처 정보가 없습니다" }}</p>
+                      <p id="quickOrderRecipientSummary" class="leading-[1.5]">{{ quick_order_recipient }}</p>
+                      <p id="quickOrderAddressSummary" class="leading-[1.55]">{{ quick_order_address }}</p>
+                      <p id="quickOrderPhoneSummary" class="leading-[1.5]">{{ quick_order_phone }}</p>
                     </div>
                   </div>
                   <button type="button"
@@ -530,7 +530,7 @@
                   <div class="flex min-w-0 flex-1 items-start gap-[8px]">
                     <div class="w-[14px] shrink-0 pt-[1px] text-[13px] leading-none text-[#2d3748]" aria-hidden="true">💳</div>
                     <div class="min-w-0 flex-1 space-y-[5px] text-[12px] text-[#4a5568]">
-                      <p id="quickOrderCardSummary" class="leading-[1.5] text-[#718096]">등록된 결제수단이 없습니다 / 일시불</p>
+                      <p id="quickOrderCardSummary" class="leading-[1.5] {% if quick_order_payment_method == '등록된 결제수단이 없습니다' %}text-[#718096]{% else %}text-[#4a5568]{% endif %}">{{ quick_order_payment_method }}</p>
                     </div>
                   </div>
                   <button type="button"
@@ -2940,7 +2940,11 @@
     try {
       var savedAddress = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
       if (savedAddress) {
-        if (quickOrderAddressSummary && savedAddress.addressMain) {
+        if (
+          quickOrderAddressSummary &&
+          quickOrderAddressSummary.textContent.indexOf('없습니다') !== -1 &&
+          savedAddress.addressMain
+        ) {
           var addressText = savedAddress.addressMain || '';
           if (savedAddress.addressDetail) {
             addressText += ' ' + savedAddress.addressDetail;
@@ -2952,7 +2956,13 @@
 
     try {
       var savedPayment = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-      if (savedPayment && quickOrderCardSummary && savedPayment.cardName && savedPayment.maskedCard) {
+      if (
+        savedPayment &&
+        quickOrderCardSummary &&
+        quickOrderCardSummary.textContent.indexOf('없습니다') !== -1 &&
+        savedPayment.cardName &&
+        savedPayment.maskedCard
+      ) {
         quickOrderCardSummary.textContent = savedPayment.cardName + ' / ' + savedPayment.maskedCard;
         quickOrderCardSummary.classList.remove('text-[#718096]');
       }
@@ -3105,20 +3115,6 @@
   function buildQuickOrderPayload() {
     var addressText = quickOrderAddressSummary ? quickOrderAddressSummary.textContent.trim() : '';
     var paymentMethod = quickOrderCardSummary ? quickOrderCardSummary.textContent.trim() : '';
-
-    try {
-      var savedAddress = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
-      if (savedAddress && (savedAddress.addressMain || savedAddress.addressDetail)) {
-        addressText = [savedAddress.addressMain || '', savedAddress.addressDetail || ''].filter(Boolean).join(' | ');
-      }
-    } catch (e) {}
-
-    try {
-      var savedPayment = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-      if (savedPayment && savedPayment.cardName && savedPayment.maskedCard) {
-        paymentMethod = savedPayment.cardName + ' / ' + savedPayment.maskedCard;
-      }
-    } catch (e) {}
 
     return {
       recipient_name: quickOrderRecipientSummary ? quickOrderRecipientSummary.textContent.trim() : '',

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -853,13 +853,16 @@
     var addressParts = splitAddressParts(orderSummaryPanel.dataset.deliveryAddress || '');
     var paymentMethod = (orderSummaryPanel.dataset.paymentMethod || '').trim();
 
-    if (addressPreview && (addressPreview.addressMain || addressPreview.addressDetail)) {
+    var hasServerAddress = addressParts.base && addressParts.base.indexOf('없습니다') === -1;
+    var hasServerPaymentMethod = paymentMethod && paymentMethod.indexOf('없습니다') === -1;
+
+    if (!hasServerAddress && addressPreview && (addressPreview.addressMain || addressPreview.addressDetail)) {
       addressParts.base = (addressPreview.addressMain || '').trim() || addressParts.base;
       addressParts.detail = (addressPreview.addressDetail || '').trim();
       orderSummaryPanel.dataset.deliveryAddress = [addressParts.base, addressParts.detail].filter(Boolean).join(' | ');
     }
 
-    if (paymentPreview && paymentPreview.cardName && paymentPreview.maskedCard) {
+    if (!hasServerPaymentMethod && paymentPreview && paymentPreview.cardName && paymentPreview.maskedCard) {
       paymentMethod = paymentPreview.cardName + ' / ' + paymentPreview.maskedCard;
       orderSummaryPanel.dataset.paymentMethod = paymentMethod;
     }


### PR DESCRIPTION
## 작업 내용
- 프로필에 저장된 주소/연락처/결제수단을 주문 및 빠른주문 화면에 반영
- 서버 저장값이 없을 때만 localStorage 미리보기 값을 fallback으로 사용
- 주문 API에서 결제수단 요청값이 없으면 프로필 저장값을 사용하도록 보완
- 관련 주문 테스트 추가

## 검증
- 로컬 브랜치에서 작업 분리 후 별도 커밋

Refs: #199