### PR TITLE
[fix] 소셜 재가입 온보딩 및 프로필 초기화 정리

### DIFF
--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from pets.models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 from users.models import User, UserProfile
+from users.onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY
 
 
 class ChatPageTests(TestCase):
@@ -52,6 +53,16 @@ class ChatPageTests(TestCase):
         )
         UserProfile.objects.create(user=incomplete_user, nickname="")
         self.client.force_login(incomplete_user)
+
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response["Location"], f"{reverse('profile')}?setup=1")
+
+    def test_chat_page_redirects_to_profile_setup_when_new_user_force_flag_exists(self):
+        session = self.client.session
+        session[ONBOARDING_FORCE_PROFILE_SESSION_KEY] = True
+        session.save()
 
         response = self.client.get(reverse("chat"))
 

--- a/services/django/config/settings.py
+++ b/services/django/config/settings.py
@@ -141,7 +141,7 @@ SOCIAL_AUTH_PIPELINE = (
     "users.social_pipeline.ensure_email",
     "social_core.pipeline.social_auth.auth_allowed",
     "social_core.pipeline.social_auth.social_user",
-    "social_core.pipeline.social_auth.associate_by_email",
+    "users.social_pipeline.associate_active_user_by_email",
     "social_core.pipeline.user.create_user",
     "social_core.pipeline.social_auth.associate_user",
     "social_core.pipeline.social_auth.load_extra_data",

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -250,9 +250,6 @@
 {% block scripts %}
 <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script>
-  var PROFILE_ADDRESS_STORAGE_KEY = 'tailtalk_profile_address_preview';
-  var PROFILE_PAYMENT_STORAGE_KEY = 'tailtalk_profile_payment_preview';
-
   window.closeWithdrawModal = function (e) {
     if (e && e.target !== document.getElementById('withdrawModal')) return;
     document.getElementById('withdrawModal').style.display = 'none';
@@ -287,16 +284,7 @@
       expiryInput.value = '';
 
       if (!isNewMode) {
-        try {
-          var saved = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-          if (saved) {
-            nameInput.value = saved.cardName || '';
-            numberInput.value = saved.maskedCard || '';
-            expiryInput.value = saved.expiry || '';
-          }
-        } catch (e) {}
-
-        if (!nameInput.value && existingPaymentMethod) {
+        if (existingPaymentMethod) {
           var parts = existingPaymentMethod.split(' / ');
           nameInput.value = parts[0] || '';
           numberInput.value = parts[1] || '';
@@ -370,13 +358,6 @@
     paymentCardProviderInput.value = cardName;
     paymentCardMaskedNumberInput.value = maskedCard;
     button.textContent = '수정';
-    try {
-      window.localStorage.setItem(PROFILE_PAYMENT_STORAGE_KEY, JSON.stringify({
-        cardName: cardName,
-        maskedCard: maskedCard,
-        expiry: expiry
-      }));
-    } catch (e) {}
     closePaymentModal();
   };
 
@@ -508,41 +489,6 @@
       });
     }
 
-    function loadAddressPreview() {
-      if (!zipcodeInput || !addressMainInput || !addressDetailInput) return;
-      try {
-        var saved = JSON.parse(window.localStorage.getItem(PROFILE_ADDRESS_STORAGE_KEY) || 'null');
-        if (!saved) return;
-        if (!zipcodeInput.value.trim()) zipcodeInput.value = saved.zipcode || '';
-        if (!addressMainInput.value.trim()) addressMainInput.value = saved.addressMain || '';
-        if (!addressDetailInput.value.trim()) addressDetailInput.value = saved.addressDetail || '';
-      } catch (e) {}
-    }
-
-    function saveAddressPreview() {
-      if (!zipcodeInput || !addressMainInput || !addressDetailInput) return;
-      try {
-        window.localStorage.setItem(PROFILE_ADDRESS_STORAGE_KEY, JSON.stringify({
-          zipcode: zipcodeInput.value.trim(),
-          addressMain: addressMainInput.value.trim(),
-          addressDetail: addressDetailInput.value.trim()
-        }));
-      } catch (e) {}
-    }
-
-    function loadPaymentPreview() {
-      if (!paymentSummary || !paymentMethodInput || !paymentButton) return;
-      if (paymentMethodInput.value.trim()) return;
-      try {
-        var saved = JSON.parse(window.localStorage.getItem(PROFILE_PAYMENT_STORAGE_KEY) || 'null');
-        if (!saved || !saved.cardName || !saved.maskedCard) return;
-        paymentMethodInput.value = saved.cardName + ' / ' + saved.maskedCard;
-        paymentSummary.textContent = paymentMethodInput.value;
-        paymentSummary.className = 'text-[13px] text-[#4a5568]';
-        paymentButton.textContent = '수정';
-      } catch (e) {}
-    }
-
     function sanitizeNickname() {
       var sanitized = input.value.replace(allowedNicknamePattern, '').slice(0, 12);
       if (input.value !== sanitized) {
@@ -610,8 +556,6 @@
     }
 
     sanitizeNickname();
-    loadAddressPreview();
-    loadPaymentPreview();
     updatePhoneVerificationUi();
 
     input.addEventListener('compositionstart', function () {
@@ -847,7 +791,6 @@
             }
 
             addressStatus.textContent = '';
-            saveAddressPreview();
             addressDetailInput.focus();
           }
         }).open();
