### PR TITLE
fix(ci): restore django static serving and latest smoke checks

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -104,6 +104,75 @@ jobs:
       - name: Run Django tests
         run: docker compose -f infra/docker-compose.yml run --rm django python manage.py test
 
+      - name: Smoke test deploy bundle runtime
+        run: |
+          rm -rf .deploy-django
+          mkdir -p .deploy-django
+          python3 - <<'PY'
+          from pathlib import Path
+          src = Path("deploy/eb/test-django/docker-compose.yml").read_text()
+          Path(".deploy-django/docker-compose.yml").write_text(
+              src.replace("__DJANGO_IMAGE__", "tailtalk-django:latest")
+          )
+          PY
+          cp -r deploy/eb/test-django/nginx .deploy-django/nginx
+          cat <<'EOF' > .deploy-django/docker-compose.smoke.yml
+          services:
+            django:
+              depends_on:
+                postgres:
+                  condition: service_healthy
+            postgres:
+              image: pgvector/pgvector:pg16
+              platform: linux/amd64
+              environment:
+                POSTGRES_DB: ${POSTGRES_DB}
+                POSTGRES_USER: ${POSTGRES_USER}
+                POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+              expose:
+                - "5432"
+              healthcheck:
+                test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+                interval: 5s
+                timeout: 5s
+                retries: 10
+          EOF
+          cat <<'EOF' > .deploy-django/.env
+          DJANGO_SECRET_KEY=test-secret
+          DJANGO_DEBUG=False
+          DJANGO_ALLOWED_HOSTS=localhost,127.0.0.1
+          APP_BASE_URL=http://localhost
+          FASTAPI_INTERNAL_CHAT_URL=http://fastapi.example.com/api/chat/
+          INTERNAL_SERVICE_TOKEN=dev-internal-token
+          POSTGRES_DB=test_db
+          POSTGRES_USER=test_user
+          POSTGRES_PASSWORD=test_password
+          POSTGRES_HOST=postgres
+          POSTGRES_PORT=5432
+          CORS_ALLOWED_ORIGINS=
+          EOF
+          cleanup() {
+            docker compose \
+              -f .deploy-django/docker-compose.yml \
+              -f .deploy-django/docker-compose.smoke.yml \
+              --env-file .deploy-django/.env \
+              down -v --remove-orphans || true
+          }
+          trap cleanup EXIT
+          docker compose \
+            -f .deploy-django/docker-compose.yml \
+            -f .deploy-django/docker-compose.smoke.yml \
+            --env-file .deploy-django/.env \
+            up -d
+          for _ in $(seq 1 20); do
+            if curl --fail --silent http://127.0.0.1/health/ > /dev/null; then
+              break
+            fi
+            sleep 3
+          done
+          curl --fail --silent --show-error http://127.0.0.1/health/ > /dev/null
+          curl --fail --silent --show-error http://127.0.0.1/static/admin/css/base.css > /dev/null
+
       - name: Teardown
         if: always()
         run: docker compose -f infra/docker-compose.yml down -v --remove-orphans

--- a/deploy/eb/test-django/docker-compose.yml
+++ b/deploy/eb/test-django/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "80:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - django_static:/var/www/static:ro
     depends_on:
       - django
     restart: unless-stopped
@@ -17,6 +18,8 @@ services:
       sh -c "python manage.py migrate --noinput &&
              python manage.py collectstatic --noinput &&
              gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
+    volumes:
+      - django_static:/app/staticfiles
     environment:
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
@@ -43,3 +46,6 @@ services:
     expose:
       - "8000"
     restart: unless-stopped
+
+volumes:
+  django_static:

