### PR TITLE
테스트 RDS DBeaver 런북 추가 및 AI 서브모듈 포인터 업데이트

### DIFF
--- a/docs/infra/08_dbeaver_rds_tunnel.md
+++ b/docs/infra/08_dbeaver_rds_tunnel.md
@@ -1,0 +1,73 @@
+# DBeaver로 Test RDS 확인하기
+
+## 배경
+
+테스트 Django EB 환경이 바라보는 RDS는 아래와 같다.
+
+- EB 환경: `test-tailtalk-django-env`
+- RDS endpoint: `test-tailtalk-postgres-v2.cpkmaq4eqdte.ap-northeast-2.rds.amazonaws.com`
+- Engine: `PostgreSQL`
+- `PubliclyAccessible=False`
+
+즉, DBeaver에서 RDS endpoint로 직접 붙는 방식은 동작하지 않는다.
+사용자 PC에서 `EC2(EB 인스턴스) -> RDS` SSH 터널을 열고, DBeaver는 `localhost`로 붙어야 한다.
+
+## 준비물
+
+- `aws` CLI
+- `ssh`, `ssh-keygen`
+- `curl`
+- DBeaver
+
+## 빠른 실행
+
+프로젝트 루트에서 아래를 실행한다.
+
+```bash
+bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+```
+
+스크립트 동작:
+
+1. EB 환경 변수에서 실제 RDS 접속 정보 조회
+2. 현재 내 공인 IP 확인
+3. EB 인스턴스 Security Group에 내 IP로 `22/tcp` 임시 허용
+4. EC2 Instance Connect로 임시 SSH 키 업로드
+5. 로컬 `127.0.0.1:15432` -> RDS `5432` 터널 오픈
+6. 종료 시 임시 `22/tcp` 규칙 자동 제거
+
+실행 중 터미널은 닫지 말아야 한다.
+
+## DBeaver 입력값
+
+스크립트가 시작되면 아래 값을 출력한다.
+
+- Host: `127.0.0.1`
+- Port: `15432`
+- Database: `tailtalk`
+- Username: `tailtalk`
+- Password: 스크립트 출력값 사용
+
+DB 타입은 `PostgreSQL`로 선택하면 된다.
+
+## 자주 쓰는 옵션
+
+```bash
+# 터널은 열지 않고 접속 정보만 출력
+PRINT_ONLY=1 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+
+# 로컬 포트 변경
+LOCAL_PORT=25432 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+
+# 공인 IP 자동 감지가 안 될 때 직접 지정
+PUBLIC_IP_CIDR=203.0.113.10/32 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+
+# 종료 후에도 22 허용 규칙 유지
+KEEP_SSH_RULE=1 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+```
+
+## 참고
+
+- AWS 자격증명이 셸에 없으면 기본적으로 `services/django/.env`를 읽는다.
+- DBeaver는 터널을 직접 여는 것이 아니라, 이미 열린 로컬 포트 `127.0.0.1:<LOCAL_PORT>` 에 접속한다.
+- DBeaver 최초 PostgreSQL 연결 시 드라이버 다운로드가 필요할 수 있다.

