### PR TITLE
[feat] 반려동물 정보와 관심 상품 메뉴 정리 (#219)

### DIFF
--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -39,6 +39,21 @@ class ChatPageTests(TestCase):
         self.assertEqual(serialized_pet["allergies"], ["chicken"])
         self.assertEqual(serialized_pet["food_preferences"], ["dry"])
 
+    def test_chat_page_profile_menu_includes_wishlist_link(self):
+        Pet.objects.create(
+            user=self.user,
+            name="Bori",
+            species="dog",
+            gender="male",
+            budget_range="5_10",
+        )
+
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "/products/?tab=wishlist")
+        self.assertContains(response, "관심 상품")
+
     def test_chat_page_redirects_to_pet_add_when_profile_complete_but_no_pet(self):
         response = self.client.get(reverse("chat"))
 

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -594,6 +594,7 @@ def used_products(request):
     base_address = address_parts[0] if address_parts else "배송지 정보가 아직 등록되지 않았어요"
     detail_address = address_parts[1] if len(address_parts) > 1 else ""
     phone = getattr(profile, "phone", "") or "연락처 정보가 아직 없습니다."
+    postal_code = getattr(profile, "postal_code", "") or ""
     payment_method = getattr(profile, "payment_method", "") or "결제 수단 정보가 아직 없습니다."
     for item in items:
         item["price_label"] = _format_price(item["price"])
@@ -621,6 +622,7 @@ def used_products(request):
             "delivery_base_address": base_address,
             "delivery_detail_address": detail_address,
             "recipient_phone": phone,
+            "delivery_postal_code": postal_code,
             "delivery_message": "",
             "payment_method": payment_method,
             "coupon_summary": "적용된 쿠폰 없음",

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -601,6 +601,10 @@ def used_products(request):
     for item in wishlist_items:
         item["price_label"] = _format_price(item["price"])
 
+    active_tab = (request.GET.get("tab") or "cart").strip().lower()
+    if active_tab not in {"cart", "wishlist"}:
+        active_tab = "cart"
+
     return render(
         request,
         "orders/products.html",
@@ -623,7 +627,7 @@ def used_products(request):
             "mileage_summary": "사용 가능 3,200원",
             "discount_total_raw": discount,
             "shipping_fee_raw": shipping_fee,
-            "active_tab": "cart",
+            "active_tab": active_tab,
         },
     )
 

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -277,7 +277,34 @@ class OrderCreateApiTests(TestCase):
         self.assertEqual(response.data["detail"], "recipient_name is required.")
         self.assertEqual(response.data["code"], "missing_required_fields")
         self.assertEqual(response.data["field"], "recipient_name")
