### PR TITLE
[fix] Django smoke test readiness 보정 (#280)

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -169,12 +169,11 @@ jobs:
             --env-file .deploy-django/.env \
             up -d
           for _ in $(seq 1 20); do
-            if curl --fail --silent http://127.0.0.1/health/ > /dev/null; then
+            if curl --fail --silent http://127.0.0.1/static/css/main.css > /dev/null; then
               break
             fi
             sleep 3
           done
-          curl --fail --silent --show-error http://127.0.0.1/health/ > /dev/null
           curl --fail --silent --show-error http://127.0.0.1/static/css/main.css > /dev/null
           curl --fail --silent --show-error http://127.0.0.1/static/admin/css/base.css > /dev/null
           curl --silent --show-error --head http://127.0.0.1/static/css/main.css | grep -qi '^Content-Type: text/css'


### PR DESCRIPTION
## 작업 내용
- deploy bundle smoke test의 readiness 기준을 에서 로 조정했습니다.
- nginx가 직접 200을 반환하는  대신 실제 static 응답이 준비될 때까지 대기하도록 바꿨습니다.

## 검증
- 브랜치 기반 GitHub Actions로 확인 예정

## 관련 이슈
- Closes #280