### PR TITLE
[fix] Django EB 배포 환경변수를 repo secrets 기준으로 정리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -242,14 +242,11 @@ jobs:
           DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_DEBUG=False
           DJANGO_ALLOWED_HOSTS=*.elasticbeanstalk.com
-          DJANGO_SECURE_SSL_REDIRECT=True
-          DJANGO_SESSION_COOKIE_SECURE=True
-          DJANGO_CSRF_COOKIE_SECURE=True
 
-          APP_BASE_URL=http://test-tailtalk-django-env.ap-northeast-2.elasticbeanstalk.com
-          FASTAPI_INTERNAL_CHAT_URL=http://test-tailtalk-fastapi-env.ap-northeast-2.elasticbeanstalk.com/api/chat/
+          APP_BASE_URL=${{ secrets.APP_BASE_URL }}
+          FASTAPI_INTERNAL_CHAT_URL=${{ secrets.FASTAPI_INTERNAL_CHAT_URL }}
           INTERNAL_SERVICE_TOKEN=${{ secrets.INTERNAL_SERVICE_TOKEN }}
-          CORS_ALLOWED_ORIGINS=*
+          CORS_ALLOWED_ORIGINS=${{ secrets.CORS_ALLOWED_ORIGINS }}
 
           AWS_S3_BUCKET_NAME=${{ secrets.AWS_S3_BUCKET_NAME }}
           AWS_S3_REGION_NAME=ap-northeast-2


### PR DESCRIPTION
## 요약
- Django EB 배포용 `.env`를 repo secrets 기반으로 생성하도록 정리했습니다.
- HTTP 환경과 맞지 않는 secure 쿠키/리다이렉트 강제 설정을 workflow에서 제거했습니다.

## 변경 사항
- `APP_BASE_URL`, `FASTAPI_INTERNAL_CHAT_URL`, `CORS_ALLOWED_ORIGINS`를 하드코딩하지 않고 repo secrets에서 읽도록 변경했습니다.
- `DJANGO_SECURE_SSL_REDIRECT`, `DJANGO_SESSION_COOKIE_SECURE`, `DJANGO_CSRF_COOKIE_SECURE`를 배포 `.env` 생성 대상에서 제거했습니다.
- 배포 설정이 코드와 분리되도록 하여 EB 재배포 시 최신 운영값을 그대로 반영하게 했습니다.

## 관련 이슈
- ref #247

## 체크리스트
- [ ] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- WEB repo secrets의 `APP_BASE_URL`, `FASTAPI_INTERNAL_CHAT_URL`, `CORS_ALLOWED_ORIGINS` 값 기준으로 Django Test EB CI/CD를 다시 확인 부탁드립니다.
- 기존 EB 환경변수에 `CORS_ALLOWED_ORIGINS=*`가 남아 있다면 제거 후 배포 결과를 함께 확인해 주세요.
