### PR TITLE
[feat] 상품 목록 페이지 후속 UI 보강 (#255)

### DIFF
--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,6 +1,6 @@
 from urllib.parse import parse_qs, urlencode, urlparse
 
-from django.db.models import DecimalField, IntegerField, Q, Value
+from django.db.models import Case, DecimalField, IntegerField, Q, Value, When
 from django.db.models.functions import Coalesce
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
@@ -135,6 +135,10 @@ CATALOG_SORT_OPTIONS = {
         "label": "가격 높은순",
         "ordering": ("-price", "-_sort_review_count", "-_sort_popularity_score", "goods_name"),
     },
+    "rating_high": {
+        "label": "평점 높은순",
+        "ordering": ("-_sort_has_rating", "-_sort_rating", "-_sort_review_count", "-_sort_popularity_score", "goods_name"),
+    },
 }
 
 
@@ -206,6 +210,11 @@ def _catalog_brand_sort_key(value):
 
 def _with_catalog_sort_fields(queryset):
     return queryset.annotate(
+        _sort_has_rating=Case(
+            When(rating__isnull=False, then=Value(1)),
+            default=Value(0),
+            output_field=IntegerField(),
+        ),
         _sort_popularity_score=Coalesce(
             "popularity_score",
             Value(0),
@@ -763,6 +772,7 @@ def used_products(request):
 
 @login_required
 def catalog(request):
+    keyword = (request.GET.get("q") or "").strip()[:50]
     pet = (request.GET.get("pet") or "").strip()
     category = (request.GET.get("category") or "").strip()
     subcategory = (request.GET.get("subcategory") or "").strip()
@@ -773,6 +783,8 @@ def catalog(request):
 
     base_queryset = Product.objects.filter(soldout_yn=False)
     queryset = base_queryset
+    if keyword:
+        queryset = queryset.filter(Q(goods_name__icontains=keyword) | Q(brand_name__icontains=keyword))
     if pet:
         queryset = queryset.filter(pet_type__contains=[pet])
     if category:
@@ -783,6 +795,8 @@ def catalog(request):
         queryset = queryset.filter(brand_name=brand)
 
     brand_queryset = base_queryset
+    if keyword:
+        brand_queryset = brand_queryset.filter(Q(goods_name__icontains=keyword) | Q(brand_name__icontains=keyword))
     if pet:
         brand_queryset = brand_queryset.filter(pet_type__contains=[pet])
     if category:
@@ -816,6 +830,7 @@ def catalog(request):
     }
 
     current_params = {
+        "q": keyword,
         "pet": pet,
         "category": category,
         "subcategory": subcategory,
@@ -877,6 +892,7 @@ def catalog(request):
         "catalog_pagination_links": pagination_links,
         "catalog_prev_query": _catalog_querystring(current_params, page=page_obj.previous_page_number()) if page_obj.has_previous() else "",
         "catalog_next_query": _catalog_querystring(current_params, page=page_obj.next_page_number()) if page_obj.has_next() else "",
+        "catalog_current_keyword": keyword,
         "catalog_current_pet": pet,
         "catalog_current_category": category,
         "catalog_current_subcategory": subcategory,

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1191,7 +1191,7 @@
               <div>
                 <p class="text-[20px] font-bold text-[#2d3748]">상품 카테고리</p>
               </div>
-              <a href="{% if is_preview_member %}#{% else %}/catalog/{% endif %}"
+              <a id="catalogMenuAllLink" href="{% if is_preview_member %}#{% else %}/catalog/{% endif %}"
                  class="inline-flex h-[32px] items-center rounded-full bg-[#edf2f7] px-[12px] text-[12px] font-bold text-[#4a5568]"
                  {% if is_preview_member %}onclick="return false"{% endif %}>전체 보기</a>
             </div>
@@ -1404,10 +1404,25 @@
 
   function buildCatalogLink(href, label, extraClassName, disabled) {
     var className = extraClassName || '';
+    var nextHref = href || '/catalog/';
+    if (!disabled && activeSessionId && nextHref.indexOf('/catalog/') === 0) {
+      var joiner = nextHref.indexOf('?') >= 0 ? '&' : '?';
+      nextHref += joiner + 'session=' + encodeURIComponent(activeSessionId);
+    }
     if (disabled) {
       return '<span class="' + className + ' cursor-default opacity-60">' + escapeHtml(label) + '</span>';
     }
-    return '<a href="' + escapeHtml(href || '/catalog/') + '" class="' + className + '">' + escapeHtml(label) + '</a>';
+    return '<a href="' + escapeHtml(nextHref) + '" class="' + className + '">' + escapeHtml(label) + '</a>';
+  }
+
+  function syncCatalogMenuAllLink() {
+    var allLink = document.getElementById('catalogMenuAllLink');
+    if (!allLink) return;
+    var nextHref = '/catalog/';
+    if (activeSessionId) {
+      nextHref += '?session=' + encodeURIComponent(activeSessionId);
+    }
+    allLink.setAttribute('href', nextHref);
   }
 
   function renderCatalogPetList() {
@@ -1918,6 +1933,7 @@
   });
 
   initializeCatalogMenu();
+  syncCatalogMenuAllLink();
 
   function openPetDropdown() {
     if (!petDropdownMenu || !petDropdownButton || !petDropdownChevron) return;
@@ -2175,6 +2191,7 @@
 
   function activateSession(sessionId) {
     activeSessionId = sessionId;
+    syncCatalogMenuAllLink();
     updateSessionItemStyles();
     openProductPanel();
     switchProductTab('recommended');
@@ -2412,6 +2429,7 @@
     ensureSessionPromise.then(function (sessionData) {
       var sessionId = sessionData.session_id;
       activeSessionId = sessionId;
+      syncCatalogMenuAllLink();
       var sessionState = ensureSessionState(sessionId);
       promoteSessionItem(sessionId, sessionData.title || (msg.length > 18 ? msg.slice(0, 18) + '...' : msg));
 

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -102,6 +102,25 @@
   details[open] .catalog-more-summary-label::after {
     content: "－";
   }
+
+  .catalog-session-drawer {
+    transition: transform 200ms ease, opacity 200ms ease, visibility 200ms ease;
+  }
+
+  .catalog-session-drawer.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translateY(-50%) translateX(0);
+  }
+
+  .catalog-session-drawer-toggle {
+    transition: transform 180ms ease, box-shadow 180ms ease;
+    margin-right: -1px;
+  }
+
+  .catalog-session-drawer.is-open .catalog-session-drawer-toggle {
+    box-shadow: 0 12px 24px rgba(45, 55, 72, 0.12);
+  }
   @media (max-width: 767px) {
     .catalog-header-stack {
       flex-direction: column;
@@ -374,6 +393,86 @@
      class="catalog-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
   오류가 발생했습니다.
 </div>
+
+<div id="catalogSessionDrawer"
+     class="catalog-session-drawer fixed right-0 top-1/2 z-[65] flex -translate-y-1/2 translate-x-[calc(100%-48px)] items-center opacity-100 visible">
+  <button type="button"
+          id="catalogSessionDrawerToggle"
+          class="catalog-session-drawer-toggle inline-flex h-[120px] w-[48px] self-center items-center justify-center rounded-l-[20px] border border-r-0 border-[#dbe7f5] bg-white text-[12px] font-bold tracking-[0.08em] text-[#4a5568] shadow-[0_8px_20px_rgba(45,55,72,0.08)]"
+          onclick="toggleCatalogSessionDrawer()">
+    <span class="[writing-mode:vertical-rl]">추천 상품</span>
+  </button>
+  <aside class="h-[min(78vh,680px)] w-[360px] overflow-hidden rounded-l-[24px] border border-[#dbe7f5] bg-white shadow-[0_18px_40px_rgba(45,55,72,0.12)]">
+    <div class="flex items-center justify-between border-b border-[#edf2f7] px-5 py-4">
+      <div>
+        <p class="text-[16px] font-bold text-[#2d3748]">추천 상품</p>
+        <p class="mt-1 text-[12px] text-[#90a4b8]">{% if catalog_recommended_session %}현재 채팅 세션에서 추천된 상품{% else %}추천 세션이 연결되지 않았어요{% endif %}</p>
+      </div>
+    </div>
+    <div class="h-[calc(100%-69px)] overflow-y-auto px-4 py-4">
+      {% if catalog_recommended_items %}
+      <div class="space-y-3">
+        {% for item in catalog_recommended_items %}
+        <article class="rounded-[20px] border border-[#e2e8f0] bg-[#fbfdff] p-4">
+          <div class="flex gap-3">
+            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="block h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[16px] bg-[#f1f5f9]">
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+            </a>
+            <div class="min-w-0 flex-1">
+              <p class="truncate text-[11px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
+              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="mt-1 block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">{{ item.name }}</a>
+              <p class="mt-2 text-[12px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
+              <div class="mt-3 flex items-end justify-between gap-3">
+                <div>
+                  <p class="text-[16px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
+                  <p class="mt-1 flex items-center gap-1 text-[11px] text-[#a0aec0]">
+                    {% if item.rating %}
+                    <span class="text-[#f6ad55]">★</span>
+                    <span>{{ item.rating }}</span>
+                    <span>·</span>
+                    {% endif %}
+                    <span>리뷰 {{ item.review_count }}</span>
+                  </p>
+                </div>
+                <div class="flex items-center gap-2">
+                  <button type="button"
+                          class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:text-[#e53e3e]"
+                          aria-label="관심 상품 상태 변경"
+                          data-product-id="{{ item.product_id }}"
+                          onclick="toggleCatalogWishlist(this)">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                      <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                    </svg>
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                      <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+                    </svg>
+                  </button>
+                  <button type="button"
+                          class="inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[16px] font-semibold leading-none text-white"
+                          data-product-id="{{ item.product_id }}"
+                          data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
+                          aria-label="장바구니에 상품 추가"
+                          onclick="addCatalogToCart(this)">
+                    <span class="relative top-[-1px]">+</span>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+      {% else %}
+      <div class="flex h-full min-h-[320px] flex-col items-center justify-center px-4 text-center">
+        <div class="text-[34px] text-[#90cdf4]">🧺</div>
+        <p class="mt-4 text-[18px] font-bold text-[#2d3748]">추천된 상품이 없어요</p>
+        <p class="mt-3 text-[13px] leading-[1.7] text-[#718096]">{% if catalog_current_session_id %}이 채팅 세션에서는 아직 추천 상품이 저장되지 않았습니다.{% else %}채팅에서 추천을 받으면<br>이곳에서 다시 모아볼 수 있어요{% endif %}</p>
+        <a href="/chat/" class="mt-5 inline-flex h-[38px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white">채팅에서 추천받기</a>
+      </div>
+      {% endif %}
+    </div>
+  </aside>
+</div>
 {% endblock %}
 
 {% block scripts %}
@@ -381,6 +480,7 @@
 (function () {
   var catalogFeedbackToast = document.getElementById('catalogFeedbackToast');
   var catalogToastTimer = null;
+  var catalogSessionDrawer = document.getElementById('catalogSessionDrawer');
 
   function getCsrfToken() {
     var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
@@ -428,6 +528,22 @@
       catalogFeedbackToast.classList.remove('is-open');
     }, 2400);
   }
+
+  window.toggleCatalogSessionDrawer = function () {
+    if (!catalogSessionDrawer) return;
+    catalogSessionDrawer.classList.toggle('is-open');
+  };
+
+  window.closeCatalogSessionDrawer = function () {
+    if (!catalogSessionDrawer) return;
+    catalogSessionDrawer.classList.remove('is-open');
+  };
+
+  document.addEventListener('mousedown', function (event) {
+    if (!catalogSessionDrawer || !catalogSessionDrawer.classList.contains('is-open')) return;
+    if (catalogSessionDrawer.contains(event.target)) return;
+    closeCatalogSessionDrawer();
+  });
 
   window.toggleCatalogWishlist = function (button) {
     var productId = button && button.dataset ? button.dataset.productId : '';

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -157,7 +157,7 @@
         {% endif %}
 
         {% if catalog_group_options %}
-        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+        <section class="relative rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
           {% if catalog_current_category != '사료' %}
           <div class="flex h-[24px] items-center justify-between gap-3">
             <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">세부 항목</p>
@@ -166,12 +166,10 @@
             {% endif %}
           </div>
           {% elif catalog_current_subcategory or catalog_current_brand %}
-          <div class="flex h-[24px] items-center justify-end">
-            <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
-          </div>
+          <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="absolute right-5 top-5 inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
           {% endif %}
           {% for group in catalog_group_options %}
-          <div class="{% if not forloop.first %}mt-5 border-t border-[#edf2f7] pt-5{% else %}{% if catalog_current_category == '사료' and not catalog_current_subcategory and not catalog_current_brand %}mt-0{% elif catalog_current_category == '사료' %}mt-3{% else %}mt-3{% endif %}{% endif %}">
+          <div class="{% if not forloop.first %}mt-5 border-t border-[#edf2f7] pt-5{% else %}{% if catalog_current_category == '사료' %}mt-0{% else %}mt-3{% endif %}{% endif %}">
             {% if group.label != '전체' %}
             <p class="text-[13px] font-bold text-[#90a4b8]">{{ group.label }}</p>
             {% endif %}
@@ -216,12 +214,13 @@
 
       <section class="min-w-0">
         <div class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
-          <div class="flex flex-wrap items-start justify-between gap-4">
-            <div>
-              <p class="text-[14px] font-semibold text-[#90a4b8]">검색 결과</p>
+          <div class="space-y-4">
+            <div class="flex flex-wrap items-start justify-between gap-4">
+              <div>
+              <p class="text-[14px] font-semibold text-[#90a4b8]">{% if catalog_current_keyword %}“{{ catalog_current_keyword }}” 검색 결과{% else %}검색 결과{% endif %}</p>
               <p class="mt-2 text-[26px] font-bold text-[#2d3748]">{{ catalog_count }}개 상품</p>
-            </div>
-            <div class="flex flex-wrap items-center justify-end gap-2">
+              </div>
+              <div class="flex flex-wrap items-center justify-end gap-2">
               {% if catalog_current_pet %}
               <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_pet }}</span>
               {% endif %}
@@ -238,39 +237,59 @@
               <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_subcategory }}</span>
               {% endif %}
               {% if catalog_current_brand %}
-              {% if catalog_current_subcategory or catalog_current_category %}
+              {% if catalog_current_subcategory or catalog_current_category or catalog_current_pet %}
               <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
               {% endif %}
               <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_brand }}</span>
               {% endif %}
+              </div>
             </div>
-          </div>
-        </div>
-
-        {% if catalog_items %}
-        <div class="mt-6 flex items-center justify-end">
-          <div class="relative">
-            <div class="flex items-center gap-2">
-              <select id="catalogSort"
-                      class="catalog-sort-select h-[36px] rounded-full border border-[#dbe7f5] bg-white pl-4 text-[12px] font-semibold text-[#4a5568] outline-none transition-colors focus:border-[#90cdf4]"
-                      onchange="if (this.value) { window.location.href = this.value; }">
-                {% for option in catalog_sort_options %}
-                <option value="/catalog/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>{{ option.label }}</option>
-                {% endfor %}
-              </select>
-              <div class="catalog-sort-tooltip-wrap relative">
-                <button type="button"
-                        class="catalog-sort-trigger inline-flex h-[20px] w-[20px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold text-[#718096]"
-                        aria-label="TailTalk 추천순 설명">
-                  i
-                </button>
-                <div class="catalog-sort-tooltip pointer-events-none absolute right-0 top-[28px] z-10 w-[240px] rounded-[16px] border border-[#dbe7f5] bg-white p-3 text-[12px] leading-[1.6] text-[#4a5568] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.08)] transition-all duration-150 ease-out">
-                  TailTalk 추천순은 상품 점수와<br>리뷰 수를 함께 반영해 정렬합니다
+            <div class="flex flex-wrap items-center gap-3">
+              <form method="get" action="/catalog/" class="min-w-0 flex-1">
+                {% if catalog_current_pet %}<input type="hidden" name="pet" value="{{ catalog_current_pet }}">{% endif %}
+                {% if catalog_current_category %}<input type="hidden" name="category" value="{{ catalog_current_category }}">{% endif %}
+                {% if catalog_current_subcategory %}<input type="hidden" name="subcategory" value="{{ catalog_current_subcategory }}">{% endif %}
+                {% if catalog_current_brand %}<input type="hidden" name="brand" value="{{ catalog_current_brand }}">{% endif %}
+                {% if catalog_current_sort %}<input type="hidden" name="sort" value="{{ catalog_current_sort }}">{% endif %}
+                <div class="relative w-full max-w-[720px]">
+                  <input type="search"
+                         name="q"
+                         value="{{ catalog_current_keyword }}"
+                         maxlength="50"
+                         placeholder="상품명 또는 브랜드로 검색"
+                         class="h-[42px] w-full rounded-full border border-[#dbe7f5] bg-[#fbfdff] pl-4 pr-[88px] text-[13px] font-medium text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]">
+                  <button type="submit"
+                          class="absolute right-[6px] top-1/2 inline-flex h-[30px] -translate-y-1/2 items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white transition-colors hover:bg-[#1f2937]">
+                    검색
+                  </button>
+                </div>
+              </form>
+              <div class="relative">
+                <div class="flex h-[36px] items-center gap-2">
+                  <select id="catalogSort"
+                          class="catalog-sort-select h-[36px] rounded-full border border-[#dbe7f5] bg-white pl-4 text-[12px] font-semibold text-[#4a5568] outline-none transition-colors focus:border-[#90cdf4]"
+                          onchange="if (this.value) { window.location.href = this.value; }">
+                    {% for option in catalog_sort_options %}
+                    <option value="/catalog/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>{{ option.label }}</option>
+                    {% endfor %}
+                  </select>
+                  <div class="catalog-sort-tooltip-wrap relative">
+                    <button type="button"
+                            class="catalog-sort-trigger inline-flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold leading-none text-[#718096]"
+                            aria-label="TailTalk 추천순 설명">
+                      i
+                    </button>
+                    <div class="catalog-sort-tooltip pointer-events-none absolute right-0 top-[28px] z-10 w-[240px] rounded-[16px] border border-[#dbe7f5] bg-white p-3 text-[12px] leading-[1.6] text-[#4a5568] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.08)] transition-all duration-150 ease-out">
+                      TailTalk 추천순은 상품 점수와<br>리뷰 수를 함께 반영해 정렬합니다
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
+
+        {% if catalog_items %}
         <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
           {% for item in catalog_items %}
           <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">


### PR DESCRIPTION
## 작업 내용
- 상품 목록 페이지 상단 검색/정렬 영역을 재배치하고 검색 UX를 보강했습니다
- 상품 목록 추천 드로어 UI를 추가하고 채팅에서 catalog 진입 시 현재 세션을 유지하도록 연결했습니다
- 카탈로그 카드/빈 상태/경로 표시 등 후속 UI 디테일을 정리했습니다

## 확인 사항
- 상품 목록 검색/정렬/브랜드 필터가 함께 동작합니다
- 채팅에서 catalog로 이동하면 현재 세션 기준 추천 상품 드로어가 열릴 수 있습니다
- 빈 상태 문구와 액션 버튼 UI를 정리했습니다

closes #255