### PR TITLE
[revert] Django EB secret key 검증 보강 원복

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -217,12 +217,7 @@ jobs:
             ${{ env.DJANGO_IMAGE_REPO }}:latest
             ${{ env.DJANGO_IMAGE_REPO }}:${{ steps.django-meta.outputs.short_sha }}
 
-      - name: Validate required Django deployment secrets
-        run: |
-          if [ -z "${{ secrets.DJANGO_SECRET_KEY }}" ]; then
-            echo "Missing required secret: DJANGO_SECRET_KEY"
-            exit 1
-          fi
+    
 
       - name: Create Django deployment bundle
         run: |
@@ -244,6 +239,7 @@ jobs:
           POSTGRES_HOST=${{ secrets.POSTGRES_HOST }}
           POSTGRES_PORT=${{ secrets.POSTGRES_PORT || 5432 }}
 
+          DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_DEBUG=False
           DJANGO_ALLOWED_HOSTS=*.elasticbeanstalk.com
           DJANGO_SECURE_SSL_REDIRECT=True


### PR DESCRIPTION
## 작업 내용
- Django EB secret key 검증 보강 변경을 원복
- 배포 번들 .env 에 DJANGO_SECRET_KEY 를 다시 포함하도록 복구
- Validate required Django deployment secrets step 제거

## 확인 사항
- fix/django-eb-secret-key 브랜치에 원복 커밋 반영
- develop 은 직접 수정하지 않음
- 후속 판단 전까지 기존 동작 상태로 되돌리는 목적
