### PR TITLE
[feat] 반려동물 품종 저장 검증 추가 (#268)

### DIFF
--- a/services/django/pets/breeds.py
+++ b/services/django/pets/breeds.py
@@ -1,0 +1,83 @@
+from collections import defaultdict
+from functools import lru_cache
+
+from django.db import connection
+
+
+SPECIES_KEY_MAP = {
+    "dog": "dog",
+    "cat": "cat",
+    "강아지": "dog",
+    "고양이": "cat",
+}
+
+
+def _normalize_species(species):
+    return SPECIES_KEY_MAP.get((species or "").strip(), "")
+
+
+def _normalize_breed_key(value):
+    return " ".join(str(value or "").strip().split())
+
+
+def _collapse_breed_key(value):
+    return _normalize_breed_key(value).replace(" ", "")
+
+
+@lru_cache(maxsize=1)
+def _breed_meta_snapshot():
+    options = defaultdict(list)
+    aliases = defaultdict(dict)
+
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            SELECT DISTINCT species, breed_name, breed_name_en
+            FROM breed_meta
+            WHERE species IN ('dog', 'cat')
+              AND breed_name IS NOT NULL
+              AND breed_name <> ''
+            ORDER BY species, breed_name
+            """
+        )
+        rows = cursor.fetchall()
+
+    for species, breed_name, breed_name_en in rows:
+        normalized_species = _normalize_species(species)
+        canonical_name = _normalize_breed_key(breed_name)
+        english_name = _normalize_breed_key(breed_name_en)
+        if not normalized_species or not canonical_name:
+            continue
+
+        if canonical_name not in options[normalized_species]:
+            options[normalized_species].append(canonical_name)
+
+        aliases[normalized_species][canonical_name.casefold()] = canonical_name
+        aliases[normalized_species][_collapse_breed_key(canonical_name).casefold()] = canonical_name
+        if english_name:
+            aliases[normalized_species][english_name.casefold()] = canonical_name
+            aliases[normalized_species][_collapse_breed_key(english_name).casefold()] = canonical_name
+
+    return {key: list(values) for key, values in options.items()}, {key: dict(values) for key, values in aliases.items()}
+
+
+def get_breed_options(species):
+    options, _ = _breed_meta_snapshot()
+    return options.get(_normalize_species(species), [])
+
+
+def resolve_breed(species, breed):
+    normalized_breed = _normalize_breed_key(breed)
+    if not normalized_breed:
+        return None
+
+    _, aliases = _breed_meta_snapshot()
+    species_aliases = aliases.get(_normalize_species(species), {})
+    return (
+        species_aliases.get(normalized_breed.casefold())
+        or species_aliases.get(_collapse_breed_key(normalized_breed).casefold())
+    )
+
+
+def is_valid_breed(species, breed):
+    return resolve_breed(species, breed) is not None

--- a/services/django/pets/page_views.py
+++ b/services/django/pets/page_views.py
@@ -1,8 +1,10 @@
+import json
 from dataclasses import dataclass
 
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
+from .breeds import get_breed_options, resolve_breed
 from .future_profile import get_future_pet_profile_for_request
 from .models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 
@@ -63,6 +65,11 @@ def _food_preference_labels(food_values, species):
     label_map = dict(_food_options_for_species(species))
     fallback_label_map = dict(PetFoodPreference.FOOD_TYPE_CHOICES)
     return [label_map.get(value, fallback_label_map.get(value, value)) for value in food_values]
+
+
+def _breed_error_message(species):
+    species_label = "고양이" if species == "cat" else "강아지"
+    return f"{species_label} 품종은 목록에서 선택해 주세요."
 
 
 @dataclass
@@ -381,6 +388,10 @@ def pet_add_details(request):
         {
             "pet": pet_seed,
             "species": species,
+            "breed_options_json": json.dumps({
+                "dog": get_breed_options("dog"),
+                "cat": get_breed_options("cat"),
+            }),
             "age_year_options": AGE_YEAR_OPTIONS,
             "age_month_options": AGE_MONTH_OPTIONS,
             "step3_data": step3_data,
@@ -406,6 +417,42 @@ def pet_add_health(request):
         "weight_kg": request.POST.get("weight_kg", "").strip(),
         "neutered": request.POST.get("neutered", ""),
     }
+    resolved_breed = resolve_breed(species, step2_data["breed"])
+    if not resolved_breed:
+        pet_preview = {
+            "species": species,
+            "name": step2_data["name"],
+            "breed": step2_data["breed"],
+            "gender": step2_data["gender"],
+            "age_years": step2_data["age_years"],
+            "age_months": step2_data["age_months"],
+            "weight_kg": step2_data["weight_kg"],
+            "neutered": True if step2_data["neutered"] == "yes" else False if step2_data["neutered"] == "no" else None,
+        }
+        return render(
+            request,
+            "pets/add_step2.html",
+            {
+                "pet": pet_preview,
+                "species": species,
+                "breed_options_json": json.dumps({
+                    "dog": get_breed_options("dog"),
+                    "cat": get_breed_options("cat"),
+                }),
+                "age_year_options": AGE_YEAR_OPTIONS,
+                "age_month_options": AGE_MONTH_OPTIONS,
+                "step3_data": {
+                    "vaccination_date": request.POST.get("vaccination_date", "").strip(),
+                    "health_concerns": request.POST.getlist("health_concerns"),
+                    "allergies": request.POST.get("allergies", "").strip(),
+                    "food_preferences": request.POST.getlist("food_preferences"),
+                    "budget_range": request.POST.get("budget_range", "").strip(),
+                    "special_notes": request.POST.get("special_notes", "").strip(),
+                },
+                "breed_error_message": _breed_error_message(species),
+            },
+        )
+    step2_data["breed"] = resolved_breed
 
     if request.POST.get("final_step") == "1":
         if not getattr(request.user, "is_authenticated", False):
@@ -484,6 +531,10 @@ def pet_edit(request, pet_id):
         {
             "pet": pet,
             "species": pet.species,
+            "breed_options_json": json.dumps({
+                "dog": get_breed_options("dog"),
+                "cat": get_breed_options("cat"),
+            }),
             "is_edit": True,
             "age_year_options": AGE_YEAR_OPTIONS,
             "age_month_options": AGE_MONTH_OPTIONS,
@@ -496,8 +547,36 @@ def pet_edit_health(request, pet_id):
     if request.method != "POST":
         return redirect("pet_edit", pet_id=pet.pet_id)
 
+    resolved_breed = resolve_breed(pet.species, request.POST.get("breed", "").strip())
+    if not resolved_breed:
+        return render(
+            request,
+            "pets/add_step2.html",
+            {
+                "pet": {
+                    "species": pet.species,
+                    "name": request.POST.get("name", "").strip(),
+                    "breed": request.POST.get("breed", "").strip(),
+                    "gender": request.POST.get("gender", "male"),
+                    "age_years": int(request.POST.get("age_years", 0) or 0),
+                    "age_months": int(request.POST.get("age_months", 0) or 0),
+                    "weight_kg": request.POST.get("weight_kg", "").strip(),
+                    "neutered": {"yes": True, "no": False}.get(request.POST.get("neutered", "")),
+                },
+                "species": pet.species,
+                "breed_options_json": json.dumps({
+                    "dog": get_breed_options("dog"),
+                    "cat": get_breed_options("cat"),
+                }),
+                "is_edit": True,
+                "age_year_options": AGE_YEAR_OPTIONS,
+                "age_month_options": AGE_MONTH_OPTIONS,
+                "breed_error_message": _breed_error_message(pet.species),
+            },
+        )
+
     pet.name = request.POST.get("name", "").strip()
-    pet.breed = request.POST.get("breed", "").strip() or None
+    pet.breed = resolved_breed
     pet.gender = request.POST.get("gender", "male")
     pet.age_years = int(request.POST.get("age_years", 0) or 0)
     pet.age_months = int(request.POST.get("age_months", 0) or 0)
@@ -542,6 +621,34 @@ def preview_pet_edit(request, pet_id):
             "weight_kg": request.POST.get("weight_kg", "").strip(),
             "neutered": request.POST.get("neutered", ""),
         }
+        resolved_breed = resolve_breed(pet.species, step2_data["breed"])
+        if not resolved_breed:
+            return render(
+                request,
+                "pets/add_step2.html",
+                {
+                    "pet": {
+                        "species": pet.species,
+                        "name": step2_data["name"],
+                        "breed": step2_data["breed"],
+                        "gender": step2_data["gender"],
+                        "age_years": step2_data["age_years"],
+                        "age_months": step2_data["age_months"],
+                        "weight_kg": step2_data["weight_kg"],
+                        "neutered": True if step2_data["neutered"] == "yes" else False if step2_data["neutered"] == "no" else None,
+                    },
+                    "species": pet.species,
+                    "breed_options_json": json.dumps({
+                        "dog": get_breed_options("dog"),
+                        "cat": get_breed_options("cat"),
+                    }),
+                    "is_edit": True,
+                    "age_year_options": AGE_YEAR_OPTIONS,
+                    "age_month_options": AGE_MONTH_OPTIONS,
+                    "breed_error_message": _breed_error_message(pet.species),
+                },
+            )
+        step2_data["breed"] = resolved_breed
         return render(
             request,
             "pets/add_step3.html",
@@ -560,6 +667,10 @@ def preview_pet_edit(request, pet_id):
         {
             "pet": pet,
             "species": pet.species,
+            "breed_options_json": json.dumps({
+                "dog": get_breed_options("dog"),
+                "cat": get_breed_options("cat"),
+            }),
             "is_edit": True,
             "is_preview_edit": True,
             "age_year_options": AGE_YEAR_OPTIONS,

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -3,16 +3,33 @@ from decimal import Decimal
 
 from django.test import TestCase
 from django.urls import reverse
+from django.db import connection
 from rest_framework import status
 from rest_framework.test import APIClient
 
 from users.models import User, UserProfile
 
+from .breeds import _breed_meta_snapshot, resolve_breed
 from .models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
+
+
+def seed_breed_meta_rows():
+    with connection.cursor() as cursor:
+        cursor.execute(
+            """
+            INSERT INTO breed_meta (species, breed_name, breed_name_en)
+            VALUES
+                ('dog', '말티즈', 'Maltese'),
+                ('cat', '브리티시 숏헤어', 'British Shorthair')
+            ON CONFLICT DO NOTHING
+            """
+        )
+    _breed_meta_snapshot.cache_clear()
 
 
 class PetApiTests(TestCase):
     def setUp(self):
+        seed_breed_meta_rows()
         self.client = APIClient()
         self.user = User.objects.create_user(email="pet-owner@example.com", password="Password123!")
         UserProfile.objects.create(user=self.user, nickname="Pet Owner")
@@ -50,7 +67,7 @@ class PetApiTests(TestCase):
                 "name": "Bori",
                 "species": "dog",
                 "gender": "male",
-                "breed": "Maltese",
+                "breed": "말티즈",
                 "age_years": 3,
                 "age_months": 2,
                 "weight_kg": "4.20",
@@ -152,6 +169,27 @@ class PetApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["detail"], "You can register up to 5 pets.")
 
+    def test_post_pets_rejects_unregistered_breed(self):
+        response = self.client.post(
+            "/api/pets/",
+            {
+                "name": "Bori",
+                "species": "dog",
+                "gender": "male",
+                "breed": "왈왈",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "breed must be one of the registered breeds.")
+
+    def test_resolve_breed_accepts_english_name_and_spacing_variants(self):
+        self.assertEqual(resolve_breed("dog", "Maltese"), "말티즈")
+        self.assertEqual(resolve_breed("cat", "British Shorthair"), "브리티시 숏헤어")
+        self.assertEqual(resolve_breed("cat", "British   Shorthair"), "브리티시 숏헤어")
+        self.assertEqual(resolve_breed("cat", "브리티시숏헤어"), "브리티시 숏헤어")
+
     def test_patch_pet_updates_fields_and_replaces_multi_value_fields(self):
         pet = Pet.objects.create(
             user=self.user,
@@ -233,6 +271,7 @@ class PetApiTests(TestCase):
 
 class PetPageTests(TestCase):
     def setUp(self):
+        seed_breed_meta_rows()
         self.user = User.objects.create_user(email="pet-page@example.com", password="Password123!")
         UserProfile.objects.create(user=self.user, nickname="Pet Page")
         self.client.force_login(self.user)
@@ -306,3 +345,22 @@ class PetPageTests(TestCase):
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response["Location"], reverse("pet_list"))
         self.assertFalse(FuturePetProfile.objects.filter(user=self.user).exists())
+
+    def test_pet_add_health_rejects_unregistered_breed(self):
+        response = self.client.post(
+            reverse("pet_add_health"),
+            {
+                "species": "dog",
+                "name": "코코",
+                "breed": "왈왈",
+                "gender": "male",
+                "age_years": "2",
+                "age_months": "0",
+                "weight_kg": "4",
+                "neutered": "yes",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "강아지 품종은 목록에서 선택해 주세요.")
+        self.assertContains(response, "왈왈")

--- a/services/django/pets/views.py
+++ b/services/django/pets/views.py
@@ -11,6 +11,7 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
 
+from .breeds import resolve_breed
 from .models import Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 
 
@@ -165,7 +166,6 @@ def _apply_pet_payload(pet, request, *, partial):
         pet.gender = gender
 
     scalar_fields = {
-        "breed": lambda value: str(value).strip() or None,
         "age_years": lambda value: _parse_integer(value, "age_years"),
         "age_months": lambda value: _parse_integer(value, "age_months"),
         "weight_kg": lambda value: _parse_decimal(value, "weight_kg"),
@@ -178,6 +178,12 @@ def _apply_pet_payload(pet, request, *, partial):
     for field, parser in scalar_fields.items():
         if field in request.data:
             setattr(pet, field, parser(request.data.get(field)))
+
+    if "breed" in request.data:
+        resolved_breed = resolve_breed(pet.species, request.data.get("breed"))
+        if not resolved_breed:
+            raise ValueError("breed must be one of the registered breeds.")
+        pet.breed = resolved_breed
 
     valid_health_concerns = {choice for choice, _ in PetHealthConcern.CONCERN_CHOICES}
     valid_food_preferences = {choice for choice, _ in PetFoodPreference.FOOD_TYPE_CHOICES}

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -52,7 +52,7 @@
               <input id="breedInput" name="breed" value="{{ pet.breed|default:'' }}" autocomplete="off" placeholder="{% if species == 'cat' %}품종을 검색해주세요 (예: 벵갈, ㅂㄱ){% else %}품종을 검색해주세요 (예: 말티즈, ㅁㅌㅈ){% endif %}" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
               <div id="breedSuggestions" class="pointer-events-none absolute left-0 right-0 top-[calc(100%+8px)] z-10 hidden max-h-[220px] overflow-y-auto rounded-[12px] border border-[#dbe7f5] bg-white p-[6px] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.10)] transition-all duration-150"></div>
             </div>
-            <p id="breedStatus" class="hidden text-right text-[12px]"></p>
+            <p id="breedStatus" class="{% if breed_error_message %}text-right text-[12px] text-[#e53e3e]{% else %}hidden text-right text-[12px]{% endif %}">{{ breed_error_message|default:'' }}</p>
           </div>
 
           <div class="space-y-[12px]">
@@ -141,10 +141,7 @@
     var highlightedBreedIndex = -1;
     var isNameComposing = false;
     var allowedNamePattern = /[^가-힣A-Za-z0-9\s]/g;
-    var breedData = {
-      dog: ['말티즈', '푸들', '포메라니안', '비숑 프리제', '시바견', '웰시 코기', '리트리버', '치와와', '불독', '요크셔테리어'],
-      cat: ['코리안 숏헤어', '브리티시 숏헤어', '러시안 블루', '스코티시 폴드', '페르시안', '샴', '먼치킨', '랙돌', '노르웨이 숲', '벵갈'],
-    };
+    var breedData = {{ breed_options_json|safe }};
     var CHOSEONG = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ'];
 
     function paintToggle(button, active) {


### PR DESCRIPTION
## 변경 사항
- breed_meta 기반 반려동물 품종 저장 검증 추가
- 영문/공백 입력을 canonical breed_name으로 정규화
- 등록/수정/API 경로 모두 임의 품종 문자열 저장 차단
- 관련 테스트 추가

## 검증
- docker compose -f infra/docker-compose.yml exec -T django python manage.py test pets.tests --keepdb
- docker compose -f infra/docker-compose.yml exec -T django python manage.py check