-        self.assertEqual(response.data["missing_fields"], ["recipient_name", "recipient_phone", "delivery_address"])
+        self.assertEqual(
+            response.data["missing_fields"],
+            ["recipient_name", "recipient_phone", "postal_code", "delivery_address_main", "delivery_address_detail"],
+        )
+
+    def test_post_order_requires_structured_delivery_info_even_if_legacy_address_exists(self):
+        self.add_cart_items()
+        self.user.profile.postal_code = ""
+        self.user.profile.address_main = ""
+        self.user.profile.address_detail = ""
+        self.user.profile.address = "서울 강동구 올림픽로 123 | 101동 1203호"
+        self.user.profile.save(update_fields=["postal_code", "address_main", "address_detail", "address", "updated_at"])
+
+        response = self.client.post(
+            "/api/orders/",
+            {
+                "payment_method": "우리카드 1234 / 일시불",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "missing_required_fields")
+        self.assertEqual(response.data["field"], "postal_code")
+        self.assertEqual(
+            response.data["missing_fields"],
+            ["postal_code", "delivery_address_main", "delivery_address_detail"],
+        )
 
     def test_post_order_rejects_invalid_payment_method_with_available_options(self):
         self.add_cart_items()

--- a/services/django/orders/views.py
+++ b/services/django/orders/views.py
@@ -342,6 +342,17 @@ def normalize_delivery_address(data, user):
     return get_profile_value(user, "address").strip()
 
 
+def get_delivery_defaults(user):
+    quick_purchase = serialize_quick_purchase_profile(user)
+    return {
+        "recipient_name": quick_purchase["recipient_name"].strip(),
+        "recipient_phone": quick_purchase["recipient_phone"].strip(),
+        "postal_code": quick_purchase["postal_code"].strip(),
+        "address_main": quick_purchase["address_main"].strip(),
+        "address_detail": quick_purchase["address_detail"].strip(),
+    }
+
+
 def parse_positive_int(value, field_name):
     try:
         parsed = int(value or 0)
@@ -378,9 +389,20 @@ def get_coupon_or_400(coupon_id):
 
 
 def validate_checkout_payload(data, user, cart_items):
-    recipient_name = (data.get("recipient_name") or get_profile_value(user, "recipient_name") or get_profile_value(user, "nickname")).strip()
-    recipient_phone = (data.get("recipient_phone") or get_profile_value(user, "phone")).strip()
-    delivery_address = normalize_delivery_address(data, user)
+    delivery_defaults = get_delivery_defaults(user)
+    recipient_name = (data.get("recipient_name") or delivery_defaults["recipient_name"] or get_profile_value(user, "nickname")).strip()
+    recipient_phone = (data.get("recipient_phone") or delivery_defaults["recipient_phone"]).strip()
+    postal_code = (data.get("postal_code") or delivery_defaults["postal_code"]).strip()
+    address_main = (data.get("delivery_address_main") or delivery_defaults["address_main"]).strip()
+    address_detail = (data.get("delivery_address_detail") or delivery_defaults["address_detail"]).strip()
+    delivery_address = normalize_delivery_address(
+        {
+            **data,
+            "delivery_address_main": address_main,
+            "delivery_address_detail": address_detail,
+        },
+        user,
+    )
     delivery_message = (data.get("delivery_message") or "").strip()
     payment_method = (data.get("payment_method") or get_profile_value(user, "payment_method")).strip()
     missing_fields = []
@@ -389,8 +411,12 @@ def validate_checkout_payload(data, user, cart_items):
         missing_fields.append("recipient_name")
     if not recipient_phone:
         missing_fields.append("recipient_phone")
-    if not delivery_address:
-        missing_fields.append("delivery_address")
+    if not postal_code:
+        missing_fields.append("postal_code")
+    if not address_main:
+        missing_fields.append("delivery_address_main")
+    if not address_detail:
+        missing_fields.append("delivery_address_detail")
     if not payment_method:
         missing_fields.append("payment_method")
 

--- a/services/django/pets/models.py
+++ b/services/django/pets/models.py
@@ -54,8 +54,13 @@ class PetAllergy(models.Model):
 
 class PetFoodPreference(models.Model):
     FOOD_TYPE_CHOICES = [
-        ("dry", "건식"), ("wet_can", "습식캔"), ("wet_pouch", "습식파우치"),
-        ("freeze_dried", "동결건조"), ("raw", "생식"),
+        ("dry", "건식"),
+        ("wet_can", "습식"),
+        ("wet_pouch", "습식파우치"),
+        ("freeze_dried", "동결건조/에어드라이"),
+        ("raw", "혼합/자연식"),
+        ("soft", "소프트"),
+        ("cooked", "화식"),
     ]
     id        = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     pet       = models.ForeignKey(Pet, on_delete=models.CASCADE, related_name="food_preferences")

--- a/services/django/pets/page_views.py
+++ b/services/django/pets/page_views.py
@@ -12,10 +12,18 @@ SPECIES_OPTIONS = [
 ]
 AGE_YEAR_OPTIONS = list(range(0, 31))
 AGE_MONTH_OPTIONS = list(range(0, 12))
-FOOD_OPTIONS = [
+DOG_FOOD_OPTIONS = [
     ("dry", "건식"),
+    ("cooked", "화식"),
+    ("soft", "소프트"),
     ("wet_can", "습식"),
-    ("raw", "혼합/자연식"),
+    ("freeze_dried", "동결건조/에어드라이"),
+]
+CAT_FOOD_OPTIONS = [
+    ("dry", "건식"),
+    ("wet_can", "주식캔"),
+    ("wet_pouch", "주식파우치"),
+    ("freeze_dried", "에어/동결건조"),
 ]
 FUTURE_HOUSING_OPTIONS = [
     ("studio", "원룸"),
@@ -42,6 +50,18 @@ BUDGET_OPTIONS = [
     ("10_20", "10만 원 ~ 20만 원 미만"),
     ("over_20", "20만 원 이상"),
 ]
+
+
+def _food_options_for_species(species):
+    if species == "dog":
+        return DOG_FOOD_OPTIONS
+    return CAT_FOOD_OPTIONS
+
+
+def _food_preference_labels(food_values, species):
+    label_map = dict(_food_options_for_species(species))
+    fallback_label_map = dict(PetFoodPreference.FOOD_TYPE_CHOICES)
+    return [label_map.get(value, fallback_label_map.get(value, value)) for value in food_values]
 
 
 @dataclass
@@ -162,7 +182,7 @@ def _step3_context(pet, species, step2_data=None, step3_data=None):
         "species": species,
         "step2_data": step2_data,
         "step3_data": step3_data,
-        "food_options": FOOD_OPTIONS,
+        "food_options": _food_options_for_species(species),
         "health_options": PetHealthConcern.CONCERN_CHOICES,
         "budget_options": BUDGET_OPTIONS,
     }
@@ -257,9 +277,14 @@ def pet_list(request):
         pets = _preview_pets()
         actual_pet_count = len(pets)
     elif getattr(request.user, "is_authenticated", False):
-        pets = list(Pet.objects.filter(user=request.user))
+        pets = list(Pet.objects.filter(user=request.user).prefetch_related("food_preferences"))
         actual_pet_count = len(pets)
         future_pet = _future_pet_list_item(request.session.get("future_pet_profile"))
+        for pet in pets:
+            pet.food_preference_labels = _food_preference_labels(
+                list(pet.food_preferences.values_list("food_type", flat=True)),
+                pet.species,
+            )
         if future_pet:
             pets.append(future_pet)
         pets = _sort_pet_list_items(pets)
@@ -323,9 +348,21 @@ def pet_add_details(request):
 
     pet_seed = {
         "species": species,
-        "gender": "male",
-        "age_years": 0,
-        "age_months": 0,
+        "name": request.GET.get("name", "").strip(),
+        "breed": request.GET.get("breed", "").strip(),
+        "gender": request.GET.get("gender", "male"),
+        "age_years": int(request.GET.get("age_years", 0) or 0),
+        "age_months": int(request.GET.get("age_months", 0) or 0),
+        "weight_kg": request.GET.get("weight_kg", "").strip(),
+        "neutered": True if request.GET.get("neutered") == "yes" else False if request.GET.get("neutered") == "no" else None,
+    }
+    step3_data = {
+        "vaccination_date": request.GET.get("vaccination_date", "").strip(),
+        "health_concerns": request.GET.getlist("health_concerns"),
+        "allergies": request.GET.get("allergies", "").strip(),
+        "food_preferences": request.GET.getlist("food_preferences"),
+        "budget_range": request.GET.get("budget_range", "").strip(),
+        "special_notes": request.GET.get("special_notes", "").strip(),
     }
     return render(
         request,
@@ -335,6 +372,7 @@ def pet_add_details(request):
             "species": species,
             "age_year_options": AGE_YEAR_OPTIONS,
             "age_month_options": AGE_MONTH_OPTIONS,
+            "step3_data": step3_data,
         },
     )
 
@@ -385,7 +423,7 @@ def pet_add_health(request):
             PetAllergy.objects.get_or_create(pet=pet, ingredient=ingredient)
 
         for food_type in request.POST.getlist("food_preferences"):
-            if food_type in dict(FOOD_OPTIONS):
+            if food_type in dict(_food_options_for_species(species)):
                 PetFoodPreference.objects.get_or_create(pet=pet, food_type=food_type)
 
         return redirect("chat")

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -2,6 +2,7 @@ from datetime import date, timedelta
 from decimal import Decimal
 
 from django.test import TestCase
+from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -228,3 +229,28 @@ class PetApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_302_FOUND)
         self.assertEqual(response["Location"], "/pets/")
         self.assertFalse(Pet.objects.filter(pet_id=pet.pet_id).exists())
