### PR TITLE
fix(auth): 소셜 로그인 callback 호스트를 현재 도메인으로 유지

### DIFF
--- a/services/django/users/social_auth.py
+++ b/services/django/users/social_auth.py
@@ -1,4 +1,5 @@
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
 from django.conf import settings
 from django.http import HttpResponseBase
@@ -45,9 +46,25 @@ def get_provider_name(backend_name: str) -> str:
 
 def build_callback_url(request, route_name: str, provider: str) -> str:
     path = reverse(route_name, kwargs={"provider": provider})
-    if settings.APP_BASE_URL:
-        return f"{settings.APP_BASE_URL.rstrip('/')}{path}"
-    return request.build_absolute_uri(path)
+    request_absolute_uri = request.build_absolute_uri(path)
+    if not settings.APP_BASE_URL:
+        return request_absolute_uri
+
+    current_host = request.get_host().split(":", 1)[0]
+    app_base_host = urlparse(settings.APP_BASE_URL).hostname or ""
+    same_site_hosts = {app_base_host}
+    if app_base_host.startswith("www."):
+        same_site_hosts.add(app_base_host.removeprefix("www."))
+    elif app_base_host:
+        same_site_hosts.add(f"www.{app_base_host}")
+
+    # Keep the callback on the host the user actually used when it is one of
+    # our public domains. This prevents OAuth state from being stored on one
+    # host (for example www) and validated on another (for example apex).
+    if current_host in same_site_hosts:
+        return request_absolute_uri
+
+    return f"{settings.APP_BASE_URL.rstrip('/')}{path}"
 
 
 def build_authorization_url(request, provider: str, redirect_uri: str, next_url: str | None = None) -> str:

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -1,6 +1,6 @@
 from unittest.mock import patch
 
-from django.test import TestCase, override_settings
+from django.test import RequestFactory, TestCase, override_settings
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -16,6 +16,7 @@ from users.social_auth import (
     SOCIAL_AUTH_ACCESS_SESSION_KEY,
     SOCIAL_AUTH_REFRESH_SESSION_KEY,
     SocialLoginResult,
+    build_callback_url,
 )
 from users.social_pipeline import associate_active_user_by_email
 
@@ -47,6 +48,9 @@ TEST_SOCIAL_PROVIDERS = {
 
 @override_settings(SOCIAL_AUTH_PROVIDERS=TEST_SOCIAL_PROVIDERS)
 class SocialLoginPageViewTests(TestCase):
+    def setUp(self):
+        self.factory = RequestFactory()
+
     @patch("users.page_views.build_authorization_url")
     def test_social_login_start_redirects_to_provider(self, build_authorization_url_mock):
         build_authorization_url_mock.return_value = "https://nid.naver.com/oauth2.0/authorize?state=test"
@@ -80,6 +84,40 @@ class SocialLoginPageViewTests(TestCase):
         self.assertIn(SOCIAL_AUTH_ACCESS_SESSION_KEY, session)
         self.assertIn(SOCIAL_AUTH_REFRESH_SESSION_KEY, session)
         self.assertTrue(session[ONBOARDING_FORCE_PROFILE_SESSION_KEY])
+
+    @override_settings(
+        APP_BASE_URL="https://tailtalk.store",
+        ALLOWED_HOSTS=[
+            "tailtalk.store",
+            "www.tailtalk.store",
+            "test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com",
+        ],
+    )
+    def test_build_callback_url_preserves_www_host_for_public_domain(self):
+        request = self.factory.get("/auth/google/start/")
+        request.META["HTTP_HOST"] = "www.tailtalk.store"
+        request.META["HTTP_X_FORWARDED_PROTO"] = "https"
+
+        callback_url = build_callback_url(request, "social-login-callback", "google")
+
+        self.assertEqual(callback_url, "https://www.tailtalk.store/auth/google/callback/")
+
+    @override_settings(
+        APP_BASE_URL="https://tailtalk.store",
+        ALLOWED_HOSTS=[
+            "tailtalk.store",
+            "www.tailtalk.store",
+            "test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com",
+        ],
+    )
+    def test_build_callback_url_falls_back_to_app_base_for_non_public_host(self):
+        request = self.factory.get("/auth/google/start/")
+        request.META["HTTP_HOST"] = "test-tailtalk-django-env.eba-idn3t8gh.ap-northeast-2.elasticbeanstalk.com"
+        request.META["HTTP_X_FORWARDED_PROTO"] = "https"
+
+        callback_url = build_callback_url(request, "social-login-callback", "google")
+
+        self.assertEqual(callback_url, "https://tailtalk.store/auth/google/callback/")
 
     def test_associate_active_user_by_email_ignores_inactive_user(self):
         withdrawn_user = User.objects.create_user(email="social@example.com")


### PR DESCRIPTION
## 요약
- 소셜 로그인 callback URL이 로그인 시작 호스트를 유지하도록 수정해 `state` 세션 검증 실패를 방지했습니다.

## 변경 사항
- `build_callback_url`이 `APP_BASE_URL`만 강제 사용하지 않고, `tailtalk.store`/`www.tailtalk.store`로 시작한 요청은 현재 호스트 기준 callback URL을 사용하도록 변경했습니다.
- Elastic Beanstalk CNAME 같은 비공개 호스트로 접근한 경우에는 기존처럼 `APP_BASE_URL`을 fallback으로 사용하도록 유지했습니다.
- `www` 호스트 보존과 fallback 동작을 검증하는 회귀 테스트를 추가했습니다.

## 관련 이슈
- 관련 이슈 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 커스텀 도메인(`tailtalk.store`, `www.tailtalk.store`)에서 시작한 소셜 로그인 흐름만 현재 호스트를 유지하고, EB CNAME 접근은 기존 fallback을 타는지 봐주세요.