--- a/docs/infra/09_dbeaver_rds_reconnect_runbook.md
+++ b/docs/infra/09_dbeaver_rds_reconnect_runbook.md
@@ -1,0 +1,247 @@
+# DBeaver RDS 재접속 런북
+
+## 목적
+
+이 문서는 한 번 종료했던 SSH 터널을 다시 열고,
+Windows DBeaver에서 테스트 RDS를 다시 확인하는 절차를 정리한 문서다.
+
+특히 `2026-03-27` 금요일에 실제로 사용했던 방식과 동일한 흐름으로 다시 붙는 것을 기준으로 작성했다.
+
+## 현재 접속 구조
+
+테스트 RDS는 private 이므로 DBeaver에서 RDS endpoint로 직접 붙지 않는다.
+반드시 bastion EC2를 경유한 SSH 터널을 먼저 열어야 한다.
+
+현재 확인된 대상:
+
+- Bastion EC2 이름: `test-tailtalk-bastion`
+- Bastion 공인 IP: `54.116.141.184`
+- Bastion SSH 사용자: `ec2-user`
+- Bastion 키 파일: `output/bastion/test-tailtalk-bastion-key.pem`
+- RDS endpoint: `test-tailtalk-postgres-v2.cpkmaq4eqdte.ap-northeast-2.rds.amazonaws.com`
+- RDS port: `5432`
+- DBeaver 접속 대상: `127.0.0.1:15432`
+
+즉 구조는 아래와 같다.
+
+```text
+DBeaver (Windows)
+  -> 127.0.0.1:15432
+  -> SSH 터널
+  -> test-tailtalk-bastion (54.116.141.184)
+  -> test-tailtalk-postgres-v2...:5432
+```
+
+## 지난 금요일에 실제로 썼던 방식
+
+로컬 히스토리 기준으로 `2026-03-27`에 실제로 실행한 명령은 아래였다.
+
+```bash
+ssh -i /home/playdata/SKN22-Final-2Team-WEB/output/bastion/test-tailtalk-bastion-key.pem \
+  -L 15432:test-tailtalk-postgres-v2.cpkmaq4eqdte.ap-northeast-2.rds.amazonaws.com:5432 \
+  ec2-user@54.116.141.184
+```
+
+중요한 점:
+
+- 그때도 `.pem` 키는 사용했다
+- 다만 DBeaver 안에서 쓴 게 아니라 WSL/bash 쪽 SSH 터널에서 썼다
+- DBeaver는 `127.0.0.1:15432` 로컬 포트만 보고 있었다
+
+그래서 체감상 "DBeaver에서는 키를 안 썼다"처럼 느껴졌을 수 있다.
+
+## 가장 권장하는 재접속 방법
+
+기존과 가장 같은 방식은 Windows DBeaver는 그대로 두고,
+WSL/bash에서 SSH 터널만 다시 여는 것이다.
+
+### 1. WSL 터미널 열기
+
+Ubuntu 또는 현재 작업 중인 WSL/bash 터미널을 연다.
+
+### 2. 저장소 루트로 이동
+
+```bash
+cd /home/playdata/SKN22-Final-2Team-WEB
+```
+
+### 3. 기존 15432 포트가 이미 사용 중인지 확인
+
+```bash
+lsof -i :15432
+```
+
+아무것도 안 나오면 다음 단계로 간다.
+
+프로세스가 보이면 이미 다른 SSH 터널이 떠 있거나,
+이전 터널이 정리되지 않은 상태다.
+
+### 4. SSH 터널 다시 열기
+
+이제 아래 명령을 실행한다.
+
+```bash
+ssh -N -i /home/playdata/SKN22-Final-2Team-WEB/output/bastion/test-tailtalk-bastion-key.pem \
+  -L 15432:test-tailtalk-postgres-v2.cpkmaq4eqdte.ap-northeast-2.rds.amazonaws.com:5432 \
+  ec2-user@54.116.141.184
+```
+
+설명:
+
+- `-N`: 쉘 접속 없이 포트포워딩만 유지
+- `-i`: `.pem` 키 파일 지정
+- `-L 15432:...:5432`: 내 PC `15432`를 RDS `5432`에 연결
+
+이 명령은 성공하면 조용히 멈춰 있는 것처럼 보일 수 있다.
+그 상태가 정상이다.
+
+이 창은 닫지 말고 그대로 유지해야 한다.
+
+### 5. DBeaver 열기
+
+Windows DBeaver를 연다.
+
+이미 저장된 연결이 있다.
+
+- `TailTalk_RDS_PgPass`
+- `tailtalk`
+
+둘 다 현재 기준 `127.0.0.1:15432/tailtalk` 로 저장돼 있다.
+
+가능하면 새 연결을 만들지 말고 기존 연결을 그대로 재사용한다.
+
+### 6. 기존 연결로 접속
+
+DBeaver에서 위 연결 중 하나를 더블클릭하거나 `Connect`를 누른다.
+
+정상이라면 바로 붙는다.
+
+## 새 연결을 다시 만들어야 할 때
+
+기존 연결이 깨졌거나 새로 만들어야 하면 아래 값으로 만든다.
+
+- DB 타입: `PostgreSQL`
+- Host: `127.0.0.1`
+- Port: `15432`
+- Database: `tailtalk`
+
+사용자명/비밀번호가 기억나지 않으면 새 문서에 하드코딩하지 말고,
+프로젝트 루트에서 아래 명령으로 현재 값을 확인한다.
+
+```bash
+PRINT_ONLY=1 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+```
+
+이 명령은 현재 AWS 기준 DB 접속 정보를 출력한다.
+
+## PowerShell에서 다시 열고 싶을 때
+
+지난 금요일의 실제 기록은 WSL/bash 방식이었다.
+그래도 PowerShell에서 직접 열고 싶다면 아래 순서로 한다.
+
+### 1. WSL 경로를 Windows 경로로 변환
+
+WSL에서 아래를 실행하면 Windows에서 쓸 수 있는 경로가 나온다.
+
+```bash
+wslpath -w /home/playdata/SKN22-Final-2Team-WEB/output/bastion/test-tailtalk-bastion-key.pem
+```
+
+### 2. PowerShell에서 SSH 터널 열기
+
+변환된 경로를 그대로 사용해서 실행한다.
+
+```powershell
+ssh -N -i "<wslpath -w 출력값>" `
+  -L 15432:test-tailtalk-postgres-v2.cpkmaq4eqdte.ap-northeast-2.rds.amazonaws.com:5432 `
+  ec2-user@54.116.141.184
+```
+
+PowerShell 방식은 키 경로나 권한 문제로 실패할 수 있다.
+그럴 때는 WSL/bash 방식으로 여는 쪽이 더 안정적이다.
+
+## 정상 연결 확인 방법
+
+SSH 터널이 열린 상태에서 다른 터미널에서 아래를 확인한다.
+
+WSL/bash:
+
+```bash
+lsof -i :15432
+```
+
+Windows PowerShell:
+
+```powershell
+Test-NetConnection -ComputerName 127.0.0.1 -Port 15432
+```
+
+정상이라면 DBeaver에서 `127.0.0.1:15432` 연결이 성공해야 한다.
+
+## 자주 막히는 경우
+
+### 1. `Connection timed out`
+
+원인:
+
+- Bastion EC2 보안그룹에 현재 공인 IP가 허용되지 않음
+
+현재 확인된 SSH 허용 CIDR은 `222.112.208.66/32`다.
+다른 네트워크에서 붙으면 timeout 이 날 수 있다.
+
+### 2. `Permission denied (publickey)`
+
+원인:
+
+- 잘못된 `.pem` 파일 사용
+- 사용자 계정을 `ec2-user`가 아닌 다른 값으로 사용
+
+확인:
+
+- 키 파일: `output/bastion/test-tailtalk-bastion-key.pem`
+- 사용자: `ec2-user`
+
+### 3. `Address already in use`
+
+원인:
+
+- `15432` 포트를 이미 다른 프로세스가 사용 중
+
+확인:
+
+```bash
+lsof -i :15432
+```
+
+### 4. DBeaver에서 `Connection refused`
+
+원인:
+
+- SSH 터널 창을 닫았음
+- SSH 터널이 애초에 성공하지 않았음
+
+조치:
+
+1. SSH 명령부터 다시 실행
+2. 그 창을 닫지 않은 상태에서 DBeaver 접속
+
+### 5. DBeaver가 사용자명/비밀번호를 다시 물어봄
+
+원인:
+
+- 기존 저장 연결이 초기화됐거나 새 연결을 만든 경우
+
+조치:
+
+```bash
+PRINT_ONLY=1 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+```
+
+로 현재 값을 확인해서 입력한다.
+
+## 종료 방법
+
+터널을 닫고 싶으면 SSH를 띄운 터미널에서 `Ctrl+C`를 누른다.
+
+그 다음 DBeaver 연결은 더 이상 `127.0.0.1:15432`에 붙지 않는다.
+다시 확인하려면 위 절차를 처음부터 반복하면 된다.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -65,6 +65,22 @@ bash scripts/dump_db.sh backup/my_backup.dump
 
 ---
 