@@ -865,12 +808,7 @@
         ) {
           addressStatus.textContent = '';
         }
-        saveAddressPreview();
       });
-    }
-
-    if (addressMainInput) {
-      addressMainInput.addEventListener('change', saveAddressPreview);
     }
 
     if (paymentCardNumberInput) {

--- a/services/django/users/onboarding.py
+++ b/services/django/users/onboarding.py
@@ -2,6 +2,8 @@ from django.urls import reverse
 
 from .models import UserProfile
 
+ONBOARDING_FORCE_PROFILE_SESSION_KEY = "tailtalk_onboarding_force_profile"
+
 
 def is_profile_complete(user):
     if not getattr(user, "is_authenticated", False):
@@ -29,6 +31,9 @@ def has_completed_pet_onboarding(request):
 def get_onboarding_redirect_url(request):
     if not getattr(request.user, "is_authenticated", False):
         return None
+
+    if request.session.get(ONBOARDING_FORCE_PROFILE_SESSION_KEY):
+        return f"{reverse('profile')}?setup=1"
 
     if not is_profile_complete(request.user):
         return f"{reverse('profile')}?setup=1"

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -11,7 +11,7 @@ from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthExcept
 
 from .models import UserProfile
 from .nickname_utils import build_unique_nickname, get_nickname_validation_error
-from .onboarding import get_onboarding_redirect_url
+from .onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY, get_onboarding_redirect_url
 from .quick_purchase import build_payment_info, split_legacy_address
 from .social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
@@ -187,6 +187,7 @@ def profile_view(request):
             return _render_profile(request, profile)
         messages.success(request, "프로필 정보가 저장되었습니다.")
         if setup_mode:
+            request.session.pop(ONBOARDING_FORCE_PROFILE_SESSION_KEY, None)
             return redirect("pet_add")
         return redirect("chat")
 
@@ -259,6 +260,7 @@ def social_login_callback_view(request, provider):
     request.session.pop(SOCIAL_AUTH_REMEMBER_SESSION_KEY, None)
     messages.success(request, "소셜 로그인이 완료되었습니다.")
     if result.is_new_user:
+        request.session[ONBOARDING_FORCE_PROFILE_SESSION_KEY] = True
         return redirect(f"{reverse('profile')}?setup=1")
     onboarding_redirect_url = get_onboarding_redirect_url(request)
     if onboarding_redirect_url:

--- a/services/django/users/social_pipeline.py
+++ b/services/django/users/social_pipeline.py
@@ -1,5 +1,9 @@
+from django.contrib.auth import get_user_model
+
 from .models import SocialAccount, UserProfile
 from .nickname_utils import build_unique_nickname
+
+User = get_user_model()
 
 
 PROVIDER_NAME_MAP = {
@@ -23,6 +27,21 @@ def ensure_email(details, backend, response, uid=None, *args, **kwargs):
     normalized_details = details.copy()
     normalized_details["email"] = fallback_email
     return {"details": normalized_details}
+
+
+def associate_active_user_by_email(details, user=None, *args, **kwargs):
+    if user is not None:
+        return None
+
+    email = (details or {}).get("email")
+    if not email:
+        return None
+
+    matched_user = User.objects.filter(email__iexact=email, is_active=True).first()
+    if matched_user is None:
+        return None
+
+    return {"user": matched_user, "is_new": False}
 
 
 def sync_tailtalk_social_data(backend, user=None, uid=None, response=None, *args, **kwargs):

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -5,15 +5,18 @@ from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
+from social_django.models import UserSocialAuth
 
 from orders.models import Order
 from products.models import Product
 from users.models import SocialAccount, User, UserProfile
+from users.onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY
 from users.social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
     SOCIAL_AUTH_REFRESH_SESSION_KEY,
     SocialLoginResult,
 )
+from users.social_pipeline import associate_active_user_by_email
 
 
 TEST_SOCIAL_PROVIDERS = {
@@ -75,6 +78,16 @@ class SocialLoginPageViewTests(TestCase):
         session = self.client.session
         self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)
         self.assertIn(SOCIAL_AUTH_REFRESH_SESSION_KEY, session)
+        self.assertTrue(session[ONBOARDING_FORCE_PROFILE_SESSION_KEY])
+
+    def test_associate_active_user_by_email_ignores_inactive_user(self):
+        withdrawn_user = User.objects.create_user(email="social@example.com")
+        withdrawn_user.is_active = False
+        withdrawn_user.save(update_fields=["is_active"])
+
+        result = associate_active_user_by_email({"email": "social@example.com"})
+
+        self.assertIsNone(result)
 
 
 @override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)