--- a/deploy/eb/test-django/nginx/nginx.conf
+++ b/deploy/eb/test-django/nginx/nginx.conf
@@ -7,6 +7,14 @@ http {
         listen 80;
         server_name _;
 
+        location /static/ {
+            alias /var/www/static/;
+            access_log off;
+            expires 1h;
+            add_header Cache-Control "public, max-age=3600";
+            try_files $uri =404;
+        }
+
         location /health/ {
             proxy_pass http://django;
             proxy_set_header Host $host;

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "80:80"
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+      - django_static:/var/www/static:ro
     depends_on:
       - django
       - fastapi
@@ -21,8 +22,11 @@ services:
     build: ../services/django
     platform: linux/amd64
     command: >
-      sh -c "python manage.py migrate &&
+      sh -c "python manage.py migrate --noinput &&
+             python manage.py collectstatic --noinput &&
              gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
+    volumes:
+      - django_static:/app/staticfiles
     environment:
       DJANGO_SECRET_KEY: ${DJANGO_SECRET_KEY}
       DJANGO_DEBUG: ${DJANGO_DEBUG:-False}
@@ -107,3 +111,4 @@ services:
 
 volumes:
   postgres_data:
+  django_static:

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -11,6 +11,14 @@ http {
         listen 80;
         server_name _;
 
+        location /static/ {
+            alias /var/www/static/;
+            access_log off;
+            expires 1h;
+            add_header Cache-Control "public, max-age=3600";
+            try_files $uri =404;
+        }
+
         # FastAPI — 챗봇 / 추천
         location /api/chat/ {
             proxy_pass http://django;

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -411,6 +411,32 @@ class OrderCreateApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["code"], "quick_purchase_requirements_missing")
 
+    def test_post_quick_purchase_rejects_legacy_address_without_structured_fields(self):
+        self.add_cart_items()
+        self.user.profile.address_main = ""
+        self.user.profile.address_detail = ""
+        self.user.profile.address = "서울 강동구 올림픽로 123 | 101동 1203호"
+        self.user.profile.payment_method = "현대카드 M / 1234 **** **** 3456"
+        self.user.profile.payment_card_provider = "현대카드 M"
+        self.user.profile.payment_card_masked_number = "1234 **** **** 3456"
+        self.user.profile.save(
+            update_fields=[
+                "address_main",
+                "address_detail",
+                "address",
+                "payment_method",
+                "payment_card_provider",
+                "payment_card_masked_number",
+                "updated_at",
+            ]
+        )
+
+        response = self.client.post("/api/orders/quick-purchase/", {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "quick_purchase_requirements_missing")
+        self.assertEqual(response.data["missing_fields"], ["delivery_info"])
+
 
 class OrderReadApiTests(TestCase):
     def setUp(self):

--- a/services/django/users/quick_purchase.py
+++ b/services/django/users/quick_purchase.py
@@ -26,13 +26,14 @@ def split_legacy_payment_method(payment_method):
 def build_delivery_info(profile):
     address_main = (getattr(profile, "address_main", "") or "").strip()
     address_detail = (getattr(profile, "address_detail", "") or "").strip()
-    if not address_main and not address_detail:
-        address_main, address_detail = split_legacy_address(getattr(profile, "address", ""))
 
     recipient_name = (getattr(profile, "recipient_name", "") or getattr(profile, "nickname", "") or "").strip()
     recipient_phone = (getattr(profile, "phone", "") or "").strip()
     postal_code = (getattr(profile, "postal_code", "") or "").strip()
     delivery_summary = " ".join(part for part in [address_main, address_detail] if part).strip()
+    if not delivery_summary:
+        legacy_address_main, legacy_address_detail = split_legacy_address(getattr(profile, "address", ""))
+        delivery_summary = " ".join(part for part in [legacy_address_main, legacy_address_detail] if part).strip()
 
     return {
         "recipient_name": recipient_name,


### PR DESCRIPTION
## 요약
Django Test EB 배포에서 누락된 static 서빙을 복구하고, 동일 문제가 CI에서 다시 발생하지 않도록 배포 번들 스모크 테스트를 추가했습니다.

## 변경 사항
- `deploy/eb/test-django/docker-compose.yml`과 `deploy/eb/test-django/nginx/nginx.conf`에 Django static volume 및 `/static/` 서빙 설정을 추가했습니다.
- `infra/docker-compose.yml`과 `infra/nginx/nginx.conf`에도 동일한 static 서빙 구성을 반영해 로컬 검증 환경을 배포 구성과 맞췄습니다.
- `.github/workflows/ci-cd.yml`에 deploy bundle runtime smoke test를 추가해 `/health/`와 `/static/admin/css/base.css` 응답까지 확인하도록 보강했습니다.
- `services/django/users/quick_purchase.py`와 `services/django/orders/tests.py`를 정리해 legacy address만으로 구조화 배송지를 만족시키지 않도록 맞추고, 최신 `develop` 기준 CI 실패 원인도 함께 해결했습니다.

## 관련 이슈
- 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 배포 번들에서 static volume 공유 방식과 nginx `/static/` alias 구성이 EB 환경에서도 의도대로 동작하는지 확인 부탁드립니다.
- quick purchase 기본 배송지에서 legacy address fallback을 제거한 정책 방향이 현재 주문 API 기대값과 맞는지 함께 봐주시면 됩니다.
