### PR TITLE
[fix] 테스트 Django EB worker 수를 1로 조정

### DIFF
--- a/deploy/eb/test-django/docker-compose.yml
+++ b/deploy/eb/test-django/docker-compose.yml
@@ -17,7 +17,7 @@ services:
     command: >
       sh -c "python manage.py migrate --noinput &&
              python manage.py collectstatic --noinput &&
-             gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 3"
+             gunicorn config.wsgi:application --bind 0.0.0.0:8000 --workers 1"
     volumes:
       - django_static:/app/staticfiles
     environment:


### PR DESCRIPTION
## 요약
테스트 Django EB 배포 설정의 Gunicorn worker 수를 3에서 1로 조정했습니다.

## 변경 사항
- 테스트용 Django EB 배포 컨테이너의 Gunicorn worker 수를 3에서 1로 낮췄습니다.
- 작은 인스턴스에서 메모리 사용량을 줄여 기동 안정성을 높이려는 목적입니다.
- 운영 환경 설정이나 로컬 개발용 compose는 건드리지 않았습니다.

## 관련 이슈
없음

## 체크리스트
- [ ] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 테스트 EB 환경에서 배포 후 메모리 여유와 응답성만 집중해서 확인 부탁드립니다.
