### PR TITLE
[fix] Django EB host 검증 값을 repo secret으로 전환

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -241,7 +241,7 @@ jobs:
 
           DJANGO_SECRET_KEY=${{ secrets.DJANGO_SECRET_KEY }}
           DJANGO_DEBUG=False
-          DJANGO_ALLOWED_HOSTS=*.elasticbeanstalk.com
+          DJANGO_ALLOWED_HOSTS=${{ secrets.DJANGO_ALLOWED_HOSTS || '.elasticbeanstalk.com' }}
 
           APP_BASE_URL=${{ secrets.APP_BASE_URL }}
           FASTAPI_INTERNAL_CHAT_URL=${{ secrets.FASTAPI_INTERNAL_CHAT_URL }}


### PR DESCRIPTION
## 요약
- Django EB 배포용 `.env`에서 `DJANGO_ALLOWED_HOSTS`를 하드코딩하지 않고 repo secret에서 읽도록 변경했습니다.
- 현재 CD의 `/health/` 400 원인이 되는 잘못된 host 패턴 주입을 제거합니다.

## 변경 사항
- `DJANGO_ALLOWED_HOSTS=*.elasticbeanstalk.com` 하드코딩을 제거했습니다.
- `DJANGO_ALLOWED_HOSTS=${{ secrets.DJANGO_ALLOWED_HOSTS || '.elasticbeanstalk.com' }}` 로 변경해 운영값을 secret에서 관리하도록 했습니다.
- secret이 비어 있어도 `.elasticbeanstalk.com` 기본값으로 EB CNAME이 통과되도록 했습니다.

## 관련 이슈
- ref #247
- ref #248

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- `Django Test EB CI/CD` 재실행 후 `/health/` 400이 해소되는지 확인 부탁드립니다.
- 현재 권장 secret 값은 `DJANGO_ALLOWED_HOSTS=test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com` 입니다.
