### PR TITLE
[fix] rerun 시 Django EB 새 배포 버전 생성

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -199,7 +199,10 @@ jobs:
 
       - name: Resolve image tag
         id: django-meta
-        run: echo "short_sha=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        run: |
+          short_sha="$(git rev-parse --short HEAD)"
+          echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
+          echo "version_label=django-${short_sha}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -276,9 +279,9 @@ jobs:
           region: ${{ env.AWS_REGION }}
           application_name: ${{ env.DJANGO_EB_APP_NAME }}
           environment_name: ${{ env.DJANGO_EB_ENV_NAME }}
-          version_label: django-${{ steps.django-meta.outputs.short_sha }}
+          version_label: ${{ steps.django-meta.outputs.version_label }}
           deployment_package: django-deploy.zip
-          use_existing_version_if_available: true
+          use_existing_version_if_available: false
           wait_for_deployment: true
 
       - name: Configure AWS credentials for verification


### PR DESCRIPTION
## 요약
- Django EB 배포 workflow가 rerun 시 기존 application version을 재사용하지 않도록 수정했습니다.
- secret을 수정해도 같은 커밋 rerun에서는 예전 zip이 그대로 배포되던 문제를 방지합니다.

## 변경 사항
- `Resolve image tag` step에서 `version_label`을 `django-<short_sha>-<run_id>-<run_attempt>` 형식으로 생성하도록 변경했습니다.
- EB 배포 step이 새 `version_label`을 사용하도록 수정했습니다.
- `use_existing_version_if_available`를 `false`로 바꿔 rerun 때 기존 EB application version 재사용을 막았습니다.

## 관련 이슈
- ref #247
- ref #248
- ref #249

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 같은 커밋을 rerun해도 새 application version이 생성되는지 확인 부탁드립니다.
- 이전 실패 원인은 secret 수정 후에도 `django-<short_sha>` zip이 그대로 재사용되어 새 `.env`가 배포되지 않은 점이었습니다.