+### AWS Test RDS를 DBeaver로 확인
+
+테스트 RDS는 private 이므로 직접 접속이 아니라 EB 인스턴스 경유 SSH 터널이 필요합니다.
+
+```bash
+# 접속 정보만 출력
+PRINT_ONLY=1 bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+
+# 실제 터널 열기
+bash scripts/aws/start_test_rds_dbeaver_tunnel.sh
+```
+
+상세 사용법은 `docs/infra/08_dbeaver_rds_tunnel.md` 문서를 참고합니다.
+
+---
+
 ## 팀원 온보딩 (처음 셋업)
 
 ```bash
@@ -138,6 +154,8 @@ python scripts/domain/convert_domain_data.py
 scripts/
 ├── setup_db.sh                     # 로컬 DB 셋업/복원
 ├── dump_db.sh                      # DB 덤프 생성
+├── aws/
+│   └── start_test_rds_dbeaver_tunnel.sh  # Test RDS용 SSH 터널
 ├── ingest_postgres.py              # 상품/리뷰/벡터 적재
 ├── config.py                       # ETL 공통 설정
 ├── domain/

--- a/scripts/aws/start_test_rds_dbeaver_tunnel.sh
+++ b/scripts/aws/start_test_rds_dbeaver_tunnel.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ENV_FILE="${ENV_FILE:-$ROOT_DIR/services/django/.env}"
+
+EB_APP_NAME="${EB_APP_NAME:-test-tailtalk-django}"
+EB_ENV_NAME="${EB_ENV_NAME:-test-tailtalk-django-env}"
+AWS_DEFAULT_REGION="${AWS_DEFAULT_REGION:-ap-northeast-2}"
+EC2_OS_USER="${EC2_OS_USER:-ec2-user}"
+LOCAL_PORT="${LOCAL_PORT:-15432}"
+PRINT_ONLY="${PRINT_ONLY:-0}"
+KEEP_SSH_RULE="${KEEP_SSH_RULE:-0}"
+PUBLIC_IP_CIDR="${PUBLIC_IP_CIDR:-}"
+EC2_SECURITY_GROUP_ID="${EC2_SECURITY_GROUP_ID:-}"
+
+KEY_DIR=""
+KEY_FILE=""
+RULE_ADDED=0
+SSH_GROUP_ID=""
+CIDR=""
+
+need_cmd() {
+  command -v "$1" >/dev/null 2>&1 || {
+    echo "ERROR: '$1' 명령을 찾을 수 없습니다." >&2
+    exit 1
+  }
+}
+
+require_value() {
+  local name="$1"
+  local value="$2"
+
+  if [[ -z "$value" || "$value" == "None" ]]; then
+    echo "ERROR: '$name' 값을 확인하지 못했습니다." >&2
+    exit 1
+  fi
+}
+
+load_aws_env() {
+  if [[ -z "${AWS_ACCESS_KEY_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" ]]; then
+    if [[ -f "$ENV_FILE" ]]; then
+      set -a
+      # shellcheck source=/dev/null
+      source "$ENV_FILE"
+      set +a
+    fi
+  fi
+
+  : "${AWS_ACCESS_KEY_ID:?AWS_ACCESS_KEY_ID 가 설정되어 있지 않습니다.}"
+  : "${AWS_SECRET_ACCESS_KEY:?AWS_SECRET_ACCESS_KEY 가 설정되어 있지 않습니다.}"
+
+  export AWS_DEFAULT_REGION
+}
+
+eb_env_value() {
+  local key="$1"
+
+  aws elasticbeanstalk describe-configuration-settings \
+    --application-name "$EB_APP_NAME" \
+    --environment-name "$EB_ENV_NAME" \
+    --query "ConfigurationSettings[0].OptionSettings[?Namespace=='aws:elasticbeanstalk:application:environment' && OptionName=='${key}'].Value | [0]" \
+    --output text
+}
+
+resolve_instance_id() {
+  aws elasticbeanstalk describe-environment-resources \
+    --environment-name "$EB_ENV_NAME" \
+    --query 'EnvironmentResources.Instances[0].Id' \
+    --output text
+}
+
+resolve_instance_field() {
+  local field="$1"
+
+  aws ec2 describe-instances \
+    --instance-ids "$INSTANCE_ID" \
+    --query "Reservations[0].Instances[0].${field}" \
+    --output text
+}
+
+resolve_ssh_group_id() {
+  local group_ids
+  local selected
+
+  group_ids="$(aws ec2 describe-instances \
+    --instance-ids "$INSTANCE_ID" \
+    --query 'Reservations[0].Instances[0].SecurityGroups[].GroupId' \
+    --output text)"
+
+  selected="$(aws ec2 describe-security-groups \
+    --group-ids ${group_ids} \
+    --query "SecurityGroups[?contains(GroupName, 'AWSEBSecurityGroup')].GroupId | [0]" \
+    --output text)"
+
+  if [[ -z "$selected" || "$selected" == "None" ]]; then
+    selected="$(printf '%s\n' ${group_ids} | head -n1)"
+  fi
+
+  printf '%s\n' "$selected"
+}
+
+detect_public_ip_cidr() {
+  if [[ -n "$PUBLIC_IP_CIDR" ]]; then
+    printf '%s\n' "$PUBLIC_IP_CIDR"
+    return 0
+  fi
+
+  need_cmd curl
+
+  local ip
+  ip="$(curl -fsS https://checkip.amazonaws.com | tr -d '[:space:]')"
+
+  if [[ ! "$ip" =~ ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "ERROR: 공인 IP를 자동으로 확인하지 못했습니다. PUBLIC_IP_CIDR=x.x.x.x/32 로 지정하세요." >&2
+    exit 1
+  fi
+
+  printf '%s/32\n' "$ip"
+}
+
+authorize_ssh_access() {
+  local existing
+
+  existing="$(aws ec2 describe-security-groups \
+    --group-ids "$SSH_GROUP_ID" \
+    --query "SecurityGroups[0].IpPermissions[?FromPort==\`22\` && ToPort==\`22\`].IpRanges[?CidrIp=='${CIDR}'].CidrIp | [0]" \
+    --output text)"
+
+  if [[ "$existing" == "$CIDR" ]]; then
+    return 0
+  fi
+
+  aws ec2 authorize-security-group-ingress \
+    --group-id "$SSH_GROUP_ID" \
+    --ip-permissions "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=${CIDR},Description='tailtalk-rds-dbeaver-tunnel'}]" \
+    >/dev/null
+
+  RULE_ADDED=1
+}
+
+cleanup() {
+  local exit_code=$?
+
+  if [[ -n "$KEY_DIR" && -d "$KEY_DIR" ]]; then
+    rm -rf "$KEY_DIR"
+  fi
+
+  if [[ "$RULE_ADDED" == "1" && "$KEEP_SSH_RULE" != "1" && -n "$SSH_GROUP_ID" && -n "$CIDR" ]]; then
+    aws ec2 revoke-security-group-ingress \
+      --group-id "$SSH_GROUP_ID" \
+      --ip-permissions "IpProtocol=tcp,FromPort=22,ToPort=22,IpRanges=[{CidrIp=${CIDR}}]" \
+      >/dev/null || true
+  fi
+
+  exit "$exit_code"
+}
+
+print_summary() {
+  cat <<EOF
+[Tailtalk Test RDS]
+- AWS region: ${AWS_DEFAULT_REGION}
+- Elastic Beanstalk env: ${EB_ENV_NAME}
+- EC2 instance: ${INSTANCE_ID}
+- EC2 public IP: ${EC2_PUBLIC_IP}
+- RDS endpoint: ${DB_HOST}:${DB_PORT}
+
+[DBeaver 입력값]
+- Host: 127.0.0.1
+- Port: ${LOCAL_PORT}
+- Database: ${DB_NAME}
+- Username: ${DB_USER}
+- Password: ${DB_PASSWORD}
+
+터널이 열린 동안만 DBeaver에서 127.0.0.1:${LOCAL_PORT} 로 접속하면 됩니다.
+종료하려면 이 터미널에서 Ctrl+C 를 누르세요.
+EOF
+}
+
+main() {
+  need_cmd aws
+  need_cmd ssh
+  need_cmd ssh-keygen
+
+  load_aws_env
+
+  DB_HOST="$(eb_env_value POSTGRES_HOST)"
+  DB_PORT="$(eb_env_value POSTGRES_PORT)"
+  DB_NAME="$(eb_env_value POSTGRES_DB)"
+  DB_USER="$(eb_env_value POSTGRES_USER)"
+  DB_PASSWORD="$(eb_env_value POSTGRES_PASSWORD)"
+  INSTANCE_ID="$(resolve_instance_id)"
+
+  require_value "POSTGRES_HOST" "$DB_HOST"
+  require_value "POSTGRES_PORT" "$DB_PORT"
+  require_value "POSTGRES_DB" "$DB_NAME"
+  require_value "POSTGRES_USER" "$DB_USER"
+  require_value "POSTGRES_PASSWORD" "$DB_PASSWORD"
+  require_value "EC2 instance id" "$INSTANCE_ID"
+
+  EC2_PUBLIC_IP="$(resolve_instance_field PublicIpAddress)"
+  EC2_AZ="$(resolve_instance_field Placement.AvailabilityZone)"
+
+  require_value "EC2 public IP" "$EC2_PUBLIC_IP"
+  require_value "EC2 availability zone" "$EC2_AZ"
+
+  SSH_GROUP_ID="${EC2_SECURITY_GROUP_ID:-$(resolve_ssh_group_id)}"
+  require_value "EC2 security group" "$SSH_GROUP_ID"
+
+  print_summary
+
+  if [[ "$PRINT_ONLY" == "1" ]]; then
+    exit 0
+  fi
+
+  CIDR="$(detect_public_ip_cidr)"
+  authorize_ssh_access
+
+  KEY_DIR="$(mktemp -d)"
+  KEY_FILE="${KEY_DIR}/eb-tunnel-key"
+
+  ssh-keygen -q -t rsa -b 2048 -N '' -f "$KEY_FILE"
+
+  aws ec2-instance-connect send-ssh-public-key \
+    --instance-id "$INSTANCE_ID" \
+    --availability-zone "$EC2_AZ" \
+    --instance-os-user "$EC2_OS_USER" \
+    --ssh-public-key "file://${KEY_FILE}.pub" \
+    >/dev/null
+
+  echo
+  echo "[Info] SSH 허용 CIDR: ${CIDR}"
+  echo "[Info] 로컬 터널을 엽니다: 127.0.0.1:${LOCAL_PORT} -> ${DB_HOST}:${DB_PORT}"
+  echo
+
+  ssh \
+    -N \
+    -L "127.0.0.1:${LOCAL_PORT}:${DB_HOST}:${DB_PORT}" \
+    -o ExitOnForwardFailure=yes \
+    -o ServerAliveInterval=60 \
+    -o ServerAliveCountMax=3 \
+    -o StrictHostKeyChecking=accept-new \
+    -o IdentitiesOnly=yes \
+    -i "$KEY_FILE" \
+    "${EC2_OS_USER}@${EC2_PUBLIC_IP}"
+}
+
+trap cleanup EXIT INT TERM
+main "$@"


### PR DESCRIPTION
## 요약
테스트 RDS를 DBeaver로 확인하는 런북과 SSH 터널 스크립트를 추가하고, 추천 상품 card 수정이 포함된 최신 AI 커밋을 바라보도록 FastAPI 서브모듈 포인터를 업데이트했습니다.

## 변경 사항
- 테스트 RDS를 DBeaver로 확인하기 위한 문서와 재접속 런북을 추가했습니다.
- EB 인스턴스를 경유해 private RDS에 SSH 터널을 여는 `scripts/aws/start_test_rds_dbeaver_tunnel.sh` 스크립트를 추가했습니다.
- `scripts/README.md`에 DBeaver용 RDS 확인 절차를 연결했습니다.
- `services/fastapi` 서브모듈 포인터를 AI 커밋 `3ee737d`로 업데이트했습니다.
- 검증: `bash -n scripts/aws/start_test_rds_dbeaver_tunnel.sh`

## 관련 이슈
- ref skn-ai22-251029/SKN22-Final-2Team-AI#17

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- DBeaver 재접속 런북 흐름이 실제 운영 절차와 어긋나는 부분이 없는지 확인 부탁드립니다.
- FastAPI 서브모듈 포인터가 AI PR 내용과 맞는지 함께 봐주시면 됩니다.
