### PR TITLE
fix(nginx): serve static assets with proper mime types

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -171,7 +171,9 @@ jobs:
             sleep 3
           done
           curl --fail --silent --show-error http://127.0.0.1/health/ > /dev/null
+          curl --fail --silent --show-error http://127.0.0.1/static/css/main.css > /dev/null
           curl --fail --silent --show-error http://127.0.0.1/static/admin/css/base.css > /dev/null
+          curl --silent --show-error --head http://127.0.0.1/static/css/main.css | grep -qi '^Content-Type: text/css'
 
       - name: Teardown
         if: always()

--- a/deploy/eb/test-django/nginx/nginx.conf
+++ b/deploy/eb/test-django/nginx/nginx.conf
@@ -1,4 +1,7 @@
 http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
     upstream django {
         server django:8000;
     }

--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -1,4 +1,7 @@
 http {
+    include /etc/nginx/mime.types;
+    default_type application/octet-stream;
+
     upstream django {
         server django:8000;
     }


### PR DESCRIPTION
## 요약
Elastic Beanstalk 배포 환경에서 static 파일이 `200`으로 내려오더라도 `Content-Type`이 `text/plain`으로 응답되던 문제를 수정하고, CI에서 동일 문제가 다시 배포되지 않도록 검증을 추가했습니다.

## 변경 사항
- `deploy/eb/test-django/nginx/nginx.conf`에 `mime.types` 포함과 `default_type` 설정을 추가해 CSS/정적 파일이 올바른 MIME 타입으로 서빙되도록 수정했습니다.
- `infra/nginx/nginx.conf`에도 동일한 설정을 반영해 로컬 검증 환경과 배포 환경의 nginx 동작을 일치시켰습니다.
- `.github/workflows/ci-cd.yml`의 deploy bundle smoke test에 `/static/css/main.css` 응답과 `Content-Type: text/css` 헤더 검증을 추가했습니다.

## 관련 이슈
- 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- EB 환경에서 커스텀 nginx 설정이 static 파일을 `text/css` 등 올바른 MIME 타입으로 서빙하는지 중심으로 봐주시면 됩니다.
- CI smoke test가 static 응답 유무뿐 아니라 헤더 이상까지 충분히 잡아내는지 함께 확인 부탁드립니다.
