### PR TITLE
fix(cicd): Django EB 배포 회복 대기 시간을 늘려 false failure 방지

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -293,6 +293,7 @@ jobs:
           deployment_package: django-deploy.zip
           use_existing_version_if_available: false
           wait_for_deployment: true
+          wait_for_environment_recovery: 180
 
       - name: Resolve Django environment URL
         id: django-env


### PR DESCRIPTION
## 요약
- Django 테스트 EB 배포가 실제 반영 후 정상 회복되는데도 GitHub Actions가 너무 빨리 실패 처리하는 문제를 줄입니다.

## 변경 사항
- `beanstalk-deploy`의 `wait_for_environment_recovery`를 `180`초로 추가했습니다.
- 현재 환경에서 EB가 배포 완료 후 `Warning -> Ok`로 회복되는 데 실제로 76초가 걸린 것을 기준으로, 기본 30초 대기 때문에 발생하던 false negative 실패를 완화합니다.

## 관련 이슈
- 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- Django 테스트 EB가 배포 후 1~2분 정도 health 회복 시간을 갖는 현재 특성을 감안할 때, `180초` 대기값이 적절한지 확인 부탁드립니다.
