### PR TITLE
[feat] 관리자 로그인 진입 UI 및 연락처 인증 코드 노출

### DIFF
--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -837,6 +837,11 @@
           <p class="whitespace-nowrap">맞춤형 반려동물 케어와 대화 기록 저장을 위해</p>
           <p class="mt-[2px] whitespace-nowrap">로그인을 진행해 주세요</p>
         </div>
+        <div class="absolute bottom-[69.5px] left-[20.5px] h-px w-[240px] bg-[#d9e4f0]"></div>
+        <a href="/vendor/login/"
+           class="absolute bottom-[30px] left-[24px] text-[13px] font-semibold text-[#a0aec0] transition-colors hover:text-[#718096]">
+          관리자 로그인
+        </a>
         {% endif %}
       </div>
 

--- a/services/django/templates/users/vendor_login.html
+++ b/services/django/templates/users/vendor_login.html
@@ -1,0 +1,117 @@
+{% extends "base.html" %}
+{% block title %}관리자 로그인 — TailTalk{% endblock %}
+
+{% block content %}
+<div class="min-h-screen bg-[#f7fafc]">
+  <div class="flex min-h-screen items-center justify-center px-4 py-8">
+    <div class="relative w-full max-w-[420px] overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white shadow-[0_16px_40px_rgba(45,55,72,0.08)]">
+      <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.98)_0%,rgba(247,250,252,0.98)_100%)]"></div>
+
+      <div class="relative px-8 py-9">
+        <a href="/"
+           class="mx-auto block w-fit text-center text-[26px] font-bold leading-none text-[#2d3748]">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+
+        <div class="mt-7 text-center">
+          <p class="text-[22px] font-bold text-[#2d3748]">관리자 로그인</p>
+        </div>
+
+        <form class="mt-8 space-y-4" id="vendorLoginForm" onsubmit="return false;">
+          <div>
+            <label for="vendorBrandInput" class="mb-2 block text-[13px] font-semibold text-[#4a5568]">
+              관리자 아이디
+            </label>
+            <input
+              id="vendorBrandInput"
+              type="text"
+              placeholder="아이디를 입력해 주세요"
+              class="h-[46px] w-full rounded-[12px] border border-[#dbe7f5] bg-[#f8fbff] px-4 text-[14px] text-[#2d3748] outline-none transition focus:border-[#90cdf4] focus:bg-white"
+            />
+          </div>
+
+          <div>
+            <label for="vendorPasswordInput" class="mb-2 block text-[13px] font-semibold text-[#4a5568]">
+              비밀번호
+            </label>
+            <input
+              id="vendorPasswordInput"
+              type="password"
+              placeholder="비밀번호를 입력해 주세요"
+              class="h-[46px] w-full rounded-[12px] border border-[#dbe7f5] bg-[#f8fbff] px-4 text-[14px] text-[#2d3748] outline-none transition focus:border-[#90cdf4] focus:bg-white"
+            />
+          </div>
+
+          <button
+            type="button"
+            id="vendorLoginSubmit"
+            class="mt-2 flex h-[48px] w-full items-center justify-center rounded-[12px] bg-[linear-gradient(135deg,#3b82f6_0%,#2563eb_100%)] text-[15px] font-bold text-white transition hover:opacity-95"
+          >
+            관리자 로그인
+          </button>
+          <p class="hidden text-[12px] font-semibold text-[#e53e3e]" id="vendorLoginError">
+            아이디 또는 비밀번호를 확인해 주세요
+          </p>
+        </form>
+      </div>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+  (function () {
+    var idInput = document.getElementById('vendorBrandInput');
+    var passwordInput = document.getElementById('vendorPasswordInput');
+    var submitButton = document.getElementById('vendorLoginSubmit');
+    var errorText = document.getElementById('vendorLoginError');
+
+    if (!idInput || !passwordInput || !submitButton || !errorText) {
+      return;
+    }
+
+    function hideError() {
+      errorText.classList.add('hidden');
+    }
+
+    function showError() {
+      errorText.classList.remove('hidden');
+    }
+
+    function handleSubmit() {
+      var userId = idInput.value.trim();
+      var password = passwordInput.value.trim();
+
+      if (!userId || !password) {
+        showError();
+        return;
+      }
+
+      if (userId !== 'orijen' || password !== 'tailtalk2026!') {
+        showError();
+        return;
+      }
+
+      hideError();
+      window.location.href = '/vendor/dashboard/';
+    }
+
+    submitButton.addEventListener('click', handleSubmit);
+    idInput.addEventListener('input', hideError);
+    passwordInput.addEventListener('input', hideError);
+    passwordInput.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleSubmit();
+      }
+    });
+    idInput.addEventListener('keydown', function (event) {
+      if (event.key === 'Enter') {
+        event.preventDefault();
+        handleSubmit();
+      }
+    });
+  })();
+</script>
+{% endblock %}

