### PR TITLE
ci(web): Django 테스트 EB 이미지를 Docker Hub에서 ECR로 전환

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -31,7 +31,7 @@ concurrency:
 
 env:
   AWS_REGION: ap-northeast-2
-  DJANGO_IMAGE_REPO: kimheejoon91/test-tailtalk-django
+  DJANGO_IMAGE_REPO: 027099020675.dkr.ecr.ap-northeast-2.amazonaws.com/test-tailtalk-django
   DJANGO_EB_APP_NAME: test-tailtalk-django
   DJANGO_EB_ENV_NAME: test-tailtalk-django-env
   DJANGO_HEALTH_PATH: /health/
@@ -79,6 +79,7 @@ jobs:
           )
           PY
           cp -r deploy/eb/test-django/nginx .deploy-django/nginx
+          cp -r deploy/eb/test-django/.platform .deploy-django/.platform
           cat <<'EOF' > .deploy-django/.env
           DJANGO_SECRET_KEY=test-secret
           DJANGO_DEBUG=False
@@ -94,6 +95,8 @@ jobs:
           CORS_ALLOWED_ORIGINS=
           EOF
           docker compose -f .deploy-django/docker-compose.yml --env-file .deploy-django/.env config -q
+          test -f .deploy-django/.platform/hooks/prebuild/01_ecr_login.sh
+          test -f .deploy-django/.platform/confighooks/prebuild/01_ecr_login.sh
 
       - name: Reset local test stack
         run: docker compose -f infra/docker-compose.yml down -v --remove-orphans || true
@@ -116,6 +119,7 @@ jobs:
           )
           PY
           cp -r deploy/eb/test-django/nginx .deploy-django/nginx
+          cp -r deploy/eb/test-django/.platform .deploy-django/.platform
           cat <<'EOF' > .deploy-django/docker-compose.smoke.yml
           services:
             django:
@@ -204,11 +208,15 @@ jobs:
           echo "short_sha=$short_sha" >> "$GITHUB_OUTPUT"
           echo "version_label=django-${short_sha}-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}" >> "$GITHUB_OUTPUT"
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Build & push Django image
         uses: docker/build-push-action@v6
@@ -268,8 +276,9 @@ jobs:
           docker compose -f .deploy-django/docker-compose.yml --env-file .deploy-django/.env config -q
           # .ebextensions 디렉토리 복사 (EB 기본 설정)
           cp -r deploy/eb/test-django/.ebextensions .deploy-django/.ebextensions
+          cp -r deploy/eb/test-django/.platform .deploy-django/.platform
           cd .deploy-django
-          zip -r ../django-deploy.zip docker-compose.yml .env nginx .ebextensions
+          zip -r ../django-deploy.zip docker-compose.yml .env nginx .ebextensions .platform
 
       - name: Deploy Django to Elastic Beanstalk
         uses: einaregilsson/beanstalk-deploy@v22
@@ -283,13 +292,6 @@ jobs:
           deployment_package: django-deploy.zip
           use_existing_version_if_available: false
           wait_for_deployment: true
-
-      - name: Configure AWS credentials for verification
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ env.AWS_REGION }}
 
       - name: Resolve Django environment URL
         id: django-env

--- a/deploy/eb/test-django/.platform/confighooks/prebuild/01_ecr_login.sh
+++ b/deploy/eb/test-django/.platform/confighooks/prebuild/01_ecr_login.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+compose_file="docker-compose.yml"
+if [[ ! -f "$compose_file" ]]; then
+  echo "docker-compose.yml not found"
+  exit 1
+fi
+
+mapfile -t registries < <(
+  grep -E '^[[:space:]]*image:[[:space:]]*' "$compose_file" \
+  | awk '{print $2}' \
+  | cut -d/ -f1 \
+  | grep -E '\.dkr\.ecr\..*\.amazonaws\.com$' \
+  | sort -u
+)
+
+if [[ ${#registries[@]} -eq 0 ]]; then
+  echo "No ECR registries found in docker-compose.yml"
+  exit 0
+fi
+
+for registry in "${registries[@]}"; do
+  region="$(echo "$registry" | cut -d. -f4)"
+  aws ecr get-login-password --region "$region" \
+    | docker login --username AWS --password-stdin "$registry"
+done

--- a/deploy/eb/test-django/.platform/hooks/prebuild/01_ecr_login.sh
+++ b/deploy/eb/test-django/.platform/hooks/prebuild/01_ecr_login.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+compose_file="docker-compose.yml"
+if [[ ! -f "$compose_file" ]]; then
+  echo "docker-compose.yml not found"
+  exit 1
+fi
+
+mapfile -t registries < <(
+  grep -E '^[[:space:]]*image:[[:space:]]*' "$compose_file" \
+  | awk '{print $2}' \
+  | cut -d/ -f1 \
+  | grep -E '\.dkr\.ecr\..*\.amazonaws\.com$' \
+  | sort -u
+)
+
+if [[ ${#registries[@]} -eq 0 ]]; then
+  echo "No ECR registries found in docker-compose.yml"
+  exit 0
+fi
+
+for registry in "${registries[@]}"; do
+  region="$(echo "$registry" | cut -d. -f4)"
+  aws ecr get-login-password --region "$region" \
+    | docker login --username AWS --password-stdin "$registry"
+done


### PR DESCRIPTION
## 요약
Django 테스트 EB 배포 경로를 Docker Hub 기반 이미지 배포에서 Amazon ECR 기반 배포로 전환합니다.

## 변경 사항
- Django CI/CD workflow의 이미지 저장소를 ECR URI로 변경했습니다.
- Docker Hub 로그인 단계를 제거하고 AWS 자격증명 + Amazon ECR 로그인 단계로 교체했습니다.
- Django EB 배포 번들에 `.platform` prebuild hook을 추가해 EB 인스턴스에서 ECR 로그인 후 이미지를 pull 하도록 변경했습니다.
- AWS에 `test-tailtalk-django`, `test-tailtalk-fastapi` ECR repository를 생성하고, EB 인스턴스 역할 `skn22-ec2-role`에 `AmazonEC2ContainerRegistryReadOnly` 정책을 추가했습니다.
- ECR 전환 절차와 현재 계정 기준 변경 포인트를 `docs/infra/12_dockerhub_to_ecr_migration_runbook.md`에 정리했습니다.

## 관련 이슈
없음

## 체크리스트
- [x] 배포 번들이 ECR 기준으로 생성되는지 로컬에서 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- Django EB 배포 번들에 추가한 `.platform` ECR 로그인 hook 경로와 zip 포함 범위를 중점적으로 봐주세요.
- GitHub Actions의 AWS 자격증명이 실제로 ECR push 권한을 가지는지 운영 계정 기준으로 함께 확인해 주세요.
