### PR TITLE
[feat] 상품 목록 페이지 구현 (#243)

### DIFF
--- a/infra/nginx/nginx.conf
+++ b/infra/nginx/nginx.conf
@@ -2,17 +2,13 @@ http {
     include /etc/nginx/mime.types;
     default_type application/octet-stream;
 
-    upstream django {
-        server django:8000;
-    }
-
-    upstream fastapi {
-        server fastapi:8001;
-    }
+    resolver 127.0.0.11 valid=10s ipv6=off;
 
     server {
         listen 80;
         server_name _;
+        set $django_upstream http://django:8000;
+        set $fastapi_upstream http://fastapi:8001;
 
         location /static/ {
             alias /var/www/static/;
@@ -24,7 +20,7 @@ http {
 
         # FastAPI — 챗봇 / 추천
         location /api/chat/ {
-            proxy_pass http://django;
+            proxy_pass $django_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             # SSE 스트리밍 지원
@@ -34,33 +30,33 @@ http {
         }
 
         location /api/recommend/ {
-            proxy_pass http://fastapi;
+            proxy_pass $fastapi_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
 
         location /api/products/ {
-            proxy_pass http://fastapi;
+            proxy_pass $fastapi_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
 
         # Django — Auth / User / Pet / Order / Admin
         location /api/ {
-            proxy_pass http://django;
+            proxy_pass $django_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
 
         location /admin/ {
-            proxy_pass http://django;
+            proxy_pass $django_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }
 
         # Django — Template (MVT)
         location / {
-            proxy_pass http://django;
+            proxy_pass $django_upstream;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
         }

--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -1,5 +1,4 @@
 import json
-from collections import Counter, defaultdict
 
 from django.db.models import Q
 from django.shortcuts import redirect, render
@@ -7,6 +6,7 @@ from django.views.decorators.csrf import ensure_csrf_cookie
 
 from orders.models import Cart
 from pets.future_profile import get_future_pet_profile_for_request
+from products.catalog_menu import build_catalog_menu_context
 from products.models import Product
 from users.onboarding import get_onboarding_redirect_url
 
@@ -214,169 +214,7 @@ def _serialize_future_pet(profile):
 
 
 def _build_catalog_menu_context():
-    pet_labels = ["강아지", "고양이"]
-    rows = Product.objects.filter(soldout_yn=False).values_list("pet_type", "category", "subcategory")[:5000]
-    grouped_raw = {label: defaultdict(Counter) for label in pet_labels}
-
-    for pet_types, categories, subcategories in rows:
-        normalized_pet_types = [value for value in (pet_types or []) if value in pet_labels]
-        normalized_categories = [value for value in (categories or []) if value]
-        normalized_subcategories = [value for value in (subcategories or []) if value]
-
-        for pet_type in normalized_pet_types:
-            for category in normalized_categories:
-                for subcategory in normalized_subcategories or ["(없음)"]:
-                    grouped_raw[pet_type][category][subcategory] += 1
-
-    category_order = {
-        "강아지": ["사료", "간식", "용품", "배변용품", "덴탈관"],
-        "고양이": ["사료", "간식", "용품", "모래", "습식관"],
-    }
-    category_labels = {}
-    group_definitions = {
-        "강아지": {
-            "사료": [
-                ("급여 연령", ["퍼피(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
-                ("종류", ["건식사료", "화식", "소프트사료", "습식사료", "동결건조/에어드라이"]),
-                ("기능", ["처방식", "눈/눈물", "체중조절", "피부/모질", "위장/소화", "관절", "중성화", "스트레스 완화", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "견종별"]),
-                ("주요 브랜드", ["아카나", "오리젠"]),
-                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한임박", "유통기한 임박")]),
-            ],
-            "간식": [
-                ("전체", ["덴탈껌", "원물/뼈간식", "캔/파우치", "져키/트릿", "비스킷/쿠키", "사사미", "통살/소시지", "동결/건조간식", "수제간식", "파우더", "음료/분유/우유", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
-            ],
-            "용품": [
-                ("전체", ["구강관리", "건강관리", "미용/목욕", "급식/급수기", "장난감/훈련", "의류/악세사리", "하우스/방석", "이동장/캐리어", "목줄/하네스", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
-            ],
-            "덴탈관": [
-                ("전체", ["수의사인증", "덴탈껌", "칫솔", "치약", "원물/뼈간식"]),
-            ],
-            "배변용품": [
-                ("전체", ["배변패드", "배변판", "기저귀/팬티", "탈취/소독", "배변봉투/집게", "배변유도제", "물티슈/클리너"]),
-            ],
-        },
-        "고양이": {
-            "사료": [
-                ("급여 연령", ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
-                ("종류", ["주식캔", "건식", "주식파우치", "에어/동결건조"]),
-                ("기능", ["처방식", "헤어볼", "피부/피모", "위장/소화", "요로기계", "체중조절", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "면역력", "묘종별"]),
-                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한 임박", "유통기한 임박")]),
-            ],
-            "습식관": [
-                ("전체", ["주식캔", "주식파우치"]),
-            ],
-            "간식": [
-                ("전체", ["간식캔", "간식파우치", "동결/건조간식", "스낵/캔디", "져키/스틱", "통살/소시지", "음료", "파우더/토퍼", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
-            ],
-            "모래": [
-                ("전체", ["두부모래", "카사바/천연모래", "벤토나이트", ("기타 모래", "기타모래")]),
-            ],
-            "용품": [
-                ("전체", ["건강관리", "장난감/캣닢", "스크래쳐/캣타워", "치아관리", "화장실/위생", "미용/목욕", "급식/급수기", "의류/악세사리", "하우스/방석", "이동장/캐리어", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
-            ],
-        },
-    }
-    strict_category_groups = {
-        "강아지": {"사료", "간식", "용품", "배변용품", "덴탈관"},
-        "고양이": {"사료", "습식관", "간식", "용품", "모래"},
-    }
-    strict_category_order_pets = {"강아지", "고양이"}
-
-    def build_category_href(pet_type, category):
-        if category:
-            return f"/products/?pet={pet_type}&category={category}"
-        return f"/products/?pet={pet_type}"
-
-    sections = []
-    for pet_type in pet_labels:
-        categories = []
-        ordered_categories = []
-        seen_categories = set()
-        for category in category_order.get(pet_type, []):
-            if category in grouped_raw[pet_type]:
-                ordered_categories.append(category)
-                seen_categories.add(category)
-        if pet_type not in strict_category_order_pets:
-            for category, _counter in sorted(grouped_raw[pet_type].items(), key=lambda item: (-sum(item[1].values()), item[0])):
-                if category not in seen_categories:
-                    ordered_categories.append(category)
-
-        for category in ordered_categories:
-            raw_counter = grouped_raw[pet_type].get(category, Counter())
-            if not raw_counter:
-                continue
-
-            group_config = group_definitions.get(pet_type, {}).get(category, [])
-            used_subcategories = set()
-            groups = []
-            for group_label, group_items in group_config:
-                items = []
-                for subcategory in group_items:
-                    display_label = subcategory
-                    raw_value = subcategory
-                    is_brand = False
-                    if isinstance(subcategory, (tuple, list)) and len(subcategory) >= 2:
-                        display_label = subcategory[0]
-                        raw_value = subcategory[1]
-                    if category == "사료" and group_label == "주요 브랜드":
-                        is_brand = True
-                        brand_products = Product.objects.filter(
-                            soldout_yn=False,
-                            pet_type__contains=[pet_type],
-                            brand_name=raw_value,
-                        )
-                        if not brand_products.exists():
-                            continue
-                    elif raw_counter.get(raw_value, 0) <= 0:
-                        continue
-                    if not is_brand:
-                        used_subcategories.add(raw_value)
-                    href = build_category_href(pet_type, category)
-                    if is_brand:
-                        href += f"&brand={raw_value}"
-                    elif category:
-                        href += f"&subcategory={raw_value}"
-                    else:
-                        href = f"/products/?pet={pet_type}&subcategory={raw_value}"
-                    items.append({"label": display_label, "href": href})
-                if items:
-                    groups.append({"label": group_label, "items": items})
-
-            remaining = []
-            if category not in strict_category_groups.get(pet_type, set()):
-                remaining = [
-                    subcategory
-                    for subcategory, _count in sorted(raw_counter.items(), key=lambda item: (-item[1], item[0]))
-                    if subcategory not in used_subcategories
-                ]
-            if remaining:
-                items = []
-                for subcategory in remaining:
-                    href = build_category_href(pet_type, category)
-                    if category:
-                        href += f"&subcategory={subcategory}"
-                    else:
-                        href = f"/products/?pet={pet_type}&subcategory={subcategory}"
-                    items.append({"label": subcategory, "href": href})
-                groups.append({"label": "기타", "items": items})
-
-            categories.append(
-                {
-                    "label": category_labels.get(category, category),
-                    "href": build_category_href(pet_type, category),
-                    "groups": groups,
-                }
-            )
-
-        sections.append(
-            {
-                "label": pet_type,
-                "href": f"/products/?pet={pet_type}",
-                "categories": categories,
-            }
-        )
-
-    return sections
+    return build_catalog_menu_context()
 
 
 def _sort_member_pets(pets):

--- a/services/django/orders/page_urls.py
+++ b/services/django/orders/page_urls.py
@@ -5,4 +5,5 @@ urlpatterns = [
     path("orders/", page_views.order_list, name="order_list"),
     path("orders/complete/<uuid:order_id>/", page_views.order_complete, name="order_complete"),
     path("products/", page_views.used_products, name="used_products"),
+    path("catalog/", page_views.catalog, name="catalog"),
 ]

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,8 +1,11 @@
+from urllib.parse import parse_qs, urlencode, urlparse
+
 from django.db.models import Q
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
 
+from products.catalog_menu import build_catalog_menu_context
 from products.models import Product
 from .models import Cart, Order, Wishlist
 
@@ -113,6 +116,7 @@ ORDER_LIST_ORDERING = {
     "oldest": {"label": "오래된순", "queryset": "created_at"},
 }
 DEFAULT_ORDER_PAGE_SIZE = 12
+DEFAULT_CATALOG_PAGE_SIZE = 24
 
 
 def _serialize_order_item(product, quantity=1):
@@ -125,6 +129,82 @@ def _serialize_order_item(product, quantity=1):
         "unit_price": _format_price(product.price),
         "price": _format_price(product.price * quantity),
     }
+
+
+def _serialize_catalog_item(product):
+    return {
+        "product_id": product.goods_id,
+        "thumbnail_url": product.thumbnail_url,
+        "product_url": product.product_url,
+        "brand_name": product.brand_name,
+        "name": _display_product_name(product.brand_name, product.goods_name),
+        "summary": _product_summary(product),
+        "price": product.price,
+        "price_label": _format_price(product.price),
+        "rating": f"{product.rating:.1f}" if product.rating is not None else None,
+        "review_count": product.review_count or 0,
+        "pet_type": product.pet_type,
+        "category": product.category,
+        "subcategory": product.subcategory,
+    }
+
+
+def _catalog_query_params(request, overrides=None):
+    params = {}
+    for key in ("pet", "category", "subcategory", "brand", "page"):
+        value = (request.GET.get(key) or "").strip()
+        if value:
+            params[key] = value
+    if overrides:
+        for key, value in overrides.items():
+            if value:
+                params[key] = value
+            else:
+                params.pop(key, None)
+    if not params:
+        return ""
+    return "&".join(f"{key}={value}" for key, value in params.items())
+
+
+def _build_catalog_filter_options(queryset, field_name):
+    values = []
+    for row in queryset.values_list(field_name, flat=True):
+        if not row:
+            continue
+        for item in row:
+            if item and item not in values:
+                values.append(item)
+    return values
+
+
+def _catalog_querystring(current_params, **overrides):
+    params = dict(current_params)
+    for key, value in overrides.items():
+        if value is None or value == "":
+            params.pop(key, None)
+        else:
+            params[key] = value
+    page_value = params.get("page")
+    if page_value in {"", None, 1, "1"}:
+        params.pop("page", None)
+    if not params:
+        return ""
+    return urlencode(params)
+
+
+def _href_query_matches(href, current_params):
+    parsed = parse_qs(urlparse(href).query)
+    for key in ("pet", "category", "subcategory", "brand"):
+        current_value = (current_params.get(key) or "").strip()
+        href_value = (parsed.get(key) or [""])[0].strip()
+        if current_value != href_value:
+            return False
+    return True
+
+
+def _query_value_from_href(href, key):
+    parsed = parse_qs(urlparse(href).query)
+    return (parsed.get(key) or [""])[0].strip()
 
 
 def _serialize_order_group(order):
@@ -632,6 +712,119 @@ def used_products(request):
             "active_tab": active_tab,
         },
     )
+
+
+@login_required
+def catalog(request):
+    pet = (request.GET.get("pet") or "").strip()
+    category = (request.GET.get("category") or "").strip()
+    subcategory = (request.GET.get("subcategory") or "").strip()
+    brand = (request.GET.get("brand") or "").strip()
+
+    queryset = Product.objects.filter(soldout_yn=False)
+    if pet:
+        queryset = queryset.filter(pet_type__contains=[pet])
+    if category:
+        queryset = queryset.filter(category__contains=[category])
+    if subcategory:
+        queryset = queryset.filter(subcategory__contains=[subcategory])
+    if brand:
+        queryset = queryset.filter(brand_name=brand)
+
+    queryset = queryset.order_by("-popularity_score", "-review_count", "goods_name")
+    paginator = Paginator(queryset, DEFAULT_CATALOG_PAGE_SIZE)
+    page_obj = paginator.get_page(request.GET.get("page") or 1)
+
+    current_params = {
+        "pet": pet,
+        "category": category,
+        "subcategory": subcategory,
+        "brand": brand,
+        "page": request.GET.get("page") or "",
+    }
+    catalog_menu_sections = build_catalog_menu_context()
+    selected_pet_section = next((section for section in catalog_menu_sections if section["label"] == pet), None)
+    selected_category = None
+    if selected_pet_section and category:
+        selected_category = next(
+            (
+                item
+                for item in selected_pet_section["categories"]
+                if item["label"] == category or _query_value_from_href(item["href"], "category") == category
+            ),
+            None,
+        )
+        if selected_category is None:
+            selected_category = next(
+                (
+                    item
+                    for item in selected_pet_section["categories"]
+                    if any(
+                        _href_query_matches(entry["href"], current_params)
+                        for group in item.get("groups", [])
+                        for entry in group.get("items", [])
+                    )
+                ),
+                None,
+            )
+
+    pagination_links = []
+    if paginator.num_pages > 1:
+        start_page = max(page_obj.number - 2, 1)
+        end_page = min(start_page + 4, paginator.num_pages)
+        start_page = max(end_page - 4, 1)
+        for number in range(start_page, end_page + 1):
+            pagination_links.append(
+                {
+                    "number": number,
+                    "is_active": page_obj.number == number,
+                    "query": _catalog_querystring(current_params, page=number),
+                }
+            )
+
+    context = {
+        "catalog_items": [_serialize_catalog_item(product) for product in page_obj.object_list],
+        "catalog_count": paginator.count,
+        "catalog_page_obj": page_obj,
+        "catalog_pagination_links": pagination_links,
+        "catalog_prev_query": _catalog_querystring(current_params, page=page_obj.previous_page_number()) if page_obj.has_previous() else "",
+        "catalog_next_query": _catalog_querystring(current_params, page=page_obj.next_page_number()) if page_obj.has_next() else "",
+        "catalog_current_pet": pet,
+        "catalog_current_category": category,
+        "catalog_current_subcategory": subcategory,
+        "catalog_current_brand": brand,
+        "catalog_menu_sections": [
+            {
+                **section,
+                "is_active": section["label"] == pet,
+            }
+            for section in catalog_menu_sections
+        ],
+        "catalog_category_options": [
+            {
+                **item,
+                "is_active": item["label"] == category,
+            }
+            for item in (selected_pet_section["categories"] if selected_pet_section else [])
+        ],
+        "catalog_group_options": [
+            {
+                "label": group["label"],
+                "items": [
+                    {
+                        **entry,
+                        "is_active": _href_query_matches(entry["href"], current_params),
+                    }
+                    for entry in group["items"]
+                ],
+            }
+            for group in (selected_category["groups"] if selected_category else [])
+        ],
+        "catalog_query_all": _catalog_querystring(current_params, page=None),
+        "catalog_clear_category_query": _catalog_querystring(current_params, category=None, subcategory=None, brand=None, page=None),
+        "catalog_clear_detail_query": _catalog_querystring(current_params, subcategory=None, brand=None, page=None),
+    }
+    return render(request, "orders/catalog.html", context)
 
 
 @login_required

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,6 +1,7 @@
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from django.db.models import Q
+from django.db.models import DecimalField, IntegerField, Q, Value
+from django.db.models.functions import Coalesce
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, render
@@ -117,6 +118,24 @@ ORDER_LIST_ORDERING = {
 }
 DEFAULT_ORDER_PAGE_SIZE = 12
 DEFAULT_CATALOG_PAGE_SIZE = 24
+CATALOG_SORT_OPTIONS = {
+    "tailtalk": {
+        "label": "TailTalk 추천순",
+        "ordering": ("-_sort_popularity_score", "-_sort_review_count", "-_sort_rating", "goods_name"),
+    },
+    "reviews": {
+        "label": "리뷰 많은순",
+        "ordering": ("-_sort_review_count", "-_sort_popularity_score", "-_sort_rating", "goods_name"),
+    },
+    "price_low": {
+        "label": "가격 낮은순",
+        "ordering": ("price", "-_sort_review_count", "-_sort_popularity_score", "goods_name"),
+    },
+    "price_high": {
+        "label": "가격 높은순",
+        "ordering": ("-price", "-_sort_review_count", "-_sort_popularity_score", "goods_name"),
+    },
+}
 
 
 def _serialize_order_item(product, quantity=1):
@@ -175,6 +194,26 @@ def _build_catalog_filter_options(queryset, field_name):
             if item and item not in values:
                 values.append(item)
     return values
+
+
+def _with_catalog_sort_fields(queryset):
+    return queryset.annotate(
+        _sort_popularity_score=Coalesce(
+            "popularity_score",
+            Value(0),
+            output_field=DecimalField(max_digits=10, decimal_places=4),
+        ),
+        _sort_review_count=Coalesce(
+            "review_count",
+            Value(0),
+            output_field=IntegerField(),
+        ),
+        _sort_rating=Coalesce(
+            "rating",
+            Value(0),
+            output_field=DecimalField(max_digits=3, decimal_places=1),
+        ),
+    )
 
 
 def _catalog_querystring(current_params, **overrides):
@@ -720,6 +759,9 @@ def catalog(request):
     category = (request.GET.get("category") or "").strip()
     subcategory = (request.GET.get("subcategory") or "").strip()
     brand = (request.GET.get("brand") or "").strip()
+    sort_key = (request.GET.get("sort") or "tailtalk").strip()
+    if sort_key not in CATALOG_SORT_OPTIONS:
+        sort_key = "tailtalk"
 
     queryset = Product.objects.filter(soldout_yn=False)
     if pet:
@@ -731,7 +773,7 @@ def catalog(request):
     if brand:
         queryset = queryset.filter(brand_name=brand)
 
-    queryset = queryset.order_by("-popularity_score", "-review_count", "goods_name")
+    queryset = _with_catalog_sort_fields(queryset).order_by(*CATALOG_SORT_OPTIONS[sort_key]["ordering"])
     paginator = Paginator(queryset, DEFAULT_CATALOG_PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get("page") or 1)
 
@@ -740,6 +782,7 @@ def catalog(request):
         "category": category,
         "subcategory": subcategory,
         "brand": brand,
+        "sort": sort_key,
         "page": request.GET.get("page") or "",
     }
     catalog_menu_sections = build_catalog_menu_context()
@@ -793,6 +836,16 @@ def catalog(request):
         "catalog_current_category": category,
         "catalog_current_subcategory": subcategory,
         "catalog_current_brand": brand,
+        "catalog_current_sort": sort_key,
+        "catalog_sort_options": [
+            {
+                "key": key,
+                "label": option["label"],
+                "is_active": key == sort_key,
+                "query": _catalog_querystring(current_params, sort=key, page=None),
+            }
+            for key, option in CATALOG_SORT_OPTIONS.items()
+        ],
         "catalog_menu_sections": [
             {
                 **section,

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -196,6 +196,11 @@ def _build_catalog_filter_options(queryset, field_name):
     return values
 
 
+def _catalog_brand_sort_key(value):
+    normalized = (value or "").strip()
+    return tuple(ord(char) for char in normalized)
+
+
 def _with_catalog_sort_fields(queryset):
     return queryset.annotate(
         _sort_popularity_score=Coalesce(
@@ -231,9 +236,9 @@ def _catalog_querystring(current_params, **overrides):
     return urlencode(params)
 
 
-def _href_query_matches(href, current_params):
+def _href_query_matches(href, current_params, keys=("pet", "category", "subcategory", "brand")):
     parsed = parse_qs(urlparse(href).query)
-    for key in ("pet", "category", "subcategory", "brand"):
+    for key in keys:
         current_value = (current_params.get(key) or "").strip()
         href_value = (parsed.get(key) or [""])[0].strip()
         if current_value != href_value:
@@ -763,7 +768,8 @@ def catalog(request):
     if sort_key not in CATALOG_SORT_OPTIONS:
         sort_key = "tailtalk"
 
-    queryset = Product.objects.filter(soldout_yn=False)
+    base_queryset = Product.objects.filter(soldout_yn=False)
+    queryset = base_queryset
     if pet:
         queryset = queryset.filter(pet_type__contains=[pet])
     if category:
@@ -772,6 +778,27 @@ def catalog(request):
         queryset = queryset.filter(subcategory__contains=[subcategory])
     if brand:
         queryset = queryset.filter(brand_name=brand)
+
+    brand_queryset = base_queryset
+    if pet:
+        brand_queryset = brand_queryset.filter(pet_type__contains=[pet])
+    if category:
+        brand_queryset = brand_queryset.filter(category__contains=[category])
+    if subcategory:
+        brand_queryset = brand_queryset.filter(subcategory__contains=[subcategory])
+
+    brand_values = sorted(
+        [
+        value
+        for value in brand_queryset.order_by("brand_name").values_list("brand_name", flat=True).distinct()
+        if value
+        ],
+        key=_catalog_brand_sort_key,
+    )
+    visible_brand_values = brand_values[:10]
+    if brand and brand in brand_values and brand not in visible_brand_values:
+        visible_brand_values.append(brand)
+    hidden_brand_values = [value for value in brand_values if value not in visible_brand_values]
 
     queryset = _with_catalog_sort_fields(queryset).order_by(*CATALOG_SORT_OPTIONS[sort_key]["ordering"])
     paginator = Paginator(queryset, DEFAULT_CATALOG_PAGE_SIZE)
@@ -866,16 +893,37 @@ def catalog(request):
                 "items": [
                     {
                         **entry,
-                        "is_active": _href_query_matches(entry["href"], current_params),
+                        "is_active": _href_query_matches(
+                            entry["href"],
+                            current_params,
+                            keys=("pet", "category", "subcategory"),
+                        ),
                     }
                     for entry in group["items"]
                 ],
             }
             for group in (selected_category["groups"] if selected_category else [])
         ],
+        "catalog_brand_options": [
+            {
+                "label": value,
+                "href": f"/catalog/{('?' + _catalog_querystring(current_params, brand=value, page=None)) if _catalog_querystring(current_params, brand=value, page=None) else ''}",
+                "is_active": value == brand,
+            }
+            for value in visible_brand_values
+        ],
+        "catalog_brand_hidden_options": [
+            {
+                "label": value,
+                "href": f"/catalog/{('?' + _catalog_querystring(current_params, brand=value, page=None)) if _catalog_querystring(current_params, brand=value, page=None) else ''}",
+                "is_active": value == brand,
+            }
+            for value in hidden_brand_values
+        ],
         "catalog_query_all": _catalog_querystring(current_params, page=None),
         "catalog_clear_category_query": _catalog_querystring(current_params, category=None, subcategory=None, brand=None, page=None),
         "catalog_clear_detail_query": _catalog_querystring(current_params, subcategory=None, brand=None, page=None),
+        "catalog_clear_brand_query": _catalog_querystring(current_params, brand=None, page=None),
     }
     return render(request, "orders/catalog.html", context)
 

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -150,7 +150,7 @@ def _serialize_order_item(product, quantity=1):
     }
 
 
-def _serialize_catalog_item(product):
+def _serialize_catalog_item(product, *, is_wishlisted=False, cart_quantity=0):
     return {
         "product_id": product.goods_id,
         "thumbnail_url": product.thumbnail_url,
@@ -165,6 +165,9 @@ def _serialize_catalog_item(product):
         "pet_type": product.pet_type,
         "category": product.category,
         "subcategory": product.subcategory,
+        "is_wishlisted": is_wishlisted,
+        "cart_quantity": cart_quantity,
+        "is_in_cart": cart_quantity > 0,
     }
 
 
@@ -804,6 +807,14 @@ def catalog(request):
     paginator = Paginator(queryset, DEFAULT_CATALOG_PAGE_SIZE)
     page_obj = paginator.get_page(request.GET.get("page") or 1)
 
+    cart, _ = Cart.objects.get_or_create(user=request.user)
+    wishlist, _ = Wishlist.objects.get_or_create(user=request.user)
+    wishlist_product_ids = set(wishlist.items.values_list("product_id", flat=True))
+    cart_quantities = {
+        product_id: quantity
+        for product_id, quantity in cart.items.values_list("product_id", "quantity")
+    }
+
     current_params = {
         "pet": pet,
         "category": category,
@@ -853,7 +864,14 @@ def catalog(request):
             )
 
     context = {
-        "catalog_items": [_serialize_catalog_item(product) for product in page_obj.object_list],
+        "catalog_items": [
+            _serialize_catalog_item(
+                product,
+                is_wishlisted=product.goods_id in wishlist_product_ids,
+                cart_quantity=cart_quantities.get(product.goods_id, 0),
+            )
+            for product in page_obj.object_list
+        ],
         "catalog_count": paginator.count,
         "catalog_page_obj": page_obj,
         "catalog_pagination_links": pagination_links,

--- a/services/django/products/catalog_menu.py
+++ b/services/django/products/catalog_menu.py
@@ -1,0 +1,169 @@
+from collections import Counter, defaultdict
+
+from .models import Product
+
+
+def build_catalog_menu_context():
+    pet_labels = ["강아지", "고양이"]
+    rows = Product.objects.filter(soldout_yn=False).values_list("pet_type", "category", "subcategory")[:5000]
+    grouped_raw = {label: defaultdict(Counter) for label in pet_labels}
+
+    for pet_types, categories, subcategories in rows:
+        normalized_pet_types = [value for value in (pet_types or []) if value in pet_labels]
+        normalized_categories = [value for value in (categories or []) if value]
+        normalized_subcategories = [value for value in (subcategories or []) if value]
+
+        for pet_type in normalized_pet_types:
+            for category in normalized_categories:
+                for subcategory in normalized_subcategories or ["(없음)"]:
+                    grouped_raw[pet_type][category][subcategory] += 1
+
+    category_order = {
+        "강아지": ["사료", "간식", "용품", "배변용품", "덴탈관"],
+        "고양이": ["사료", "간식", "용품", "모래", "습식관"],
+    }
+    category_labels = {}
+    group_definitions = {
+        "강아지": {
+            "사료": [
+                ("급여 연령", ["퍼피(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
+                ("종류", ["건식사료", "화식", "소프트사료", "습식사료", "동결건조/에어드라이"]),
+                ("기능", ["처방식", "눈/눈물", "체중조절", "피부/모질", "위장/소화", "관절", "중성화", "스트레스 완화", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "견종별"]),
+                ("주요 브랜드", ["아카나", "오리젠"]),
+                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한임박", "유통기한 임박")]),
+            ],
+            "간식": [
+                ("전체", ["덴탈껌", "원물/뼈간식", "캔/파우치", "져키/트릿", "비스킷/쿠키", "사사미", "통살/소시지", "동결/건조간식", "수제간식", "파우더", "음료/분유/우유", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "용품": [
+                ("전체", ["구강관리", "건강관리", "미용/목욕", "급식/급수기", "장난감/훈련", "의류/악세사리", "하우스/방석", "이동장/캐리어", "목줄/하네스", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "덴탈관": [
+                ("전체", ["수의사인증", "덴탈껌", "칫솔", "치약", "원물/뼈간식"]),
+            ],
+            "배변용품": [
+                ("전체", ["배변패드", "배변판", "기저귀/팬티", "탈취/소독", "배변봉투/집게", "배변유도제", "물티슈/클리너"]),
+            ],
+        },
+        "고양이": {
+            "사료": [
+                ("급여 연령", ["키튼(1세미만)", "어덜트(1~7세)", "시니어(7세이상)", "전연령"]),
+                ("종류", ["주식캔", "건식", "주식파우치", "에어/동결건조"]),
+                ("기능", ["처방식", "헤어볼", "피부/피모", "위장/소화", "요로기계", "체중조절", ("구강/치아 (덴탈케어)", "구강/치아(덴탈케어)"), "면역력", "묘종별"]),
+                ("기타", [("맛보기 샘플", "맛보기샘플"), ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "습식관": [
+                ("전체", ["주식캔", "주식파우치"]),
+            ],
+            "간식": [
+                ("전체", ["간식캔", "간식파우치", "동결/건조간식", "스낵/캔디", "져키/스틱", "통살/소시지", "음료", "파우더/토퍼", "영양/기능", ("유통기한 임박", "유통기한 임박")]),
+            ],
+            "모래": [
+                ("전체", ["두부모래", "카사바/천연모래", "벤토나이트", ("기타 모래", "기타모래")]),
+            ],
+            "용품": [
+                ("전체", ["건강관리", "장난감/캣닢", "스크래쳐/캣타워", "치아관리", "화장실/위생", "미용/목욕", "급식/급수기", "의류/악세사리", "하우스/방석", "이동장/캐리어", "반려인용품", ("유통기한 임박", "유통기한 임박")]),
+            ],
+        },
+    }
+    strict_category_groups = {
+        "강아지": {"사료", "간식", "용품", "배변용품", "덴탈관"},
+        "고양이": {"사료", "습식관", "간식", "용품", "모래"},
+    }
+    strict_category_order_pets = {"강아지", "고양이"}
+
+    def build_category_href(pet_type, category):
+        if category:
+            return f"/catalog/?pet={pet_type}&category={category}"
+        return f"/catalog/?pet={pet_type}"
+
+    sections = []
+    for pet_type in pet_labels:
+        categories = []
+        ordered_categories = []
+        seen_categories = set()
+        for category in category_order.get(pet_type, []):
+            if category in grouped_raw[pet_type]:
+                ordered_categories.append(category)
+                seen_categories.add(category)
+        if pet_type not in strict_category_order_pets:
+            for category, _counter in sorted(grouped_raw[pet_type].items(), key=lambda item: (-sum(item[1].values()), item[0])):
+                if category not in seen_categories:
+                    ordered_categories.append(category)
+
+        for category in ordered_categories:
+            raw_counter = grouped_raw[pet_type].get(category, Counter())
+            if not raw_counter:
+                continue
+
+            group_config = group_definitions.get(pet_type, {}).get(category, [])
+            used_subcategories = set()
+            groups = []
+            for group_label, group_items in group_config:
+                items = []
+                for subcategory in group_items:
+                    display_label = subcategory
+                    raw_value = subcategory
+                    is_brand = False
+                    if isinstance(subcategory, (tuple, list)) and len(subcategory) >= 2:
+                        display_label = subcategory[0]
+                        raw_value = subcategory[1]
+                    if category == "사료" and group_label == "주요 브랜드":
+                        is_brand = True
+                        brand_products = Product.objects.filter(
+                            soldout_yn=False,
+                            pet_type__contains=[pet_type],
+                            brand_name=raw_value,
+                        )
+                        if not brand_products.exists():
+                            continue
+                    elif raw_counter.get(raw_value, 0) <= 0:
+                        continue
+                    if not is_brand:
+                        used_subcategories.add(raw_value)
+                    href = build_category_href(pet_type, category)
+                    if is_brand:
+                        href += f"&brand={raw_value}"
+                    elif category:
+                        href += f"&subcategory={raw_value}"
+                    else:
+                        href = f"/catalog/?pet={pet_type}&subcategory={raw_value}"
+                    items.append({"label": display_label, "href": href})
+                if items:
+                    groups.append({"label": group_label, "items": items})
+
+            remaining = []
+            if category not in strict_category_groups.get(pet_type, set()):
+                remaining = [
+                    subcategory
+                    for subcategory, _count in sorted(raw_counter.items(), key=lambda item: (-item[1], item[0]))
+                    if subcategory not in used_subcategories
+                ]
+            if remaining:
+                items = []
+                for subcategory in remaining:
+                    href = build_category_href(pet_type, category)
+                    if category:
+                        href += f"&subcategory={subcategory}"
+                    else:
+                        href = f"/catalog/?pet={pet_type}&subcategory={subcategory}"
+                    items.append({"label": subcategory, "href": href})
+                groups.append({"label": "기타", "items": items})
+
+            categories.append(
+                {
+                    "label": category_labels.get(category, category),
+                    "href": build_category_href(pet_type, category),
+                    "groups": groups,
+                }
+            )
+
+        sections.append(
+            {
+                "label": pet_type,
+                "href": f"/catalog/?pet={pet_type}",
+                "categories": categories,
+            }
+        )
+
+    return sections

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1189,10 +1189,9 @@
                class="fixed z-[90] origin-top-right overflow-y-auto rounded-[20px] border border-[#dbe7f5] bg-white p-[20px] transition-all duration-[180ms] ease-[cubic-bezier(0.22,1,0.36,1)] pointer-events-none translate-y-[-8px] scale-95 opacity-0">
             <div class="mb-[14px] flex items-center justify-between">
               <div>
-                <p class="text-[15px] font-bold text-[#2d3748]">상품 둘러보기</p>
-                <p class="mt-[4px] text-[12px] leading-[1.5] text-[#718096]">반려동물 유형과 카테고리 기준으로 상품을 빠르게 탐색해보세요</p>
+                <p class="text-[20px] font-bold text-[#2d3748]">상품 카테고리</p>
               </div>
-              <a href="{% if is_preview_member %}#{% else %}/products/{% endif %}"
+              <a href="{% if is_preview_member %}#{% else %}/catalog/{% endif %}"
                  class="inline-flex h-[32px] items-center rounded-full bg-[#edf2f7] px-[12px] text-[12px] font-bold text-[#4a5568]"
                  {% if is_preview_member %}onclick="return false"{% endif %}>전체 보기</a>
             </div>
@@ -1408,7 +1407,7 @@
     if (disabled) {
       return '<span class="' + className + ' cursor-default opacity-60">' + escapeHtml(label) + '</span>';
     }
-    return '<a href="' + escapeHtml(href || '/products/') + '" class="' + className + '">' + escapeHtml(label) + '</a>';
+    return '<a href="' + escapeHtml(href || '/catalog/') + '" class="' + className + '">' + escapeHtml(label) + '</a>';
   }
 
   function renderCatalogPetList() {
@@ -1450,7 +1449,7 @@
     }
     catalogCategoryList.innerHTML = section.categories.map(function (category, index) {
       var isActive = index === activeCatalogCategoryIndex;
-      var href = disabled ? '#' : (category.href || '/products/');
+      var href = disabled ? '#' : (category.href || '/catalog/');
       var linkClass = isActive
         ? 'flex w-full items-center justify-between rounded-[14px] bg-[#edf6ff] px-[12px] py-[10px] text-left text-[13px] font-bold text-[#2b6cb0]'
         : 'flex w-full items-center justify-between rounded-[14px] px-[12px] py-[10px] text-left text-[13px] font-semibold text-[#4a5568] transition-colors hover:bg-[#f7fafc] hover:text-[#2b6cb0]';
@@ -1516,7 +1515,7 @@
     catalogSubcategoryTitle.textContent = category.label + ' · ' + group.label;
     catalogSubcategoryList.innerHTML = (group.items || []).map(function (subcategory) {
       return buildCatalogLink(
-        disabled ? '#' : (subcategory.href || category.href || '/products/'),
+        disabled ? '#' : (subcategory.href || category.href || '/catalog/'),
         subcategory.label,
         'inline-flex items-center rounded-full border border-[#dbe7f5] bg-white px-[10px] py-[6px] text-[12px] font-medium text-[#4a5568] transition-colors hover:border-[#90cdf4] hover:text-[#2b6cb0]',
         disabled

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -32,6 +32,24 @@
   .catalog-thumb {
     aspect-ratio: 1 / 1;
   }
+
+  .catalog-sort-tooltip-wrap:hover .catalog-sort-tooltip,
+  .catalog-sort-tooltip-wrap:focus-within .catalog-sort-tooltip {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .catalog-sort-select {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    background-image: linear-gradient(45deg, transparent 50%, #718096 50%), linear-gradient(135deg, #718096 50%, transparent 50%);
+    background-position: calc(100% - 18px) calc(50% - 1px), calc(100% - 13px) calc(50% - 1px);
+    background-size: 5px 5px, 5px 5px;
+    background-repeat: no-repeat;
+    padding-right: 38px;
+  }
   @media (max-width: 767px) {
     .catalog-header-stack {
       flex-direction: column;
@@ -123,17 +141,26 @@
               <p class="text-[14px] font-semibold text-[#90a4b8]">검색 결과</p>
               <p class="mt-2 text-[26px] font-bold text-[#2d3748]">{{ catalog_count }}개 상품</p>
             </div>
-            <div class="flex flex-wrap gap-2">
+            <div class="flex flex-wrap items-center justify-end gap-2">
               {% if catalog_current_pet %}
               <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_pet }}</span>
               {% endif %}
               {% if catalog_current_category %}
+              {% if catalog_current_pet %}
+              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+              {% endif %}
               <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_category }}</span>
               {% endif %}
               {% if catalog_current_subcategory %}
+              {% if catalog_current_category %}
+              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+              {% endif %}
               <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_subcategory }}</span>
               {% endif %}
               {% if catalog_current_brand %}
+              {% if catalog_current_subcategory or catalog_current_category %}
+              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+              {% endif %}
               <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_brand }}</span>
               {% endif %}
             </div>
@@ -141,6 +168,29 @@
         </div>
 
         {% if catalog_items %}
+        <div class="mt-6 flex items-center justify-end">
+          <div class="relative">
+            <div class="flex items-center gap-2">
+              <select id="catalogSort"
+                      class="catalog-sort-select h-[36px] rounded-full border border-[#dbe7f5] bg-white pl-4 text-[12px] font-semibold text-[#4a5568] outline-none transition-colors focus:border-[#90cdf4]"
+                      onchange="if (this.value) { window.location.href = this.value; }">
+                {% for option in catalog_sort_options %}
+                <option value="/catalog/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>{{ option.label }}</option>
+                {% endfor %}
+              </select>
+              <div class="catalog-sort-tooltip-wrap relative">
+                <button type="button"
+                        class="catalog-sort-trigger inline-flex h-[20px] w-[20px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold text-[#718096]"
+                        aria-label="TailTalk 추천순 설명">
+                  i
+                </button>
+                <div class="catalog-sort-tooltip pointer-events-none absolute right-0 top-[28px] z-10 w-[240px] rounded-[16px] border border-[#dbe7f5] bg-white p-3 text-[12px] leading-[1.6] text-[#4a5568] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.08)] transition-all duration-150 ease-out">
+                  TailTalk 추천순은 상품 점수와<br>리뷰 수를 함께 반영해 정렬합니다
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
         <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
           {% for item in catalog_items %}
           <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -50,6 +50,25 @@
     background-repeat: no-repeat;
     padding-right: 38px;
   }
+
+  .catalog-more-summary {
+    list-style: none;
+  }
+
+  .catalog-more-summary::-webkit-details-marker {
+    display: none;
+  }
+
+  .catalog-more-summary-label::after {
+    content: "＋";
+    margin-left: 8px;
+    font-size: 11px;
+    color: #718096;
+  }
+
+  details[open] .catalog-more-summary-label::after {
+    content: "－";
+  }
   @media (max-width: 767px) {
     .catalog-header-stack {
       flex-direction: column;
@@ -130,6 +149,34 @@
             </div>
           </div>
           {% endfor %}
+        </section>
+        {% endif %}
+
+        {% if catalog_brand_options %}
+        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <div class="flex h-[24px] items-center justify-between gap-3">
+            <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">브랜드 (가나다순)</p>
+            {% if catalog_current_brand %}
+            <a href="/catalog/{% if catalog_clear_brand_query %}?{{ catalog_clear_brand_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            {% endif %}
+          </div>
+          <div class="mt-3 flex flex-wrap gap-2">
+            {% for option in catalog_brand_options %}
+            <a href="{{ option.href }}" class="catalog-chip inline-flex min-h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 py-2 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+            {% endfor %}
+          </div>
+          {% if catalog_brand_hidden_options %}
+          <details class="mt-3">
+            <summary class="catalog-more-summary inline-flex h-[32px] cursor-pointer items-center rounded-full bg-transparent px-1 text-[12px] font-semibold text-[#718096] underline-offset-2 hover:text-[#4a5568] hover:underline">
+              <span class="catalog-more-summary-label">더보기</span>
+            </summary>
+            <div class="mt-3 flex flex-wrap gap-2">
+              {% for option in catalog_brand_hidden_options %}
+              <a href="{{ option.href }}" class="catalog-chip inline-flex min-h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 py-2 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+              {% endfor %}
+            </div>
+          </details>
+          {% endif %}
         </section>
         {% endif %}
       </aside>

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -19,6 +19,19 @@
     color: #fff;
   }
 
+  .catalog-feedback-toast {
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 10px) scale(0.98);
+    transition: opacity 180ms ease, transform 180ms ease;
+  }
+
+  .catalog-feedback-toast.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0) scale(1);
+  }
+
   .catalog-card {
     transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
   }
@@ -31,6 +44,26 @@
 
   .catalog-thumb {
     aspect-ratio: 1 / 1;
+  }
+
+  .wishlist-heart svg:last-child {
+    display: none;
+  }
+
+  .wishlist-heart {
+    color: #4a5568;
+  }
+
+  .wishlist-heart.is-active {
+    color: #e53e3e;
+  }
+
+  .wishlist-heart.is-active svg:first-child {
+    display: none;
+  }
+
+  .wishlist-heart.is-active svg:last-child {
+    display: block;
   }
 
   .catalog-sort-tooltip-wrap:hover .catalog-sort-tooltip,
@@ -241,12 +274,28 @@
         <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
           {% for item in catalog_items %}
           <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
-            <div class="catalog-thumb overflow-hidden bg-[#f8fbff]">
+            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-thumb block overflow-hidden bg-[#f8fbff]">
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
-            </div>
+            </a>
             <div class="p-5">
-              <p class="truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
-              <p class="mt-2 min-h-[48px] text-[17px] font-bold leading-[1.45] text-[#2d3748]">{{ item.name }}</p>
+              <div class="flex items-start justify-between gap-3">
+                <p class="min-w-0 truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
+                <button type="button"
+                        class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:text-[#e53e3e]"
+                        aria-label="관심 상품 상태 변경"
+                        data-product-id="{{ item.product_id }}"
+                        onclick="toggleCatalogWishlist(this)">
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+                  </svg>
+                </button>
+              </div>
+              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="mt-2 block min-h-[48px] text-[17px] font-bold leading-[1.45] text-[#2d3748] hover:text-[#3182ce]">
+                {{ item.name }}
+              </a>
               <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
               <div class="mt-4 flex items-end justify-between gap-3">
                 <div>
@@ -262,7 +311,14 @@
                     {% endif %}
                   </p>
                 </div>
-                <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="inline-flex h-[38px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">상품 보기</a>
+                  <button type="button"
+                          class="inline-flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[24px] font-semibold leading-none text-white"
+                          data-product-id="{{ item.product_id }}"
+                          data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
+                          aria-label="장바구니에 상품 추가"
+                          onclick="addCatalogToCart(this)">
+                    <span class="relative top-[-2px]">+</span>
+                  </button>
               </div>
             </div>
           </article>
@@ -294,4 +350,105 @@
     </div>
   </div>
 </div>
+
+<div id="catalogFeedbackToast"
+     class="catalog-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+  오류가 발생했습니다.
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var catalogFeedbackToast = document.getElementById('catalogFeedbackToast');
+  var catalogToastTimer = null;
+
+  function getCsrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function requestJson(url, options) {
+    var fetchOptions = Object.assign(
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+      },
+      options || {}
+    );
+
+    return fetch(url, fetchOptions).then(function (response) {
+      return response.text().then(function (text) {
+        var data = {};
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch (e) {
+            data = {};
+          }
+        }
+        if (!response.ok) {
+          throw new Error(data.detail || '요청 처리에 실패했습니다.');
+        }
+        return data;
+      });
+    });
+  }
+
+  function showCatalogToast(message) {
+    if (!catalogFeedbackToast) return;
+    catalogFeedbackToast.textContent = message || '요청 처리에 실패했습니다.';
+    catalogFeedbackToast.classList.add('is-open');
+    if (catalogToastTimer) {
+      window.clearTimeout(catalogToastTimer);
+    }
+    catalogToastTimer = window.setTimeout(function () {
+      catalogFeedbackToast.classList.remove('is-open');
+    }, 2400);
+  }
+
+  window.toggleCatalogWishlist = function (button) {
+    var productId = button && button.dataset ? button.dataset.productId : '';
+    if (!productId) {
+      showCatalogToast('상품 식별 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    var isActive = button.classList.contains('is-active');
+    requestJson('/api/orders/wishlist/', {
+      method: isActive ? 'DELETE' : 'POST',
+      body: JSON.stringify({ product_id: productId }),
+    }).then(function () {
+      button.classList.toggle('is-active', !isActive);
+      showCatalogToast(isActive ? '관심 상품에서 제거했습니다.' : '관심 상품에 저장했습니다.');
+    }).catch(function (error) {
+      showCatalogToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+    });
+  };
+
+  window.addCatalogToCart = function (button) {
+    var productId = button && button.dataset ? button.dataset.productId : '';
+    if (!productId) {
+      showCatalogToast('상품 식별 정보를 찾을 수 없습니다.');
+      return;
+    }
+
+    requestJson('/api/orders/cart/', {
+      method: 'POST',
+      body: JSON.stringify({
+        product_id: productId,
+        quantity: 1,
+      }),
+    }).then(function () {
+      button.dataset.inCart = '1';
+      showCatalogToast('장바구니에 상품을 담았습니다.');
+    }).catch(function (error) {
+      showCatalogToast(error.message || '장바구니에 상품을 담지 못했습니다.');
+    });
+  };
+})();
+</script>
 {% endblock %}

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -1,0 +1,200 @@
+{% extends "base.html" %}
+{% block title %}상품 목록 — TailTalk{% endblock %}
+
+{% block head %}
+<style>
+  html,
+  body,
+  body.bg-white {
+    background: #f7fafc !important;
+  }
+
+  .catalog-chip {
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+  }
+
+  .catalog-chip.is-active {
+    background: #2d3748;
+    border-color: #2d3748;
+    color: #fff;
+  }
+
+  .catalog-card {
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  }
+
+  .catalog-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 28px rgba(45, 55, 72, 0.08);
+    border-color: #cbd5e0;
+  }
+
+  .catalog-thumb {
+    aspect-ratio: 1 / 1;
+  }
+  @media (max-width: 767px) {
+    .catalog-header-stack {
+      flex-direction: column;
+      align-items: flex-start;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="mx-auto max-w-[1320px] px-4 py-8 md:px-6">
+    <div class="catalog-header-stack flex items-center justify-between gap-4">
+      <div>
+        <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <p class="mt-3 text-[28px] font-bold text-[#2d3748]">상품 목록</p>
+        <p class="mt-2 text-[14px] leading-[1.7] text-[#718096]">반려동물 유형과 카테고리 기준으로 전체 상품을 탐색해보세요</p>
+      </div>
+      <div class="flex flex-wrap items-center gap-2">
+        <a href="/chat/" class="inline-flex h-[40px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-4 text-[13px] font-semibold text-[#4a5568]">채팅으로 돌아가기</a>
+        <a href="/products/" class="inline-flex h-[40px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">장바구니 / 관심상품</a>
+      </div>
+    </div>
+
+    <div class="mt-8 grid gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside class="space-y-4">
+        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <p class="text-[13px] font-bold text-[#90a4b8]">반려동물</p>
+          <div class="mt-3 flex flex-wrap gap-2">
+            <a href="/catalog/" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if not catalog_current_pet %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">전체</a>
+            {% for option in catalog_menu_sections %}
+            <a href="{{ option.href }}" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+            {% endfor %}
+          </div>
+        </section>
+
+        {% if catalog_current_pet %}
+        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <div class="flex h-[24px] items-center justify-between gap-3">
+            <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">카테고리</p>
+            {% if catalog_current_category %}
+            <a href="/catalog/{% if catalog_clear_category_query %}?{{ catalog_clear_category_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            {% endif %}
+          </div>
+          <div class="mt-3 flex flex-wrap gap-2">
+            {% for option in catalog_category_options %}
+            <a href="{{ option.href }}" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
+
+        {% if catalog_group_options %}
+        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          {% if catalog_current_category != '사료' %}
+          <div class="flex h-[24px] items-center justify-between gap-3">
+            <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">세부 항목</p>
+            {% if catalog_current_subcategory or catalog_current_brand %}
+            <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            {% endif %}
+          </div>
+          {% elif catalog_current_subcategory or catalog_current_brand %}
+          <div class="flex h-[24px] items-center justify-end">
+            <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+          </div>
+          {% endif %}
+          {% for group in catalog_group_options %}
+          <div class="{% if not forloop.first %}mt-5 border-t border-[#edf2f7] pt-5{% else %}{% if catalog_current_category == '사료' and not catalog_current_subcategory and not catalog_current_brand %}mt-0{% elif catalog_current_category == '사료' %}mt-3{% else %}mt-3{% endif %}{% endif %}">
+            {% if group.label != '전체' %}
+            <p class="text-[13px] font-bold text-[#90a4b8]">{{ group.label }}</p>
+            {% endif %}
+            <div class="{% if group.label != '전체' %}mt-3{% endif %} flex flex-wrap gap-2">
+            {% for option in group.items %}
+            <a href="{{ option.href }}" class="catalog-chip inline-flex min-h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 py-2 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+            {% endfor %}
+            </div>
+          </div>
+          {% endfor %}
+        </section>
+        {% endif %}
+      </aside>
+
+      <section class="min-w-0">
+        <div class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <div class="flex flex-wrap items-start justify-between gap-4">
+            <div>
+              <p class="text-[14px] font-semibold text-[#90a4b8]">검색 결과</p>
+              <p class="mt-2 text-[26px] font-bold text-[#2d3748]">{{ catalog_count }}개 상품</p>
+            </div>
+            <div class="flex flex-wrap gap-2">
+              {% if catalog_current_pet %}
+              <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_pet }}</span>
+              {% endif %}
+              {% if catalog_current_category %}
+              <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_category }}</span>
+              {% endif %}
+              {% if catalog_current_subcategory %}
+              <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_subcategory }}</span>
+              {% endif %}
+              {% if catalog_current_brand %}
+              <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_brand }}</span>
+              {% endif %}
+            </div>
+          </div>
+        </div>
+
+        {% if catalog_items %}
+        <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+          {% for item in catalog_items %}
+          <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+            <div class="catalog-thumb overflow-hidden bg-[#f8fbff]">
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+            </div>
+            <div class="p-5">
+              <p class="truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
+              <p class="mt-2 min-h-[48px] text-[17px] font-bold leading-[1.45] text-[#2d3748]">{{ item.name }}</p>
+              <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
+              <div class="mt-4 flex items-end justify-between gap-3">
+                <div>
+                  <p class="text-[20px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
+                  <p class="mt-1 flex items-center gap-1 text-[12px] text-[#a0aec0]">
+                    {% if item.rating %}
+                    <span class="text-[#f6ad55]">★</span>
+                    <span>{{ item.rating }}</span>
+                    <span>·</span>
+                    <span>리뷰 {{ item.review_count }}</span>
+                    {% else %}
+                    <span>리뷰 {{ item.review_count }}</span>
+                    {% endif %}
+                  </p>
+                </div>
+                <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="inline-flex h-[38px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">상품 보기</a>
+              </div>
+            </div>
+          </article>
+          {% endfor %}
+        </div>
+
+        {% if catalog_page_obj.paginator.num_pages > 1 %}
+        <div class="mt-8 flex items-center justify-center gap-2">
+          {% if catalog_page_obj.has_previous %}
+          <a href="/catalog/{% if catalog_prev_query %}?{{ catalog_prev_query }}{% endif %}" class="inline-flex h-[36px] min-w-[36px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-3 text-[13px] font-semibold text-[#4a5568]">이전</a>
+          {% endif %}
+          {% for page_link in catalog_pagination_links %}
+          <a href="/catalog/?{{ page_link.query }}" class="inline-flex h-[36px] min-w-[36px] items-center justify-center rounded-full border px-3 text-[13px] font-semibold {% if page_link.is_active %}border-[#2d3748] bg-[#2d3748] text-white{% else %}border-[#dbe7f5] bg-white text-[#4a5568]{% endif %}">{{ page_link.number }}</a>
+          {% endfor %}
+          {% if catalog_page_obj.has_next %}
+          <a href="/catalog/{% if catalog_next_query %}?{{ catalog_next_query }}{% endif %}" class="inline-flex h-[36px] min-w-[36px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-3 text-[13px] font-semibold text-[#4a5568]">다음</a>
+          {% endif %}
+        </div>
+        {% endif %}
+        {% else %}
+        <div class="mt-6 flex min-h-[420px] flex-col items-center justify-center rounded-[24px] border border-dashed border-[#dbe7f5] bg-white px-6 py-10 text-center shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <div class="text-[38px] text-[#7aa6e9]">🔎</div>
+          <p class="mt-4 text-[22px] font-bold text-[#2d3748]">조건에 맞는 상품이 없습니다</p>
+          <p class="mt-3 max-w-[420px] text-[14px] leading-[1.7] text-[#718096]">선택한 반려동물 유형이나 카테고리를 조금 넓혀서 다시 탐색해보세요.</p>
+          <a href="/catalog/{% if catalog_clear_category_query %}?{{ catalog_clear_category_query }}{% endif %}" class="mt-6 inline-flex h-[42px] items-center justify-center rounded-full bg-[#2d3748] px-5 text-[13px] font-semibold text-white">필터 초기화</a>
+        </div>
+        {% endif %}
+      </section>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## 작업 내용
- 채팅/장바구니/관심상품과 분리된 상품 목록 전용 페이지 `/catalog/`를 구현했습니다.
- 헤더 상품 드롭다운에서 선택한 pet/category/subcategory 기준으로 상품 목록 페이지에 진입할 수 있게 연결했습니다.
- raw DB category/subcategory/brand 값을 기준으로 상품 목록 필터링과 정렬을 반영했습니다.
- 상품 카드에서 관심상품 저장/해제와 장바구니 추가를 바로 수행할 수 있게 했습니다.
- 카탈로그 액션 호출 시 필요한 CSRF 처리와 nginx upstream 재해석 설정을 보강했습니다.

## 확인 사항
- 헤더 상품 드롭다운에서 선택한 항목으로 `/catalog/` 진입
- pet/category/subcategory/brand 필터 기준 상품 목록 노출
- 빈 결과 상태와 필터 초기화 동작 확인
- 상품 카드에서 관심상품 저장/해제 및 장바구니 추가 동작 확인
- 썸네일/상품명 클릭 시 외부 상품 페이지 이동 확인

closes #243
