### PR TITLE
[fix] 회원정보 저장 후 redirect 분기 정리 (#266)

### DIFF
--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -11,7 +11,11 @@ from social_core.exceptions import AuthCanceled, AuthConnectionError, AuthExcept
 
 from .models import UserProfile
 from .nickname_utils import build_unique_nickname, get_nickname_validation_error
-from .onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY, get_onboarding_redirect_url
+from .onboarding import (
+    ONBOARDING_FORCE_PROFILE_SESSION_KEY,
+    get_onboarding_redirect_url,
+    has_completed_pet_onboarding,
+)
 from .quick_purchase import build_payment_info, split_legacy_address
 from .social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
@@ -188,6 +192,8 @@ def profile_view(request):
         messages.success(request, "프로필 정보가 저장되었습니다.")
         if setup_mode:
             request.session.pop(ONBOARDING_FORCE_PROFILE_SESSION_KEY, None)
+            if has_completed_pet_onboarding(request):
+                return redirect("chat")
             return redirect("pet_add")
         return redirect("chat")
 

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -8,7 +8,7 @@ from rest_framework.test import APIClient
 from social_django.models import UserSocialAuth
 
 from orders.models import Order
-from pets.models import FuturePetProfile
+from pets.models import FuturePetProfile, Pet
 from products.models import Product
 from users.models import SocialAccount, User, UserProfile
 from users.onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY
@@ -256,6 +256,80 @@ class ProfilePageViewTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertContains(response, "연락처 인증을 완료해 주세요.")
+
+    def test_profile_post_redirects_to_chat_when_pet_profile_is_missing_for_regular_edit(self):
+        response = self.client.post(
+            "/profile/",
+            {
+                "nickname": "PageProfile2",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], reverse("chat"))
+
+    def test_profile_post_redirects_to_pet_add_when_pet_profile_is_missing_in_setup_mode(self):
+        session = self.client.session
+        session[ONBOARDING_FORCE_PROFILE_SESSION_KEY] = True
+        session.save()
+
+        response = self.client.post(
+            f"{reverse('profile')}?setup=1",
+            {
+                "nickname": "PageProfile2",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], reverse("pet_add"))
+
+    def test_profile_post_redirects_to_chat_when_future_pet_profile_exists_in_setup_mode(self):
+        FuturePetProfile.objects.create(
+            user=self.user,
+            preferred_species="dog",
+            housing_type="apartment",
+            experience_level="first",
+            interests=["adoption"],
+        )
+        session = self.client.session
+        session[ONBOARDING_FORCE_PROFILE_SESSION_KEY] = True
+        session.save()
+
+        response = self.client.post(
+            f"{reverse('profile')}?setup=1",
+            {
+                "nickname": "PageProfile2",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], reverse("chat"))
+
+    def test_profile_post_redirects_to_chat_when_pet_profile_exists_in_setup_mode(self):
+        Pet.objects.create(
+            user=self.user,
+            name="코코",
+            species="dog",
+            breed="말티즈",
+            gender="male",
+            age_years=3,
+            age_months=0,
+            weight_kg=3.2,
+            budget_range="10-20",
+        )
+        session = self.client.session
+        session[ONBOARDING_FORCE_PROFILE_SESSION_KEY] = True
+        session.save()
+
+        response = self.client.post(
+            f"{reverse('profile')}?setup=1",
+            {
+                "nickname": "PageProfile2",
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertEqual(response["Location"], reverse("chat"))
 
 
 class UserProfileApiTests(TestCase):


### PR DESCRIPTION
## 변경 내용
- 회원정보 저장 후 redirect 분기를 신규 온보딩과 일반 수정 흐름으로 분리했습니다.
- `?setup=1` 온보딩 저장 시에만 반려동물/예비집사 정보 유무를 기준으로 `/pets/add/` 또는 `/chat/`으로 이동합니다.
- 일반 `/profile/` 저장은 항상 `/chat/`으로 이동하도록 정리했습니다.
- 관련 회귀 테스트를 추가했습니다.

## 검증
- `docker compose -f infra/docker-compose.yml exec -T django python manage.py test users.tests --keepdb`
- `docker compose -f infra/docker-compose.yml exec -T django python manage.py check`
- `curl -I http://localhost/profile/`
