### PR TITLE
[feat] 채팅 반려동물 등록 유도 및 펫 UI 보강 (#270, #283, #284)

### DIFF
--- a/services/django/chat/page_views.py
+++ b/services/django/chat/page_views.py
@@ -462,6 +462,12 @@ def chat_view(request):
         member_pets.append(future_pet)
         member_pets = _sort_member_pets(member_pets)
 
+    should_offer_pet_registration_prompt = (
+        is_member_view
+        and not preview_member
+        and not member_pets
+    )
+
     if preview_member and not member_pets:
         member_pets = _preview_member_pets()
         registered_pet_count = len(member_pets)
@@ -483,6 +489,7 @@ def chat_view(request):
             "chat_enabled": chat_enabled,
             "member_pets": member_pets,
             "can_add_pet": is_member_view and registered_pet_count < 5,
+            "should_offer_pet_registration_prompt": should_offer_pet_registration_prompt,
             "active_pet_id": active_pet_id,
             "active_pet": active_pet,
             "recommended_products": recommended_products,

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -326,7 +326,7 @@ class PetPageTests(TestCase):
         UserProfile.objects.create(user=self.user, nickname="Pet Page")
         self.client.force_login(self.user)
 
-    def test_pet_list_renders_food_preference_labels(self):
+    def test_pet_list_hides_food_preference_labels(self):
         pet = Pet.objects.create(
             user=self.user,
             name="콩이",
@@ -340,9 +340,9 @@ class PetPageTests(TestCase):
         response = self.client.get(reverse("pet_list"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "선호 사료")
-        self.assertContains(response, "건식")
-        self.assertContains(response, "동결건조/에어드라이")
+        self.assertNotContains(response, "선호 사료")
+        self.assertNotContains(response, "건식")
+        self.assertNotContains(response, "동결건조/에어드라이")
 
     def test_pet_add_future_persists_profile_in_db_for_logged_in_user(self):
         response = self.client.post(

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1456,6 +1456,7 @@
   var SESSION_RECOMMENDED_PRODUCTS_STORAGE_PREFIX = 'tailtalk_session_recommended_products:';
   var activeProfileSelectionPrompt = null;
   var skipProfileSelectionPromptOnce = false;
+  var shouldOfferPetRegistrationPrompt = {{ should_offer_pet_registration_prompt|yesno:"true,false" }};
 
   function getCookie(name) {
     var cookieValue = null;
@@ -1892,17 +1893,11 @@
     return ordered;
   }
 
-  function shouldPromptProfileSelection() {
+  function shouldPromptProfileSelectionBase() {
     if (skipProfileSelectionPromptOnce) {
       skipProfileSelectionPromptOnce = false;
       return false;
     }
-
-    var options = getProfileSelectionOptions();
-    var hasSelectableProfile = options.some(function (option) {
-      return !!option.id;
-    });
-    if (!hasSelectableProfile) return false;
 
     if (activeSessionId) {
       var activeSessionState = ensureSessionState(activeSessionId);
@@ -1913,12 +1908,24 @@
     return true;
   }
 
+  function hasSelectableProfileOptions() {
+    return getProfileSelectionOptions({ includeDefaultOption: false }).length > 0;
+  }
+
+  function shouldPromptProfileSelection() {
+    return shouldPromptProfileSelectionBase() && hasSelectableProfileOptions();
+  }
+
   function shouldShowSelectedProfilePrompt() {
     return shouldPromptProfileSelection() && !!activePetId;
   }
 
   function shouldShowProfileChoicePrompt() {
     return shouldPromptProfileSelection() && !activePetId;
+  }
+
+  function shouldShowPetRegistrationPrompt() {
+    return shouldPromptProfileSelectionBase() && !hasSelectableProfileOptions() && shouldOfferPetRegistrationPrompt;
   }
 
   function applyProfileSelectionOption(option) {
@@ -2065,6 +2072,85 @@
     changeButton.appendChild(changeEmoji);
     changeButton.appendChild(changeLabel);
     optionList.appendChild(changeButton);
+
+    bubble.appendChild(optionList);
+    wrapper.appendChild(bubble);
+    chatMessages.appendChild(wrapper);
+    activeProfileSelectionPrompt = wrapper;
+    scrollToBottom();
+  }
+
+  function showPetRegistrationPrompt() {
+    if (!chatMessages || activeProfileSelectionPrompt) return;
+
+    ensureChatThreadVisible();
+
+    var wrapper = document.createElement('div');
+    wrapper.className = 'flex justify-start';
+    wrapper.setAttribute('data-profile-selection-prompt', 'true');
+
+    var bubble = document.createElement('div');
+    bubble.className = 'inline-flex w-fit max-w-[460px] flex-col self-start rounded-[24px] rounded-bl-[8px] border border-[#dbe7f5] bg-white px-[20px] py-[16px] text-[#2d3748] shadow-[0_10px_24px_rgba(45,55,72,0.06)]';
+
+    var title = document.createElement('p');
+    title.className = 'w-fit text-[15px] font-semibold leading-[1.75] text-[#2d3748]';
+    title.textContent = '등록된 반려동물 정보가 없어요';
+    bubble.appendChild(title);
+
+    var description = document.createElement('p');
+    description.className = 'mt-[6px] w-fit max-w-[320px] break-keep text-[12px] leading-[1.7] text-[#718096]';
+    description.textContent = '등록하면 더 정확하게 답변하고 추천할 수 있어요';
+    bubble.appendChild(description);
+
+    var optionList = document.createElement('div');
+    optionList.className = 'mt-[12px] flex flex-wrap gap-[8px]';
+
+    var registerButton = document.createElement('button');
+    registerButton.type = 'button';
+    registerButton.className = 'inline-flex max-w-full items-center gap-[6px] rounded-full border border-[#bfdbfe] bg-[#eff8ff] px-[11px] py-[7px] text-left transition-colors duration-150 hover:border-[#90cdf4] hover:bg-[#e3f2ff]';
+    registerButton.addEventListener('click', function () {
+      window.location.href = '/pets/add/';
+    });
+
+    var registerEmoji = document.createElement('span');
+    registerEmoji.className = 'shrink-0 text-[13px] leading-none text-[#4a5568]';
+    registerEmoji.textContent = '＋';
+
+    var registerLabel = document.createElement('p');
+    registerLabel.className = 'truncate text-[12px] font-semibold leading-none text-[#2b6cb0]';
+    registerLabel.textContent = '등록하러 가기';
+
+    registerButton.appendChild(registerEmoji);
+    registerButton.appendChild(registerLabel);
+    optionList.appendChild(registerButton);
+
+    var laterButton = document.createElement('button');
+    laterButton.type = 'button';
+    laterButton.className = 'inline-flex max-w-full items-center gap-[6px] rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[11px] py-[7px] text-left transition-colors duration-150 hover:border-[#bfdbfe] hover:bg-white';
+    laterButton.addEventListener('click', function () {
+      if (activeSessionId) {
+        ensureSessionState(activeSessionId).profilePromptResolved = true;
+      }
+      skipProfileSelectionPromptOnce = true;
+      clearProfileSelectionPrompt();
+      if (messageInput) {
+        window.setTimeout(function () {
+          submitCurrentMessage();
+        }, 0);
+      }
+    });
+
+    var laterEmoji = document.createElement('span');
+    laterEmoji.className = 'shrink-0 text-[13px] leading-none text-[#718096]';
+    laterEmoji.textContent = '○';
+
+    var laterLabel = document.createElement('p');
+    laterLabel.className = 'truncate text-[12px] font-semibold leading-none text-[#2d3748]';
+    laterLabel.textContent = '나중에 하기';
+
+    laterButton.appendChild(laterEmoji);
+    laterButton.appendChild(laterLabel);
+    optionList.appendChild(laterButton);
 
     bubble.appendChild(optionList);
     wrapper.appendChild(bubble);
@@ -3150,6 +3236,10 @@
     }
     if (shouldShowProfileChoicePrompt()) {
       showProfileSelectionPrompt();
+      return;
+    }
+    if (shouldShowPetRegistrationPrompt()) {
+      showPetRegistrationPrompt();
       return;
     }
     submitCurrentMessage();

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -83,7 +83,7 @@
           <div class="space-y-[12px]">
             <label class="block text-[14px] font-bold leading-none text-[#4a5568]">몸무게 <span class="text-[#e53e3e]">(필수)</span></label>
             <div class="relative">
-              <input id="weightInput" name="weight_kg" value="{{ pet.weight_kg|default:'' }}" maxlength="3" inputmode="numeric" pattern="[0-9]*" placeholder="몸무게를 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] pr-10 text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
+              <input id="weightInput" name="weight_kg" value="{{ pet.weight_kg|default:'' }}" maxlength="5" inputmode="decimal" pattern="[0-9]+([.][0-9])?" placeholder="몸무게를 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] pr-10 text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
               <span class="absolute right-[12px] top-1/2 -translate-y-1/2 text-[14px] leading-none text-[#4a5568]">kg</span>
             </div>
             <p id="weightStatus" class="{% if weight_error_message %}text-right text-[12px] text-[#e53e3e]{% else %}hidden text-right text-[12px]{% endif %}">{{ weight_error_message|default:'' }}</p>
@@ -160,24 +160,44 @@
       button.style.fontWeight = active ? '700' : '400';
     }
 
+    function normalizeWeight(value) {
+      var cleaned = String(value || '').replace(/[^\d.]/g, '');
+      var hasDot = cleaned.indexOf('.') >= 0;
+      var parts = cleaned.split('.');
+      var integerPart = (parts.shift() || '').replace(/^0+(?=\d)/, '');
+      var decimalPart = parts.length ? parts.join('').replace(/\./g, '').slice(0, 1) : '';
+
+      if (!integerPart && decimalPart) {
+        integerPart = '0';
+      }
+
+      integerPart = integerPart.slice(0, 3);
+
+      if (!integerPart && !decimalPart) {
+        return '';
+      }
+
+      if (hasDot) {
+        return integerPart + '.' + decimalPart;
+      }
+
+      return integerPart;
+    }
+
     function keepWeight(input) {
       var rawValue = input.value;
-      var digits = rawValue.replace(/\D/g, '').slice(0, 3);
-      digits = digits.replace(/^0+(?=\d)/, '');
-      if (/^0+$/.test(digits)) {
-        digits = '';
-      }
+      var normalized = normalizeWeight(rawValue);
       if (!rawValue.trim()) {
         input.dataset.lastValidWeight = '';
         input.value = '';
         return;
       }
-      if (!digits) {
+      if (!normalized) {
         input.value = input.dataset.lastValidWeight || '';
         return;
       }
-      input.dataset.lastValidWeight = digits;
-      input.value = digits;
+      input.dataset.lastValidWeight = normalized;
+      input.value = normalized;
     }
 
     function normalizeNameSpacing(value) {
@@ -377,6 +397,12 @@
       ) {
         return;
       }
+      if (event.key === '.') {
+        if (!weightInput.value.trim() || weightInput.value.indexOf('.') >= 0) {
+          event.preventDefault();
+        }
+        return;
+      }
       if (/^\d$/.test(event.key)) {
         return;
       }
@@ -385,13 +411,13 @@
     weightInput.addEventListener('beforeinput', function (event) {
       if (!event.data) return;
       if (event.inputType && event.inputType.indexOf('insert') !== 0) return;
-      if (/\D/.test(event.data)) {
+      if (!/^[\d.]+$/.test(event.data)) {
         event.preventDefault();
       }
     });
     weightInput.addEventListener('paste', function (event) {
       var pasted = (event.clipboardData || window.clipboardData).getData('text');
-      if (/\D/.test(pasted || '')) {
+      if (!normalizeWeight(pasted || '')) {
         event.preventDefault();
       }
     });

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -87,14 +87,6 @@
             {% if pet.breed %} · {{ pet.breed }}{% endif %}
             {% endif %}
           </div>
-          {% if pet.species != "future" and pet.food_preference_labels %}
-          <div class="mt-2 flex flex-wrap gap-2">
-            <span class="inline-flex h-[24px] items-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-bold text-[#4a5568]">선호 사료</span>
-            {% for label in pet.food_preference_labels %}
-            <span class="inline-flex h-[24px] items-center rounded-full border border-[#dbe7f5] bg-[#f7fbff] px-3 text-[12px] font-medium text-[#3182ce]">{{ label }}</span>
-            {% endfor %}
-          </div>
-          {% endif %}
         </div>
         <div class="flex items-center gap-3">
           {% if pet.species == "future" %}

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -82,9 +82,9 @@
             {% if pet.species == "future" %}
             {{ pet.summary }}
             {% else %}
-            {{ pet.age_years }}년 {{ pet.age_months }}개월
-            · {{ pet.get_gender_display }}
-            {% if pet.breed %} · {{ pet.breed }}{% endif %}
+            {% if pet.breed %}{{ pet.breed }} · {% endif %}
+            {% if pet.age_unknown %}모름{% else %}{{ pet.age_years }}년 {{ pet.age_months }}개월{% endif %}
+            {% if pet.weight_kg %} · {{ pet.weight_kg|floatformat:-1 }}kg{% endif %}
             {% endif %}
           </div>
         </div>


### PR DESCRIPTION
## 작업 내용
- 채팅 내 반려동물 등록 유도 버블 추가
- 반려동물 정보 카드 하단 태그 제거
- 반려동물 정보 카드 기본 정보 줄을 품종 · 나이 · 몸무게 순서로 정리
- 몸무게 소수점 첫째 자리 입력 허용

## 검증
- docker compose -f infra/docker-compose.yml exec -T django python manage.py test pets.tests --keepdb
- docker compose -f infra/docker-compose.yml exec -T django python manage.py check
- curl -I http://localhost/chat/
- curl -I http://localhost/pets/
- curl -I http://localhost/pets/add/details/

Closes #270
Closes #283
Closes #284