+
+
+class PetPageTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(email="pet-page@example.com", password="Password123!")
+        UserProfile.objects.create(user=self.user, nickname="Pet Page")
+        self.client.force_login(self.user)
+
+    def test_pet_list_renders_food_preference_labels(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="콩이",
+            species="dog",
+            gender="male",
+            budget_range="5_10",
+        )
+        PetFoodPreference.objects.create(pet=pet, food_type="dry")
+        PetFoodPreference.objects.create(pet=pet, food_type="freeze_dried")
+
+        response = self.client.get(reverse("pet_list"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "선호 사료")
+        self.assertContains(response, "건식")
+        self.assertContains(response, "동결건조/에어드라이")

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1208,6 +1208,8 @@
             <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
             <a href="{% if is_preview_member %}/pets/?preview=filled{% else %}/pets/{% endif %}" class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
             <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+            <a href="{% if is_preview_member %}#{% else %}/products/?tab=wishlist{% endif %}" class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]" {% if is_preview_member %}onclick="return false"{% endif %}>관심 상품</a>
+            <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
             <a href="{% if is_preview_member %}#{% else %}/orders/{% endif %}" class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]" {% if is_preview_member %}onclick="return false"{% endif %}>주문 내역</a>
             <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
             <a href="{% if is_preview_member %}#{% else %}/logout/{% endif %}" class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]" {% if is_preview_member %}onclick="return false"{% endif %}>로그아웃</a>

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -468,6 +468,9 @@
       <aside id="orderSummaryPanel"
              data-recipient-name="{{ recipient_name }}"
              data-recipient-phone="{{ recipient_phone }}"