--- a/services/django/users/page_urls.py
+++ b/services/django/users/page_urls.py
@@ -4,6 +4,7 @@ from . import page_views
 urlpatterns = [
     path("", page_views.home, name="home"),
     path("login/", page_views.login_view, name="login"),
+    path("vendor/login/", page_views.vendor_login_view, name="vendor-login"),
     path("signup/", page_views.signup_view, name="signup"),
     path("logout/", page_views.logout_view, name="logout"),
     path("profile/", page_views.profile_view, name="profile"),

--- a/services/django/users/page_views.py
+++ b/services/django/users/page_views.py
@@ -93,6 +93,10 @@ def signup_view(request):
     return render(request, "users/signup.html")
 
 
+def vendor_login_view(request):
+    return render(request, "users/vendor_login.html")
+
+
 def logout_view(request):
     request.session.pop(SOCIAL_AUTH_ACCESS_SESSION_KEY, None)
     request.session.pop(SOCIAL_AUTH_REFRESH_SESSION_KEY, None)

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -402,8 +402,7 @@ class UserProfileApiTests(TestCase):
         self.assertEqual(quick_purchase["address_detail"], "101동 1203호")
         self.assertEqual(quick_purchase["payment_summary"], "현대카드 M / 1234 **** **** 5678")
 
-    @override_settings(DEBUG=True)
-    def test_phone_verification_request_returns_code_in_debug(self):
+    def test_phone_verification_request_returns_code(self):
         response = self.client.post(
             "/api/users/me/phone-verification/request/",
             {"phone": "01012341234"},
@@ -416,7 +415,6 @@ class UserProfileApiTests(TestCase):
         self.user.refresh_from_db()
         self.assertEqual(self.user.profile.phone_verification_target, "01012341234")
 
-    @override_settings(DEBUG=True)
     def test_phone_verification_confirm_marks_phone_verified(self):
         request_response = self.client.post(
             "/api/users/me/phone-verification/request/",

--- a/services/django/users/views.py
+++ b/services/django/users/views.py
@@ -580,9 +580,8 @@ class UserPhoneVerificationRequestView(APIView):
             "detail": "인증번호를 전송했습니다.",
             "phone": phone,
             "expires_in_seconds": 300,
+            "verification_code": verification_code,
         }
-        if settings.DEBUG:
-            response_payload["verification_code"] = verification_code
         return Response(response_payload, status=status.HTTP_200_OK)
 
 


### PR DESCRIPTION
## 변경 사항
- 비회원 채팅 좌측 패널 하단에 `관리자 로그인` 진입 링크 추가
- `/vendor/login/` 시연용 관리자 로그인 화면 추가
- 빈값/오입력 에러 문구 및 시연용 로그인 동작 추가
- 연락처 인증 요청 응답에 테스트 코드를 항상 포함하도록 조정
- 관련 users 테스트 정리

## 검증
- docker compose -f infra/docker-compose.yml exec -T django python manage.py test users.tests --keepdb
- docker compose -f infra/docker-compose.yml exec -T django python manage.py check
- curl -I http://localhost/vendor/login/
- curl -I http://localhost/profile/

## 이슈
- Closes #286
- Closes #289
