### PR TITLE
fix(chat): Django에서 FastAPI 스트림 대기 시간을 제한하도록 수정

### DIFF
--- a/services/django/chat/api_views.py
+++ b/services/django/chat/api_views.py
@@ -63,6 +63,15 @@ def _map_upstream_exception(exc):
     return "채팅 서버와 연결하지 못했습니다. 잠시 후 다시 시도해 주세요.", 502
 
 
+def _stream_timeout():
+    return httpx.Timeout(
+        connect=settings.FASTAPI_STREAM_CONNECT_TIMEOUT,
+        read=settings.FASTAPI_STREAM_READ_TIMEOUT,
+        write=settings.FASTAPI_STREAM_WRITE_TIMEOUT,
+        pool=settings.FASTAPI_STREAM_POOL_TIMEOUT,
+    )
+
+
 def _serialize_session(session):
     updated_at = timezone.localtime(session.updated_at)
     return {
@@ -206,7 +215,7 @@ def _stream_fastapi_response(url, payload, user_id, capture=None):
     headers = _internal_headers(user_id)
 
     try:
-        with httpx.Client(timeout=None) as client:
+        with httpx.Client(timeout=_stream_timeout()) as client:
             with client.stream("POST", url, headers=headers, json=payload) as response:
                 if response.status_code != 200:
                     detail = "채팅 요청 처리에 실패했습니다."

--- a/services/django/config/settings.py
+++ b/services/django/config/settings.py
@@ -192,6 +192,10 @@ MEDIA_ROOT = BASE_DIR / "media"
 APP_BASE_URL = config("APP_BASE_URL", default="")
 FASTAPI_INTERNAL_CHAT_URL = config("FASTAPI_INTERNAL_CHAT_URL", default="http://fastapi:8001/api/chat/")
 INTERNAL_SERVICE_TOKEN = config("INTERNAL_SERVICE_TOKEN", default="dev-internal-token")
+FASTAPI_STREAM_CONNECT_TIMEOUT = config("FASTAPI_STREAM_CONNECT_TIMEOUT", default=5, cast=float)
+FASTAPI_STREAM_READ_TIMEOUT = config("FASTAPI_STREAM_READ_TIMEOUT", default=25, cast=float)
+FASTAPI_STREAM_WRITE_TIMEOUT = config("FASTAPI_STREAM_WRITE_TIMEOUT", default=10, cast=float)
+FASTAPI_STREAM_POOL_TIMEOUT = config("FASTAPI_STREAM_POOL_TIMEOUT", default=5, cast=float)
 
 AWS_S3_BUCKET_NAME = config("AWS_S3_BUCKET_NAME", default="")
 AWS_S3_REGION_NAME = config("AWS_S3_REGION_NAME", default="")


### PR DESCRIPTION
## 요약
- Django가 FastAPI SSE 응답을 무기한 기다리지 않도록 스트림 timeout 설정을 추가했습니다.

## 변경 사항
- Django 설정에 FastAPI 스트림 연결/읽기/쓰기/pool timeout 값을 추가했습니다.
- 채팅 프록시에서 `httpx.Client(timeout=None)` 대신 설정 기반 timeout 객체를 사용하도록 변경했습니다.
- FastAPI 응답이 비정상적으로 지연될 때 Django worker가 무기한 점유되지 않도록 보호 장치를 추가했습니다.

## 관련 이슈
- ref 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 현재 읽기 timeout 25초가 실제 채팅 UX에 적절한지 확인 부탁드립니다.
- FastAPI 쪽 timeout/폴백과 합쳐졌을 때 사용자에게 과도하게 빠른 실패로 보이지 않는지 같이 봐주세요.