### PR TITLE
[feat] 상품 목록 카테고리 드롭다운 정리 (#240)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -228,239 +228,142 @@ def _build_catalog_menu_context():
                 for subcategory in normalized_subcategories or ["(없음)"]:
                     grouped_raw[pet_type][category][subcategory] += 1
 
-    catalog_config = {
-        "강아지": [
-            {
-                "label": "사료",
-                "db_categories": ["사료"],
-                "groups": [
-                    {
-                        "label": "급여 연령",
-                        "items": ["전연령", "어덜트(1~7세)", "시니어(7세이상)"],
-                    },
-                    {
-                        "label": "종류",
-                        "items": ["건식사료", "화식", "소프트사료", "습식사료", "동결건조/에어드라이"],
-                    },
-                ],
-            },
-            {
-                "label": "간식",
-                "db_categories": ["간식"],
-                "groups": [
-                    {
-                        "label": "종류",
-                        "items": ["져키/트릿", "사사미", "원물/뼈간식", "캔/파우치", "수제간식", "동결/건조간식"],
-                    },
-                    {
-                        "label": "기능",
-                        "items": ["영양/기능", "덴탈껌"],
-                    },
-                ],
-            },
-            {
-                "label": "덴탈/구강",
-                "db_categories": ["덴탈관"],
-                "groups": [
-                    {
-                        "label": "구강 간식",
-                        "items": ["덴탈껌"],
-                    },
-                    {
-                        "label": "관리 용품",
-                        "items": ["칫솔", "치약"],
-                    },
-                    {
-                        "label": "관리 기능",
-                        "items": ["구강관리", "치아관리"],
-                    },
-                ],
-            },
-            {
-                "label": "배변/위생",
-                "db_categories": ["배변용품"],
-                "groups": [
-                    {
-                        "label": "배변 용품",
-                        "items": ["배변패드", "배변봉투/집게", "기저귀/팬티", "배변판"],
-                    },
-                    {
-                        "label": "위생 관리",
-                        "items": ["물티슈/클리너", "탈취/소독"],
-                    },
-                ],
-            },
-            {
-                "label": "용품",
-                "db_categories": ["용품"],
-                "groups": [
-                    {
-                        "label": "외출/산책",
-                        "items": ["목줄/하네스", "이동장/캐리어"],
-                    },
-                    {
-                        "label": "리빙",
-                        "items": ["하우스/방석", "급식/급수기"],
-                    },
-                    {
-                        "label": "미용/패션",
-                        "items": ["미용/목욕", "의류/악세사리"],
-                    },
-                    {
-                        "label": "놀이/건강",
-                        "items": ["장난감/훈련", "건강관리"],
-                    },
-                ],
-            },
-        ],
-        "고양이": [
-            {
-                "label": "사료",
-                "db_categories": ["사료"],
-                "groups": [
-                    {
-                        "label": "급여 연령",
-                        "items": ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"],
-                    },
-                    {
-                        "label": "종류",
-                        "items": ["건식", "에어/동결건조"],
-                    },
-                ],
-            },
-            {
-                "label": "습식",
-                "db_categories": ["습식관"],
-                "groups": [
-                    {
-                        "label": "종류",
-                        "items": ["주식캔", "주식파우치"],
-                    },
-                    {
-                        "label": "급여 연령",
-                        "items": ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"],
-                    },
-                ],
-            },
-            {
-                "label": "간식",
-                "db_categories": ["간식"],
-                "groups": [
-                    {
-                        "label": "종류",
-                        "items": ["간식캔", "간식파우치", "동결/건조간식", "스낵/캔디", "통살/소시지", "져키/스틱", "져키/트릿"],
-                    },
-                    {
-                        "label": "기능",
-                        "items": ["영양/기능"],
-                    },
-                ],
-            },
-            {
-                "label": "모래",
-                "db_categories": ["모래"],
-                "groups": [
-                    {
-                        "label": "모래 종류",
-                        "items": ["벤토나이트", "두부모래", "카사바/천연모래", "기타모래"],
-                    },
-                ],
-            },
-            {
-                "label": "덴탈/구강",
-                "db_categories": ["덴탈관"],
-                "groups": [
-                    {
-                        "label": "관리 기능",
-                        "items": ["치아관리", "구강관리"],
-                    },
-                    {
-                        "label": "관리 용품",
-                        "items": ["칫솔", "치약"],
-                    },
-                ],
-            },
-            {
-                "label": "배변/위생",
-                "db_categories": ["배변용품"],
-                "groups": [
-                    {
-                        "label": "배변 용품",
-                        "items": ["화장실/위생"],
-                    },
-                    {
-                        "label": "위생 관리",
-                        "items": ["물티슈/클리너", "탈취/소독"],
-                    },
-                ],
-            },
-            {
-                "label": "용품",
-                "db_categories": ["용품"],
-                "groups": [
-                    {
-                        "label": "놀이/리빙",
-                        "items": ["장난감/캣닢", "스크래쳐/캣타워", "하우스/방석"],
-                    },
-                    {
-                        "label": "외출/급식",
-                        "items": ["이동장/캐리어", "급식/급수기"],
-                    },
-                    {
-                        "label": "관리",
-                        "items": ["미용/목욕", "의류/악세사리", "건강관리"],
-                    },
-                ],
-            },
-        ],
+    category_order = {
+        "강아지": ["사료", "간식", "용품", "배변용품", "덴탈관"],
+        "고양이": ["사료", "간식", "용품", "모래", "습식관"],
     }
+    category_labels = {}
+    group_definitions = {
+        "강아지": {
+            "사료": [
+                ("급여 연령", ["퍼피(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
+                ("종류", ["건식사료", "화식", "소프트사료", "습식사료", "동결건조/에어드라이"]),
+                ("기능", ["처방식", "눈/눈물", "체중조절", "피부/모질", "위장/소화", "관절", "중성화", "스트레스 완화", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "견종별"]),
+                ("주요 브랜드", ["아카나", "오리젠"]),
+                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한임박", "유통기한 임박")]),
+            ],
+            "간식": [
+                ("전체", ["덴탈껌", "원물/뼈간식", "캔/파우치", "져키/트릿", "비스킷/쿠키", "사사미", "통살/소시지", "동결/건조간식", "수제간식", "파우더", "음료/분유/우유", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "용품": [
+                ("전체", ["구강관리", "건강관리", "미용/목욕", "급식/급수기", "장난감/훈련", "의류/악세사리", "하우스/방석", "이동장/캐리어", "목줄/하네스", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "덴탈관": [
+                ("전체", ["수의사인증", "덴탈껌", "칫솔", "치약", "원물/뼈간식"]),
+            ],
+            "배변용품": [
+                ("전체", ["배변패드", "배변판", "기저귀/팬티", "탈취/소독", "배변봉투/집게", "배변유도제", "물티슈/클리너"]),
+            ],
+        },
+        "고양이": {
+            "사료": [
+                ("급여 연령", ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
+                ("종류", ["주식캔", "건식", "주식파우치", "에어/동결건조"]),
+                ("기능", ["처방식", "헤어볼", "피부/피모", "위장/소화", "요로기계", "체중조절", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "면역력", "묘종별"]),
+                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "습식관": [
+                ("전체", ["주식캔", "주식파우치"]),
+            ],
+            "간식": [
+                ("전체", ["간식캔", "간식파우치", "동결/건조간식", "스낵/캔디", "져키/스틱", "통살/소시지", "음료", "파우더/토퍼", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "모래": [
+                ("전체", ["두부모래", "카사바/천연모래", "벤토나이트", ("기타 모래", "기타모래")]),
+            ],
+            "용품": [
+                ("전체", ["건강관리", "장난감/캣닢", "스크래쳐/캣타워", "치아관리", "화장실/위생", "미용/목욕", "급식/급수기", "의류/악세사리", "하우스/방석", "이동장/캐리어", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
+            ],
+        },
+    }
+    strict_category_groups = {
+        "강아지": {"사료", "간식", "용품", "배변용품", "덴탈관"},
+        "고양이": {"사료", "습식관", "간식", "용품", "모래"},
+    }
+    strict_category_order_pets = {"강아지", "고양이"}
+
+    def build_category_href(pet_type, category):
+        if category:
+            return f"/products/?pet={pet_type}&category={category}"
+        return f"/products/?pet={pet_type}"
 
     sections = []
     for pet_type in pet_labels:
         categories = []
-        for config in catalog_config[pet_type]:
-            raw_counter = Counter()
-            for db_category in config["db_categories"]:
-                raw_counter.update(grouped_raw[pet_type].get(db_category, Counter()))
+        ordered_categories = []
+        seen_categories = set()
+        for category in category_order.get(pet_type, []):
+            if category in grouped_raw[pet_type]:
+                ordered_categories.append(category)
+                seen_categories.add(category)
+        if pet_type not in strict_category_order_pets:
+            for category, _counter in sorted(grouped_raw[pet_type].items(), key=lambda item: (-sum(item[1].values()), item[0])):
+                if category not in seen_categories:
+                    ordered_categories.append(category)
 
-            groups = []
-            for group_config in config["groups"]:
-                items = []
-                for subcategory in group_config["items"]:
-                    if raw_counter.get(subcategory, 0) <= 0:
-                        continue
-                    db_category = next(
-                        (
-                            category_name
-                            for category_name in config["db_categories"]
-                            if grouped_raw[pet_type].get(category_name, Counter()).get(subcategory, 0) > 0
-                        ),
-                        config["db_categories"][0],
-                    )
-                    items.append(
-                        {
-                            "label": subcategory,
-                            "href": f"/products/?pet={pet_type}&category={db_category}&subcategory={subcategory}",
-                        }
-                    )
-
-                if not items:
-                    continue
-
-                groups.append(
-                    {
-                        "label": group_config["label"],
-                        "items": items,
-                    }
-                )
-
-            if not groups:
+        for category in ordered_categories:
+            raw_counter = grouped_raw[pet_type].get(category, Counter())
+            if not raw_counter:
                 continue
+
+            group_config = group_definitions.get(pet_type, {}).get(category, [])
+            used_subcategories = set()
+            groups = []
+            for group_label, group_items in group_config:
+                items = []
+                for subcategory in group_items:
+                    display_label = subcategory
+                    raw_value = subcategory
+                    is_brand = False
+                    if isinstance(subcategory, (tuple, list)) and len(subcategory) >= 2:
+                        display_label = subcategory[0]
+                        raw_value = subcategory[1]
+                    if category == "사료" and group_label == "주요 브랜드":
+                        is_brand = True
+                        brand_products = Product.objects.filter(
+                            soldout_yn=False,
+                            pet_type__contains=[pet_type],
+                            brand_name=raw_value,
+                        )
+                        if not brand_products.exists():
+                            continue
+                    elif raw_counter.get(raw_value, 0) <= 0:
+                        continue
+                    if not is_brand:
+                        used_subcategories.add(raw_value)
+                    href = build_category_href(pet_type, category)
+                    if is_brand:
+                        href += f"&brand={raw_value}"
+                    elif category:
+                        href += f"&subcategory={raw_value}"
+                    else:
+                        href = f"/products/?pet={pet_type}&subcategory={raw_value}"
+                    items.append({"label": display_label, "href": href})
+                if items:
+                    groups.append({"label": group_label, "items": items})
+
+            remaining = []
+            if category not in strict_category_groups.get(pet_type, set()):
+                remaining = [
+                    subcategory
+                    for subcategory, _count in sorted(raw_counter.items(), key=lambda item: (-item[1], item[0]))
+                    if subcategory not in used_subcategories
+                ]
+            if remaining:
+                items = []
+                for subcategory in remaining:
+                    href = build_category_href(pet_type, category)
+                    if category:
+                        href += f"&subcategory={subcategory}"
+                    else:
+                        href = f"/products/?pet={pet_type}&subcategory={subcategory}"
+                    items.append({"label": subcategory, "href": href})
+                groups.append({"label": "기타", "items": items})
 
             categories.append(
                 {
-                    "label": config["label"],
-                    "href": f"/products/?pet={pet_type}&category={config['db_categories'][0]}",
+                    "label": category_labels.get(category, category),
+                    "href": build_category_href(pet_type, category),
                     "groups": groups,
                 }
             )

--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,4 +1,5 @@
 import json
+from collections import Counter, defaultdict
 
 from django.db.models import Q
 from django.shortcuts import redirect, render
@@ -210,6 +211,269 @@ def _serialize_future_pet(profile):
             ", ".join(interests) if interests else "",
         ],
     }
+
+
+def _build_catalog_menu_context():
+    pet_labels = ["강아지", "고양이"]
+    rows = Product.objects.filter(soldout_yn=False).values_list("pet_type", "category", "subcategory")[:5000]
+    grouped_raw = {label: defaultdict(Counter) for label in pet_labels}
+
+    for pet_types, categories, subcategories in rows:
+        normalized_pet_types = [value for value in (pet_types or []) if value in pet_labels]
+        normalized_categories = [value for value in (categories or []) if value]
+        normalized_subcategories = [value for value in (subcategories or []) if value]
+
+        for pet_type in normalized_pet_types:
+            for category in normalized_categories:
+                for subcategory in normalized_subcategories or ["(없음)"]:
+                    grouped_raw[pet_type][category][subcategory] += 1
+
+    catalog_config = {
+        "강아지": [
+            {
+                "label": "사료",
+                "db_categories": ["사료"],
+                "groups": [
+                    {
+                        "label": "급여 연령",
+                        "items": ["전연령", "어덜트(1~7세)", "시니어(7세이상)"],
+                    },
+                    {
+                        "label": "종류",
+                        "items": ["건식사료", "화식", "소프트사료", "습식사료", "동결건조/에어드라이"],
+                    },
+                ],
+            },
+            {
+                "label": "간식",
+                "db_categories": ["간식"],
+                "groups": [
+                    {
+                        "label": "종류",
+                        "items": ["져키/트릿", "사사미", "원물/뼈간식", "캔/파우치", "수제간식", "동결/건조간식"],
+                    },
+                    {
+                        "label": "기능",
+                        "items": ["영양/기능", "덴탈껌"],
+                    },
+                ],
+            },
+            {
+                "label": "덴탈/구강",
+                "db_categories": ["덴탈관"],
+                "groups": [
+                    {
+                        "label": "구강 간식",
+                        "items": ["덴탈껌"],
+                    },
+                    {
+                        "label": "관리 용품",
+                        "items": ["칫솔", "치약"],
+                    },
+                    {
+                        "label": "관리 기능",
+                        "items": ["구강관리", "치아관리"],
+                    },
+                ],
+            },
+            {
+                "label": "배변/위생",
+                "db_categories": ["배변용품"],
+                "groups": [
+                    {
+                        "label": "배변 용품",
+                        "items": ["배변패드", "배변봉투/집게", "기저귀/팬티", "배변판"],
+                    },
+                    {
+                        "label": "위생 관리",
+                        "items": ["물티슈/클리너", "탈취/소독"],
+                    },
+                ],
+            },
+            {
+                "label": "용품",
+                "db_categories": ["용품"],
+                "groups": [
+                    {
+                        "label": "외출/산책",
+                        "items": ["목줄/하네스", "이동장/캐리어"],
+                    },
+                    {
+                        "label": "리빙",
+                        "items": ["하우스/방석", "급식/급수기"],
+                    },
+                    {
+                        "label": "미용/패션",
+                        "items": ["미용/목욕", "의류/악세사리"],
+                    },
+                    {
+                        "label": "놀이/건강",
+                        "items": ["장난감/훈련", "건강관리"],
+                    },
+                ],
+            },
+        ],
+        "고양이": [
+            {
+                "label": "사료",
+                "db_categories": ["사료"],
+                "groups": [
+                    {
+                        "label": "급여 연령",
+                        "items": ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"],
+                    },
+                    {
+                        "label": "종류",
+                        "items": ["건식", "에어/동결건조"],
+                    },
+                ],
+            },
+            {
+                "label": "습식",
+                "db_categories": ["습식관"],
+                "groups": [
+                    {
+                        "label": "종류",
+                        "items": ["주식캔", "주식파우치"],
+                    },
+                    {
+                        "label": "급여 연령",
+                        "items": ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"],
+                    },
+                ],
+            },
+            {
+                "label": "간식",
+                "db_categories": ["간식"],
+                "groups": [
+                    {
+                        "label": "종류",
+                        "items": ["간식캔", "간식파우치", "동결/건조간식", "스낵/캔디", "통살/소시지", "져키/스틱", "져키/트릿"],
+                    },
+                    {
+                        "label": "기능",
+                        "items": ["영양/기능"],
+                    },
+                ],
+            },
+            {
+                "label": "모래",
+                "db_categories": ["모래"],
+                "groups": [
+                    {
+                        "label": "모래 종류",
+                        "items": ["벤토나이트", "두부모래", "카사바/천연모래", "기타모래"],
+                    },
+                ],
+            },
+            {
+                "label": "덴탈/구강",
+                "db_categories": ["덴탈관"],
+                "groups": [
+                    {
+                        "label": "관리 기능",
+                        "items": ["치아관리", "구강관리"],
+                    },
+                    {
+                        "label": "관리 용품",
+                        "items": ["칫솔", "치약"],
+                    },
+                ],
+            },
+            {
+                "label": "배변/위생",
+                "db_categories": ["배변용품"],
+                "groups": [
+                    {
+                        "label": "배변 용품",
+                        "items": ["화장실/위생"],
+                    },
+                    {
+                        "label": "위생 관리",
+                        "items": ["물티슈/클리너", "탈취/소독"],
+                    },
+                ],
+            },
+            {
+                "label": "용품",
+                "db_categories": ["용품"],
+                "groups": [
+                    {
+                        "label": "놀이/리빙",
+                        "items": ["장난감/캣닢", "스크래쳐/캣타워", "하우스/방석"],
+                    },
+                    {
+                        "label": "외출/급식",
+                        "items": ["이동장/캐리어", "급식/급수기"],
+                    },
+                    {
+                        "label": "관리",
+                        "items": ["미용/목욕", "의류/악세사리", "건강관리"],
+                    },
+                ],
+            },
+        ],
+    }
+
+    sections = []
+    for pet_type in pet_labels:
+        categories = []
+        for config in catalog_config[pet_type]:
+            raw_counter = Counter()
+            for db_category in config["db_categories"]:
+                raw_counter.update(grouped_raw[pet_type].get(db_category, Counter()))
+
+            groups = []
+            for group_config in config["groups"]:
+                items = []
+                for subcategory in group_config["items"]:
+                    if raw_counter.get(subcategory, 0) <= 0:
+                        continue
+                    db_category = next(
+                        (
+                            category_name
+                            for category_name in config["db_categories"]
+                            if grouped_raw[pet_type].get(category_name, Counter()).get(subcategory, 0) > 0
+                        ),
+                        config["db_categories"][0],
+                    )
+                    items.append(
+                        {
+                            "label": subcategory,
+                            "href": f"/products/?pet={pet_type}&category={db_category}&subcategory={subcategory}",
+                        }
+                    )
+
+                if not items:
+                    continue
+
+                groups.append(
+                    {
+                        "label": group_config["label"],
+                        "items": items,
+                    }
+                )
+
+            if not groups:
+                continue
+
+            categories.append(
+                {
+                    "label": config["label"],
+                    "href": f"/products/?pet={pet_type}&category={config['db_categories'][0]}",
+                    "groups": groups,
+                }
+            )
+
+        sections.append(
+            {
+                "label": pet_type,
+                "href": f"/products/?pet={pet_type}",
+                "categories": categories,
+            }
+        )
+
+    return sections
 
 
 def _sort_member_pets(pets):
@@ -552,6 +816,7 @@ def chat_view(request):
             "cart_total": _format_price(cart_total),
             "promo_banners": promo_banners,
             "session_threads": session_threads,
+            "catalog_menu_sections": _build_catalog_menu_context(),
             **quick_order_profile,
         },
     )

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1173,10 +1173,42 @@
 
     <div class="absolute left-0 top-0 z-30 h-[72px] w-full pointer-events-none">
       <div class="absolute right-[32px] top-[16px] flex h-[40px] items-center gap-[17px] pointer-events-auto">
-        <div class="h-[36px] w-[72px] rounded-full border border-[#e2e8f0] bg-white">
-          <div class="flex h-full w-full items-center justify-between px-[10px] text-[16px]">
-            <span class="text-[#f6ad55]">☀️</span>
-            <span class="text-[#a0aec0]">🌙</span>
+        <div class="relative h-[40px] w-[40px]" id="catalogMenuWrapper">
+          <button type="button"
+                  class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                  aria-label="상품 목록 열기"
+                  onclick="toggleCatalogMenu()">
+            <svg viewBox="0 0 24 24" class="h-[22px] w-[22px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+              <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+              <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+              <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+            </svg>
+          </button>
+          <div id="catalogMenu"
+               class="absolute right-0 top-[52px] w-[1040px] origin-top-right rounded-[20px] border border-[#dbe7f5] bg-white p-[20px] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] pointer-events-none translate-y-[-8px] scale-95 opacity-0">
+            <div class="mb-[14px] flex items-center justify-between">
+              <div>
+                <p class="text-[15px] font-bold text-[#2d3748]">상품 둘러보기</p>
+                <p class="mt-[4px] text-[12px] leading-[1.5] text-[#718096]">반려동물 유형과 카테고리 기준으로 상품을 빠르게 탐색해보세요</p>
+              </div>
+              <a href="{% if is_preview_member %}#{% else %}/products/{% endif %}"
+                 class="inline-flex h-[32px] items-center rounded-full bg-[#edf2f7] px-[12px] text-[12px] font-bold text-[#4a5568]"
+                 {% if is_preview_member %}onclick="return false"{% endif %}>전체 보기</a>
+            </div>
+            <div id="catalogPetList" class="mb-[14px] flex items-center gap-[8px]"></div>
+            <div class="grid gap-[18px] md:grid-cols-[210px_220px_minmax(0,1fr)]">
+              <div id="catalogCategoryColumn" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[10px]">
+                <div id="catalogCategoryList"></div>
+              </div>
+              <div id="catalogGroupPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[10px]">
+                <div id="catalogGroupList"></div>
+              </div>
+              <div id="catalogSubcategoryPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[14px]">
+                <p id="catalogSubcategoryTitle" class="text-[14px] font-bold text-[#2d3748]"></p>
+                <div id="catalogSubcategoryList" class="mt-[10px] flex flex-wrap gap-[8px]"></div>
+              </div>
+            </div>
           </div>
         </div>
 
@@ -1233,6 +1265,7 @@
 
 {% block scripts %}
 {{ session_threads|json_script:"sessionThreadsData" }}
+{{ catalog_menu_sections|json_script:"catalogMenuData" }}
 <script>
 (function () {
   var DRAWER_WIDTH = 281;
@@ -1248,6 +1281,17 @@
   var pageGate = document.getElementById('pageGate');
   var deleteModal = document.getElementById('deleteModal');
   var quickOrderModal = document.getElementById('quickOrderModal');
+  var catalogMenu = document.getElementById('catalogMenu');
+  var catalogMenuWrapper = document.getElementById('catalogMenuWrapper');
+  var catalogPetList = document.getElementById('catalogPetList');
+  var catalogCategoryColumn = document.getElementById('catalogCategoryColumn');
+  var catalogCategoryList = document.getElementById('catalogCategoryList');
+  var catalogGroupPanel = document.getElementById('catalogGroupPanel');
+  var catalogGroupList = document.getElementById('catalogGroupList');
+  var catalogSubcategoryPanel = document.getElementById('catalogSubcategoryPanel');
+  var catalogSubcategoryTitle = document.getElementById('catalogSubcategoryTitle');
+  var catalogSubcategoryList = document.getElementById('catalogSubcategoryList');
+  var catalogMenuDataNode = document.getElementById('catalogMenuData');
   var profileMenu = document.getElementById('profileMenu');
   var profileWrapper = document.getElementById('profileMenuWrapper');
   var messageInput = document.getElementById('messageInput');
@@ -1295,6 +1339,7 @@
   var chatHistoryList = document.getElementById('chatHistoryList');
   var sessionThreadsNode = document.getElementById('sessionThreadsData');
   var sessionThreads = sessionThreadsNode ? JSON.parse(sessionThreadsNode.textContent) : {};
+  var catalogMenuSections = catalogMenuDataNode ? JSON.parse(catalogMenuDataNode.textContent) : [];
   var csrfToken = getCookie('csrftoken');
 
   var isOpen = false;
@@ -1327,6 +1372,9 @@
   var activePetHealthConcerns = [];
   var activePetAllergies = [];
   var activePetFoodPreferences = [];
+  var activeCatalogPetIndex = 0;
+  var activeCatalogCategoryIndex = 0;
+  var activeCatalogGroupIndex = 0;
 
   function getCookie(name) {
     var cookieValue = null;
@@ -1347,6 +1395,190 @@
       .replace(/>/g, '&gt;')
       .replace(/"/g, '&quot;')
       .replace(/'/g, '&#39;');
+  }
+
+  function buildCatalogLink(href, label, extraClassName, disabled) {
+    var className = extraClassName || '';
+    if (disabled) {
+      return '<span class="' + className + ' cursor-default opacity-60">' + escapeHtml(label) + '</span>';
+    }
+    return '<a href="' + escapeHtml(href || '/products/') + '" class="' + className + '">' + escapeHtml(label) + '</a>';
+  }
+
+  function renderCatalogPetList() {
+    if (!catalogPetList) return;
+    var disabled = {{ is_preview_member|yesno:"true,false" }};
+    catalogPetList.innerHTML = catalogMenuSections.map(function (section, index) {
+      var isActive = index === activeCatalogPetIndex;
+      var buttonClass = isActive
+        ? 'inline-flex items-center rounded-full bg-[#3182ce] px-[14px] py-[8px] text-[13px] font-bold text-white'
+        : 'inline-flex items-center rounded-full border border-[#e2e8f0] bg-white px-[14px] py-[8px] text-[13px] font-semibold text-[#4a5568] transition-colors hover:border-[#bfdbfe] hover:text-[#2b6cb0]';
+      return ''
+        + '<button type="button" class="' + buttonClass + '" data-catalog-pet-index="' + index + '">'
+        + escapeHtml(section.label)
+        + '</button>';
+    }).join('');
+
+    Array.prototype.forEach.call(catalogPetList.querySelectorAll('[data-catalog-pet-index]'), function (button) {
+      button.addEventListener('mouseenter', function () {
+        setActiveCatalogPet(Number(button.getAttribute('data-catalog-pet-index') || '0'));
+      });
+      button.addEventListener('focus', function () {
+        setActiveCatalogPet(Number(button.getAttribute('data-catalog-pet-index') || '0'));
+      });
+      button.addEventListener('click', function () {
+        setActiveCatalogPet(Number(button.getAttribute('data-catalog-pet-index') || '0'));
+      });
+    });
+  }
+
+  function renderCatalogCategoryList() {
+    if (!catalogCategoryList) return;
+    var section = catalogMenuSections[activeCatalogPetIndex] || { categories: [] };
+    var disabled = {{ is_preview_member|yesno:"true,false" }};
+    if (!section.categories.length) {
+      catalogCategoryList.innerHTML = '';
+      activeCatalogCategoryIndex = -1;
+      activeCatalogGroupIndex = -1;
+      return;
+    }
+    catalogCategoryList.innerHTML = section.categories.map(function (category, index) {
+      var isActive = index === activeCatalogCategoryIndex;
+      var href = disabled ? '#' : (category.href || '/products/');
+      var linkClass = isActive
+        ? 'flex w-full items-center justify-between rounded-[14px] bg-[#edf6ff] px-[12px] py-[10px] text-left text-[13px] font-bold text-[#2b6cb0]'
+        : 'flex w-full items-center justify-between rounded-[14px] px-[12px] py-[10px] text-left text-[13px] font-semibold text-[#4a5568] transition-colors hover:bg-[#f7fafc] hover:text-[#2b6cb0]';
+      return ''
+        + '<div class="space-y-[6px]">'
+        + buildCatalogLink(href, category.label, linkClass, disabled)
+        + '</div>';
+    }).join('');
+
+    Array.prototype.forEach.call(catalogCategoryList.children, function (node, index) {
+      node.addEventListener('mouseenter', function () {
+        setActiveCatalogCategory(index);
+      });
+      node.addEventListener('focusin', function () {
+        setActiveCatalogCategory(index);
+      });
+    });
+  }
+
+  function renderCatalogGroupList() {
+    if (!catalogGroupList) return;
+    var section = catalogMenuSections[activeCatalogPetIndex] || { categories: [] };
+    var category = section.categories[activeCatalogCategoryIndex];
+    if (!category || !(category.groups || []).length) {
+      catalogGroupList.innerHTML = '';
+      activeCatalogGroupIndex = -1;
+      return;
+    }
+
+    catalogGroupList.innerHTML = category.groups.map(function (group, index) {
+      var isActive = index === activeCatalogGroupIndex;
+      var groupClass = isActive
+        ? 'flex w-full items-center rounded-[14px] bg-[#edf6ff] px-[12px] py-[10px] text-left text-[13px] font-bold text-[#2b6cb0]'
+        : 'flex w-full items-center rounded-[14px] px-[12px] py-[10px] text-left text-[13px] font-semibold text-[#4a5568] transition-colors hover:bg-[#f7fafc] hover:text-[#2b6cb0]';
+      return '<button type="button" class="' + groupClass + '" data-catalog-group-index="' + index + '">' + escapeHtml(group.label) + '</button>';
+    }).join('');
+
+    Array.prototype.forEach.call(catalogGroupList.querySelectorAll('[data-catalog-group-index]'), function (button) {
+      button.addEventListener('mouseenter', function () {
+        setActiveCatalogGroup(Number(button.getAttribute('data-catalog-group-index') || '0'));
+      });
+      button.addEventListener('focus', function () {
+        setActiveCatalogGroup(Number(button.getAttribute('data-catalog-group-index') || '0'));
+      });
+      button.addEventListener('click', function () {
+        setActiveCatalogGroup(Number(button.getAttribute('data-catalog-group-index') || '0'));
+      });
+    });
+  }
+
+  function renderCatalogSubcategories() {
+    if (!catalogSubcategoryPanel || !catalogSubcategoryTitle || !catalogSubcategoryList) return;
+    var section = catalogMenuSections[activeCatalogPetIndex] || { categories: [] };
+    var category = section.categories[activeCatalogCategoryIndex];
+    var group = category && (category.groups || [])[activeCatalogGroupIndex];
+    var disabled = {{ is_preview_member|yesno:"true,false" }};
+    if (!category || !group) {
+      catalogSubcategoryTitle.textContent = '그룹을 선택해 주세요';
+      catalogSubcategoryList.innerHTML = '';
+      return;
+    }
+
+    catalogSubcategoryTitle.textContent = category.label + ' · ' + group.label;
+    catalogSubcategoryList.innerHTML = (group.items || []).map(function (subcategory) {
+      return buildCatalogLink(
+        disabled ? '#' : (subcategory.href || category.href || '/products/'),
+        subcategory.label,
+        'inline-flex items-center rounded-full border border-[#dbe7f5] bg-white px-[10px] py-[6px] text-[12px] font-medium text-[#4a5568] transition-colors hover:border-[#90cdf4] hover:text-[#2b6cb0]',
+        disabled
+      );
+    }).join('');
+  }
+
+  function setActiveCatalogPet(index) {
+    if (!catalogMenuSections.length) return;
+    activeCatalogPetIndex = Math.max(0, Math.min(index, catalogMenuSections.length - 1));
+    activeCatalogCategoryIndex = 0;
+    activeCatalogGroupIndex = 0;
+    renderCatalogPetList();
+    renderCatalogCategoryList();
+    renderCatalogGroupList();
+    renderCatalogSubcategories();
+  }
+
+  function setActiveCatalogCategory(index) {
+    var section = catalogMenuSections[activeCatalogPetIndex] || { categories: [] };
+    if (!section.categories.length) {
+      activeCatalogCategoryIndex = 0;
+      activeCatalogGroupIndex = 0;
+      renderCatalogCategoryList();
+      renderCatalogGroupList();
+      renderCatalogSubcategories();
+      return;
+    }
+    activeCatalogCategoryIndex = Math.max(0, Math.min(index, section.categories.length - 1));
+    activeCatalogGroupIndex = 0;
+    renderCatalogCategoryList();
+    renderCatalogGroupList();
+    renderCatalogSubcategories();
+  }
+
+  function setActiveCatalogGroup(index) {
+    var section = catalogMenuSections[activeCatalogPetIndex] || { categories: [] };
+    var category = section.categories[activeCatalogCategoryIndex] || { groups: [] };
+    if (!category.groups.length) {
+      activeCatalogGroupIndex = 0;
+      renderCatalogGroupList();
+      renderCatalogSubcategories();
+      return;
+    }
+    activeCatalogGroupIndex = Math.max(0, Math.min(index, category.groups.length - 1));
+    renderCatalogGroupList();
+    renderCatalogSubcategories();
+  }
+
+  function initializeCatalogMenu() {
+    if (!catalogMenuSections.length) return;
+    activeCatalogPetIndex = 0;
+    activeCatalogCategoryIndex = 0;
+    activeCatalogGroupIndex = 0;
+    renderCatalogPetList();
+    renderCatalogCategoryList();
+    renderCatalogGroupList();
+    renderCatalogSubcategories();
+  }
+
+  function closeCatalogMenu(resetState) {
+    if (!catalogMenu) return;
+    catalogMenu.style.opacity = '0';
+    catalogMenu.style.transform = 'translateY(-8px) scale(0.95)';
+    catalogMenu.style.pointerEvents = 'none';
+    if (resetState) {
+      initializeCatalogMenu();
+    }
   }
 
   function splitBrandAndName(brand, name) {
@@ -1609,15 +1841,42 @@
     closeSidebar();
   });
 
+  window.toggleCatalogMenu = function () {
+    if (!catalogMenu) return;
+    var open = catalogMenu.style.opacity === '1';
+    if (open) {
+      closeCatalogMenu(true);
+    } else {
+      initializeCatalogMenu();
+      catalogMenu.style.opacity = '1';
+      catalogMenu.style.transform = 'translateY(0) scale(1)';
+      catalogMenu.style.pointerEvents = 'auto';
+    }
+    if (!open && profileMenu) {
+      profileMenu.style.opacity = '0';
+      profileMenu.style.transform = 'translateY(-8px) scale(0.95)';
+      profileMenu.style.pointerEvents = 'none';
+    }
+  };
+
   window.toggleProfileMenu = function () {
     if (!profileMenu) return;
     var open = profileMenu.style.opacity === '1';
     profileMenu.style.opacity = open ? '0' : '1';
     profileMenu.style.transform = open ? 'translateY(-8px) scale(0.95)' : 'translateY(0) scale(1)';
     profileMenu.style.pointerEvents = open ? 'none' : 'auto';
+    if (!open && catalogMenu) {
+      catalogMenu.style.opacity = '0';
+      catalogMenu.style.transform = 'translateY(-8px) scale(0.95)';
+      catalogMenu.style.pointerEvents = 'none';
+    }
   };
 
   document.addEventListener('mousedown', function (e) {
+    if (catalogMenuWrapper && !catalogMenuWrapper.contains(e.target) && catalogMenu) {
+      closeCatalogMenu(true);
+    }
+
     if (profileWrapper && !profileWrapper.contains(e.target) && profileMenu) {
       profileMenu.style.opacity = '0';
       profileMenu.style.transform = 'translateY(-8px) scale(0.95)';
@@ -1628,6 +1887,8 @@
       closePetDropdown();
     }
   });
+
+  initializeCatalogMenu();
 
   function openPetDropdown() {
     if (!petDropdownMenu || !petDropdownButton || !petDropdownChevron) return;

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1186,7 +1186,7 @@
             </svg>
           </button>
           <div id="catalogMenu"
-               class="absolute right-0 top-[52px] w-[1040px] origin-top-right rounded-[20px] border border-[#dbe7f5] bg-white p-[20px] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] pointer-events-none translate-y-[-8px] scale-95 opacity-0">
+               class="fixed z-[90] origin-top-right overflow-y-auto rounded-[20px] border border-[#dbe7f5] bg-white p-[20px] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] pointer-events-none translate-y-[-8px] scale-95 opacity-0">
             <div class="mb-[14px] flex items-center justify-between">
               <div>
                 <p class="text-[15px] font-bold text-[#2d3748]">상품 둘러보기</p>
@@ -1197,16 +1197,18 @@
                  {% if is_preview_member %}onclick="return false"{% endif %}>전체 보기</a>
             </div>
             <div id="catalogPetList" class="mb-[14px] flex items-center gap-[8px]"></div>
-            <div class="grid gap-[18px] md:grid-cols-[210px_220px_minmax(0,1fr)]">
+            <div class="grid gap-[18px] md:grid-cols-[210px_minmax(0,1fr)] xl:grid-cols-[210px_220px_minmax(0,1fr)]">
               <div id="catalogCategoryColumn" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[10px]">
                 <div id="catalogCategoryList"></div>
               </div>
-              <div id="catalogGroupPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[10px]">
-                <div id="catalogGroupList"></div>
-              </div>
-              <div id="catalogSubcategoryPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[14px]">
-                <p id="catalogSubcategoryTitle" class="text-[14px] font-bold text-[#2d3748]"></p>
-                <div id="catalogSubcategoryList" class="mt-[10px] flex flex-wrap gap-[8px]"></div>
+              <div class="grid gap-[18px] xl:contents">
+                <div id="catalogGroupPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[10px]">
+                  <div id="catalogGroupList"></div>
+                </div>
+                <div id="catalogSubcategoryPanel" class="rounded-[18px] border border-[#edf2f7] bg-[#f8fbff] p-[14px]">
+                  <p id="catalogSubcategoryTitle" class="text-[14px] font-bold text-[#2d3748]"></p>
+                  <div id="catalogSubcategoryList" class="mt-[10px] flex flex-wrap gap-[8px]"></div>
+                </div>
               </div>
             </div>
           </div>
@@ -1341,6 +1343,10 @@
   var sessionThreads = sessionThreadsNode ? JSON.parse(sessionThreadsNode.textContent) : {};
   var catalogMenuSections = catalogMenuDataNode ? JSON.parse(catalogMenuDataNode.textContent) : [];
   var csrfToken = getCookie('csrftoken');
+
+  if (catalogMenu && catalogMenu.parentElement !== document.body) {
+    document.body.appendChild(catalogMenu);
+  }
 
   var isOpen = false;
   var pendingDeleteId = null;
@@ -1569,6 +1575,18 @@
     renderCatalogCategoryList();
     renderCatalogGroupList();
     renderCatalogSubcategories();
+  }
+
+  function positionCatalogMenu() {
+    if (!catalogMenu || !catalogMenuWrapper) return;
+    var rect = catalogMenuWrapper.getBoundingClientRect();
+    var menuWidth = Math.min(1040, Math.max(420, window.innerWidth - 48));
+    var left = Math.max(24, rect.right - menuWidth);
+    var top = rect.bottom + 12;
+    catalogMenu.style.width = menuWidth + 'px';
+    catalogMenu.style.left = left + 'px';
+    catalogMenu.style.top = top + 'px';
+    catalogMenu.style.maxHeight = Math.min(window.innerHeight * 0.72, 760) + 'px';
   }
 
   function closeCatalogMenu(resetState) {
@@ -1848,6 +1866,7 @@
       closeCatalogMenu(true);
     } else {
       initializeCatalogMenu();
+      positionCatalogMenu();
       catalogMenu.style.opacity = '1';
       catalogMenu.style.transform = 'translateY(0) scale(1)';
       catalogMenu.style.pointerEvents = 'auto';
@@ -1872,8 +1891,19 @@
     }
   };
 
+  window.addEventListener('resize', function () {
+    if (catalogMenu && catalogMenu.style.opacity === '1') {
+      positionCatalogMenu();
+    }
+  });
+
   document.addEventListener('mousedown', function (e) {
-    if (catalogMenuWrapper && !catalogMenuWrapper.contains(e.target) && catalogMenu) {
+    if (
+      catalogMenu &&
+      catalogMenuWrapper &&
+      !catalogMenuWrapper.contains(e.target) &&
+      !catalogMenu.contains(e.target)
+    ) {
       closeCatalogMenu(true);
     }
 


### PR DESCRIPTION
## 작업 내용
- 헤더 상품 아이콘 드롭다운 구조를 정리했습니다.
- 강아지/고양이 기준 2차 카테고리와 3·4차 분류 UI를 정리했습니다.
- raw DB 카테고리/서브카테고리 값을 기준으로 실제 링크가 연결되도록 매핑했습니다.
- 드롭다운이 바깥 클릭에서만 닫히고, 화면 폭 변화에도 위치와 크기가 안정적으로 유지되도록 정리했습니다.

## 확인 사항
- 상품 아이콘 클릭 시 드롭다운이 열립니다.
- 강아지/고양이 카테고리 구조가 노출됩니다.
- 카테고리 항목 클릭 시 raw DB 값 기준 링크로 이동합니다.
- 바깥 클릭 시에만 드롭다운이 닫히고, 창 크기 변경에도 레이아웃이 크게 깨지지 않습니다.

## 참고
- 실제 상품 목록 페이지 구현은 후속 이슈에서 분리 진행 예정입니다.

refs #240