### PR TITLE
[fix] Django EB secret key 검증 보강

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -217,6 +217,13 @@ jobs:
             ${{ env.DJANGO_IMAGE_REPO }}:latest
             ${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}
 
+      - name: Validate required Django deployment secrets
+        run: |
+          if [ -z "${{ secrets.DJANGO_SECRET_KEY }}" ]; then
+            echo "Missing required secret: DJANGO_SECRET_KEY"
+            exit 1
+          fi
+
       - name: Create Django deployment bundle
         run: |
           rm -rf .deploy-django django-deploy.zip
@@ -237,7 +244,6 @@ jobs:
           POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
           POSTGRES_PORT=${{ secrets.POSTGRES_PORT || 5432 }}
 
-          DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_DEBUG=False
           DJANGO_ALLOWED_HOSTS=*.elasticbeanstalk.com
           DJANGO_SECURE_SSL_REDIRECT=True


### PR DESCRIPTION
## 작업 내용
- Django 배포 번들 `.deploy-django/.env`에서 `DJANGO_SECRET_KEY`를 제거했습니다.
- 배포 전에 `secrets.DJANGO_SECRET_KEY`가 비어 있으면 즉시 실패하는 검증 step을 추가했습니다.

## 확인 사항
- 배포 번들 `.env`에 `DJANGO_SECRET_KEY`가 더 이상 포함되지 않습니다.
- `DJANGO_SECRET_KEY` secret 누락 시 번들 생성 전에 실패해야 합니다.

## 주의
- 검증용 PR입니다.
- 머지나 auto-merge 설정은 하지 않습니다.