+             data-postal-code="{{ delivery_postal_code|default:'' }}"
+             data-delivery-address-main="{{ delivery_base_address }}"
+             data-delivery-address-detail="{{ delivery_detail_address }}"
              data-delivery-address="{{ delivery_base_address }} | {{ delivery_detail_address }}"
              data-payment-method="{{ payment_method }}"
              class="{% if item_count == 0 %}hidden{% else %}flex{% endif %} min-h-[720px] flex-col rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
@@ -902,6 +905,9 @@
       body: JSON.stringify({
         recipient_name: orderSummaryPanel.dataset.recipientName || '',
         recipient_phone: orderSummaryPanel.dataset.recipientPhone || '',
+        postal_code: orderSummaryPanel.dataset.postalCode || '',
+        delivery_address_main: orderSummaryPanel.dataset.deliveryAddressMain || '',
+        delivery_address_detail: orderSummaryPanel.dataset.deliveryAddressDetail || '',
         delivery_address: orderSummaryPanel.dataset.deliveryAddress || '',
         delivery_message: getDeliveryMessageValue(),
         payment_method: orderSummaryPanel.dataset.paymentMethod || '',

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -266,18 +266,18 @@
 
     <div class="product-tabs-row mt-8 flex items-center justify-start">
       <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
-        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white transition-colors">
+        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold transition-colors {% if active_tab == 'wishlist' %}text-[#718096] hover:text-[#2d3748]{% else %}bg-[#2d3748] text-white{% endif %}">
           <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
             <span class="inline-flex h-[18px] items-center leading-none">장바구니</span>
-            <span id="productsTabCartCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full bg-white/18 px-1.5 text-[11px] font-bold leading-none text-white {% if item_count == 0 %}hidden{% endif %}">
+            <span id="productsTabCartCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full px-1.5 text-[11px] font-bold leading-none {% if active_tab == 'wishlist' %}bg-[#edf2f7] text-[#4a5568]{% else %}bg-white/18 text-white{% endif %} {% if item_count == 0 %}hidden{% endif %}">
               <span class="inline-flex h-[18px] items-center">{{ item_count }}</span>
             </span>
           </span>
         </button>
-        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">
+        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold transition-colors {% if active_tab == 'wishlist' %}bg-[#2d3748] text-white{% else %}text-[#718096] hover:text-[#2d3748]{% endif %}">
           <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
             <span class="inline-flex h-[18px] items-center leading-none">관심 상품</span>
-            <span id="productsTabWishlistCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full bg-[#edf2f7] px-1.5 text-[11px] font-bold leading-none text-[#4a5568] {% if wishlist_count == 0 %}hidden{% endif %}">
+            <span id="productsTabWishlistCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full px-1.5 text-[11px] font-bold leading-none {% if active_tab == 'wishlist' %}bg-white/18 text-white{% else %}bg-[#edf2f7] text-[#4a5568]{% endif %} {% if wishlist_count == 0 %}hidden{% endif %}">
               <span class="inline-flex h-[18px] items-center">{{ wishlist_count }}</span>
             </span>
           </span>
@@ -287,7 +287,7 @@
 
     <div id="productsLayoutGrid" class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_470px]">
       <section id="productsMainSection" class="min-h-[720px]">
-        <div id="productsPanelCart" class="product-tab-panel is-active min-h-[720px]">
+        <div id="productsPanelCart" class="product-tab-panel {% if active_tab != 'wishlist' %}is-active{% endif %} min-h-[720px]">
         <div id="cartEmptyState" class="product-empty-state-compact {% if item_count != 0 %}hidden{% endif %} max-w-[650px] rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
           <div class="product-empty-icon text-[28px] text-[#7aa6e9]">🛒</div>
           <p class="product-empty-title mt-[10px] text-[18px] font-bold text-[#2d3748]">장바구니가 비어 있어요</p>
@@ -365,7 +365,7 @@
         </div>
         </div>
 
-        <div id="productsPanelWishlist" class="product-tab-panel min-h-[720px]">
+        <div id="productsPanelWishlist" class="product-tab-panel {% if active_tab == 'wishlist' %}is-active{% endif %} min-h-[720px]">
         <div id="wishlistEmptyState" class="product-empty-state-compact hidden max-w-[650px] rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
           <div class="product-empty-icon text-[28px] text-[#e97b7b]">♡</div>
           <p class="product-empty-title mt-[10px] text-[18px] font-bold text-[#2d3748]">관심 상품이 아직 없어요</p>
@@ -1384,6 +1384,17 @@
     scheduleViewportSync();
   }
 
+  function applyInitialProductsTab() {
+    try {
+      var params = new URLSearchParams(window.location.search || '');
+      if (params.get('tab') === 'wishlist') {
+        setActiveTab('wishlist');
+        return;
+      }
+    } catch (error) {}
+    setActiveTab('cart');
+  }
+
   function renderWishlistFromState(items) {
     if (!wishlistListViewport) return;
     wishlistListViewport.innerHTML = '';
@@ -1671,6 +1682,7 @@
   syncDeliveryMessageField();
   syncCheckoutSummaryPreview();
   syncCheckoutNotice();
+  applyInitialProductsTab();
   refreshProductsData();
   window.addEventListener('resize', scheduleViewportSync);
 })();

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -28,6 +28,16 @@
       <form method="post" class="contents" novalidate action="{% if is_preview_edit %}/pets/preview/{{ pet.pet_id }}/edit/{% elif is_edit %}/pets/{{ pet.pet_id }}/edit/{% else %}/pets/add/health/{% endif %}">
         {% csrf_token %}
         <input type="hidden" name="species" value="{{ species }}" />
+        <input type="hidden" name="vaccination_date" value="{{ step3_data.vaccination_date|default:'' }}" />
+        <input type="hidden" name="allergies" value="{{ step3_data.allergies|default:'' }}" />
+        <input type="hidden" name="budget_range" value="{{ step3_data.budget_range|default:'' }}" />
+        <input type="hidden" name="special_notes" value="{{ step3_data.special_notes|default:'' }}" />
+        {% for concern in step3_data.health_concerns %}
+        <input type="hidden" name="health_concerns" value="{{ concern }}" />
+        {% endfor %}
+        {% for food in step3_data.food_preferences %}
+        <input type="hidden" name="food_preferences" value="{{ food }}" />
+        {% endfor %}
 
         <div class="mt-[30px] grid gap-x-[28px] gap-y-[24px] {% if is_edit %}grid-cols-2{% else %}grid-cols-1 sm:grid-cols-2{% endif %} {% if is_edit %}gap-y-[28px]{% else %}sm:gap-y-[28px]{% endif %}">
           <div class="space-y-[12px]">

--- a/services/django/templates/pets/add_step3.html
+++ b/services/django/templates/pets/add_step3.html
@@ -60,9 +60,16 @@
             </div>
             <div class="flex flex-wrap gap-[8px]">
               {% for value, label in food_options %}
-              <label class="food-option flex h-[42px] flex-1 cursor-pointer items-center justify-center rounded-[8px] border text-[14px] {% if value in step3_data.food_preferences %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
+              <label class="food-option flex min-h-[42px] flex-1 cursor-pointer items-center justify-center rounded-[8px] border px-2 py-2 text-[14px] {% if value in step3_data.food_preferences %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
                 <input type="checkbox" class="hidden food-checkbox" name="food_preferences" value="{{ value }}" {% if value in step3_data.food_preferences %}checked{% endif %} />
+                {% if species == "dog" and value == "freeze_dried" %}
+                <span class="block text-center leading-[1.1] whitespace-normal">
+                  <span class="block">동결건조/</span>
+                  <span class="block">에어드라이</span>
+                </span>
+                {% else %}
                 {{ label }}
+                {% endif %}
               </label>
               {% endfor %}
             </div>
@@ -126,7 +133,11 @@
         </div>
 
         <div class="mt-[28px] flex flex-col-reverse gap-[10px] md:flex-row md:items-end md:gap-[14px]">
-          <a href="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/{% elif is_edit %}/pets/{{ pet_id }}/edit/{% else %}/pets/add/health/?species={{ step2_data.species|urlencode }}&name={{ step2_data.name|urlencode }}&breed={{ step2_data.breed|urlencode }}&gender={{ step2_data.gender|urlencode }}&age_years={{ step2_data.age_years|urlencode }}&age_months={{ step2_data.age_months|urlencode }}&weight_kg={{ step2_data.weight_kg|urlencode }}&neutered={{ step2_data.neutered|urlencode }}{% endif %}" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] md:w-[128px]">이전으로</a>
+          <a
+            href="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/{% elif is_edit %}/pets/{{ pet_id }}/edit/{% else %}/pets/add/details/{% endif %}"
+            id="step3BackLink"
+            class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] md:w-[128px]"
+          >이전으로</a>
           <button type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white">{% if is_edit %}수정 완료{% else %}등록 완료{% endif %}</button>
         </div>
       </form>