@@ -113,6 +126,8 @@ class AuthApiTests(TestCase):
         self.assertEqual(refresh_response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_withdraw_deactivates_user_and_scrubs_identity(self):
+        UserSocialAuth.objects.create(user=self.user, provider="kakao", uid="oauth-uid-1")
+
         login_response = self.client.post(
             "/api/auth/login/",
             {"email": "auth@example.com", "password": "Password123!"},
@@ -130,6 +145,7 @@ class AuthApiTests(TestCase):
         self.assertNotEqual(self.user.email, "auth@example.com")
         self.assertFalse(self.user.has_usable_password())
         self.assertFalse(UserProfile.objects.filter(user=self.user).exists())
+        self.assertFalse(UserSocialAuth.objects.filter(user=self.user).exists())
 
     def test_withdraw_preserves_orders(self):
         Order.objects.create(

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -18,6 +18,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
 from rest_framework_simplejwt.tokens import RefreshToken
+from social_django.models import UserSocialAuth
 from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthException, AuthForbidden, AuthMissingParameter
 
 from products.models import Product
@@ -54,6 +55,7 @@ def deactivate_user_and_purge_personal_data(user):
         user.pets.all().delete()
     if hasattr(user, "social_accounts"):
         user.social_accounts.all().delete()
+    UserSocialAuth.objects.filter(user=user).delete()
     if hasattr(user, "used_products"):
         user.used_products.all().delete()
     if hasattr(user, "userinteraction_set"):


### PR DESCRIPTION
## 작업 내용
- 탈퇴 후 같은 소셜 계정 재로그인 시 비활성 사용자에 다시 연결되지 않도록 소셜 파이프라인 정리
- 신규 소셜 로그인 시 프로필 설정을 먼저 타도록 온보딩 세션 가드 추가
- 탈퇴 후 프로필 화면에서 주소/결제수단이 localStorage로 다시 보이던 문제 제거
- 탈퇴 시 social_django 연결 정보까지 같이 삭제하도록 정리

## 검증
- python manage.py test users.tests.AuthApiTests users.tests.SocialLoginPageViewTests chat.tests.ChatPageTests --keepdb
- python manage.py check