@@ -159,6 +170,7 @@
     var allergyInput = document.getElementById('allergyTextInput');
     var allergiesHidden = document.getElementById('allergiesInput');
     var tagsContainer = document.getElementById('allergyTags');
+    var backLink = document.getElementById('step3BackLink');
     var tags = allergiesHidden.value ? allergiesHidden.value.split(',').map(function (item) { return item.trim(); }).filter(Boolean) : [];
     var vaccinationDateInput = document.getElementById('vaccinationDateInput');
     var vaccinationDatePicker = document.getElementById('vaccinationDatePicker');
@@ -347,6 +359,40 @@
           event.preventDefault();
           showStatus(vaccinationDateStatus, '날짜는 2000-01-01부터 오늘까지만 입력할 수 있어요');
         }
+      });
+    }
+
+    if (backLink) {
+      backLink.addEventListener('click', function (event) {
+        {% if not is_edit and not is_preview_edit %}
+        event.preventDefault();
+        var params = new URLSearchParams();
+        params.set('type', '{{ step2_data.species|escapejs }}');
+        params.set('name', '{{ step2_data.name|escapejs }}');
+        params.set('breed', '{{ step2_data.breed|escapejs }}');
+        params.set('gender', '{{ step2_data.gender|escapejs }}');
+        params.set('age_years', '{{ step2_data.age_years|escapejs }}');
+        params.set('age_months', '{{ step2_data.age_months|escapejs }}');
+        params.set('weight_kg', '{{ step2_data.weight_kg|escapejs }}');
+        params.set('neutered', '{{ step2_data.neutered|escapejs }}');
+        params.set('vaccination_date', vaccinationDateInput ? vaccinationDateInput.value : '');
+        params.set('allergies', allergiesHidden ? allergiesHidden.value : '');
+
+        var budgetSelect = document.querySelector('select[name="budget_range"]');
+        params.set('budget_range', budgetSelect ? budgetSelect.value : '');
+
+        var specialNotesInput = document.querySelector('input[name="special_notes"], textarea[name="special_notes"]');
+        params.set('special_notes', specialNotesInput ? specialNotesInput.value : '');
+
+        document.querySelectorAll('.health-checkbox:checked').forEach(function (input) {
+          params.append('health_concerns', input.value);
+        });
+        document.querySelectorAll('.food-checkbox:checked').forEach(function (input) {
+          params.append('food_preferences', input.value);
+        });
+
+        window.location.href = backLink.getAttribute('href') + '?' + params.toString();
+        {% endif %}
       });
     }
 

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -87,6 +87,14 @@
             {% if pet.breed %} · {{ pet.breed }}{% endif %}
             {% endif %}
           </div>
+          {% if pet.species != "future" and pet.food_preference_labels %}
+          <div class="mt-2 flex flex-wrap gap-2">
+            <span class="inline-flex h-[24px] items-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-bold text-[#4a5568]">선호 사료</span>
+            {% for label in pet.food_preference_labels %}
+            <span class="inline-flex h-[24px] items-center rounded-full border border-[#dbe7f5] bg-[#f7fbff] px-3 text-[12px] font-medium text-[#3182ce]">{{ label }}</span>
+            {% endfor %}
+          </div>
+          {% endif %}
         </div>
         <div class="flex items-center gap-3">
           {% if pet.species == "future" %}


### PR DESCRIPTION
## 작업 내용
- 반려동물 정보 카드에 선호 사료 라벨과 선택값을 표시
- 강아지/고양이 선호 사료 옵션을 종별로 정리
- 반려동물 등록 STEP 2, STEP 3 왕복 시 입력값 유지 흐름 수정
- 헤더 프로필 드롭다운에 관심 상품 메뉴 추가
- 관심 상품 메뉴 진입 시 처음부터 관심 상품 탭으로 렌더되도록 수정

## 테스트
- python manage.py test chat.tests pets.tests --keepdb
- python manage.py check

closes #219