### PR TITLE
[frontend] 회원 영역 공통 헤더와 프로필/반려동물 UI 정리 (#310)

### DIFF
--- a/services/django/templates/pets/add_future.html
+++ b/services/django/templates/pets/add_future.html
@@ -1,14 +1,203 @@
 {% extends "base.html" %}
 {% block title %}예비 집사 등록 — TailTalk{% endblock %}
 
-{% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
-    <a href="/chat/" class="absolute left-4 top-4 text-[22px] font-bold leading-none text-[#2d3748] md:left-8 md:top-8 md:text-[26px]" aria-label="메인으로 이동">
-      <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-    </a>
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
 
-    <div class="flex w-full max-w-[720px] flex-col rounded-[18px] border border-[#e2e8f0] bg-white px-5 pb-6 pt-0 shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #petsAddHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #petsAddHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #petsAddHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #petsAddViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="petsAddHeader">
+      <div id="petsAddHeaderInner">
+        <div></div>
+        <a href="/chat/" id="petsAddHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <div id="petsAddViewport" class="flex items-start justify-center px-4 py-8 md:items-center">
+      <div class="flex w-full max-w-[720px] flex-col rounded-[18px] border border-[#e2e8f0] bg-white px-5 pb-6 pt-0 shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
       <div class="grid grid-cols-2 gap-[10px]">
         <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
         <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
@@ -93,6 +282,7 @@
           </button>
         </div>
       </form>
+      </div>
     </div>
   </div>
 </div>
@@ -101,6 +291,8 @@
 {% block scripts %}
 <script>
   (function () {
+    var profileMenu = document.getElementById('profileMenu');
+    var profileMenuWrapper = document.getElementById('profileMenuWrapper');
     var preferredSpeciesInput = document.getElementById('preferredSpeciesInput');
     var preferredSpeciesStatus = document.getElementById('preferredSpeciesStatus');
     var submitButton = document.getElementById('futureSubmitButton');
@@ -172,6 +364,17 @@
         }
       });
     }
+
+    window.toggleProfileMenu = function toggleProfileMenu() {
+      if (!profileMenu) return;
+      profileMenu.classList.toggle('is-open');
+    };
+
+    document.addEventListener('click', function (event) {
+      if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+        profileMenu.classList.remove('is-open');
+      }
+    });
 
     syncSelectable(
       '.interest-option',

--- a/services/django/templates/pets/add_step1.html
+++ b/services/django/templates/pets/add_step1.html
@@ -1,14 +1,203 @@
 {% extends "base.html" %}
 {% block title %}반려동물 등록 — TailTalk{% endblock %}
 
-{% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
-    <a href="/chat/" class="absolute left-4 top-4 text-[22px] font-bold leading-none text-[#2d3748] md:left-8 md:top-8 md:text-[26px]" aria-label="메인으로 이동">
-      <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-    </a>
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
 
-    <div class="w-full max-w-[720px] rounded-[20px] border border-[#dbe7f5] bg-white px-5 py-6 shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:py-[32px]">
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #petsAddHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #petsAddHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #petsAddHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #petsAddViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="petsAddHeader">
+      <div id="petsAddHeaderInner">
+        <div></div>
+        <a href="/chat/" id="petsAddHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <div id="petsAddViewport" class="flex items-start justify-center px-4 py-8 md:items-center">
+      <div class="w-full max-w-[720px] rounded-[20px] border border-[#dbe7f5] bg-white px-5 py-6 shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:py-[32px]">
       <div class="grid grid-cols-3 gap-[10px]">
         <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
         <span class="h-[6px] rounded-full bg-[#e2e8f0]"></span>
@@ -38,6 +227,7 @@
       >
         다음 단계로 (기본 정보 입력)
       </button>
+      </div>
     </div>
   </div>
 </div>
@@ -46,9 +236,16 @@
 {% block scripts %}
 <script>
   (function () {
+    var profileMenu = document.getElementById('profileMenu');
+    var profileMenuWrapper = document.getElementById('profileMenuWrapper');
     var selectedSpecies = null;
     var buttons = Array.from(document.querySelectorAll('.species-btn'));
     var nextButton = document.getElementById('nextStepButton');
+
+    window.toggleProfileMenu = function toggleProfileMenu() {
+      if (!profileMenu) return;
+      profileMenu.classList.toggle('is-open');
+    };
 
     function updateButtons() {
       buttons.forEach(function (button) {
@@ -78,6 +275,12 @@
         return;
       }
       window.location.href = '/pets/add/details/?type=' + selectedSpecies;
+    });
+
+    document.addEventListener('click', function (event) {
+      if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+        profileMenu.classList.remove('is-open');
+      }
     });
   })();
 </script>

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -1,14 +1,203 @@
 {% extends "base.html" %}
 {% block title %}{% if is_edit %}반려동물 수정{% else %}반려동물 등록{% endif %} — TailTalk{% endblock %}
 
-{% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
-    <a href="/chat/" class="absolute left-4 top-4 text-[22px] font-bold leading-none text-[#2d3748] md:left-8 md:top-8 md:text-[26px]" aria-label="메인으로 이동">
-      <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-    </a>
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
 
-    <div class="flex w-full max-w-[720px] flex-col rounded-[18px] border border-[#e2e8f0] bg-white px-5 pb-6 {% if is_edit %}pt-8{% else %}pt-0{% endif %} shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:h-[610px] md:px-[40px] md:pb-[32px]">
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #petsAddHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #petsAddHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #petsAddHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #petsAddViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="petsAddHeader">
+      <div id="petsAddHeaderInner">
+        <div></div>
+        <a href="/chat/" id="petsAddHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <div id="petsAddViewport" class="flex items-start justify-center px-4 py-8 md:items-center">
+      <div class="flex w-full max-w-[720px] flex-col rounded-[18px] border border-[#e2e8f0] bg-white px-5 pb-6 {% if is_edit %}pt-8{% else %}pt-0{% endif %} shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
       {% if not is_edit %}
       <div class="grid grid-cols-3 gap-[10px]">
         <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
@@ -39,7 +228,7 @@
         <input type="hidden" name="food_preferences" value="{{ food }}" />
         {% endfor %}
 
-        <div class="mt-[30px] grid gap-x-[28px] gap-y-[24px] {% if is_edit %}grid-cols-2{% else %}grid-cols-1 sm:grid-cols-2{% endif %} {% if is_edit %}gap-y-[28px]{% else %}sm:gap-y-[28px]{% endif %}">
+        <div class="mt-[30px] grid grid-cols-1 gap-x-[28px] gap-y-[28px] md:grid-cols-2">
           <div class="space-y-[12px]">
             <label class="block text-[14px] font-bold leading-none text-[#4a5568]">이름 <span class="text-[#e53e3e]">(필수)</span></label>
             <input id="nameInput" name="name" value="{{ pet.name|default:'' }}" maxlength="12" placeholder="반려동물의 이름을 입력해주세요" class="h-[42px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] leading-none text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]" />
@@ -108,16 +297,17 @@
           </div>
         </div>
 
-        <div class="mt-[20px] flex flex-col-reverse gap-[10px] pt-[4px] md:mt-auto md:flex-row md:items-end md:gap-[14px] md:pt-[24px]">
+        <div class="mt-[20px] flex flex-row items-end gap-[10px] pt-[4px] md:gap-[14px] md:pt-[24px]">
           {% if is_edit %}
-          <a href="/pets/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">취소</a>
+          <a href="/pets/" class="flex h-[44px] min-w-[104px] shrink-0 items-center justify-center rounded-[10px] bg-[#edf2f7] px-[16px] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">취소</a>
           <button id="nextButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음으로</button>
           {% else %}
-          <a href="/pets/add/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">이전으로</a>
+          <a href="/pets/add/" class="flex h-[44px] min-w-[104px] shrink-0 items-center justify-center rounded-[10px] bg-[#edf2f7] px-[16px] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[148px]">이전으로</a>
           <button id="nextButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold leading-none text-white transition-colors hover:bg-[#2b6cb0]">다음으로</button>
           {% endif %}
         </div>
       </form>
+      </div>
     </div>
   </div>
 </div>
@@ -126,6 +316,8 @@
 {% block scripts %}
 <script>
   (function () {
+    var profileMenu = document.getElementById('profileMenu');
+    var profileMenuWrapper = document.getElementById('profileMenuWrapper');
     var form = document.querySelector('form[action]');
     var species = '{{ species|escapejs }}';
     var genderInput = document.getElementById('genderInput');
@@ -550,6 +742,17 @@
         }
       });
     }
+
+    window.toggleProfileMenu = function toggleProfileMenu() {
+      if (!profileMenu) return;
+      profileMenu.classList.toggle('is-open');
+    };
+
+    document.addEventListener('click', function (event) {
+      if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+        profileMenu.classList.remove('is-open');
+      }
+    });
 
     syncGender(genderInput.value || '');
     syncNeutered(neuteredInput.value || '');

--- a/services/django/templates/pets/add_step3.html
+++ b/services/django/templates/pets/add_step3.html
@@ -1,14 +1,265 @@
 {% extends "base.html" %}
 {% block title %}{% if is_edit %}반려동물 수정{% else %}반려동물 등록{% endif %} — TailTalk{% endblock %}
 
-{% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="relative flex min-h-screen w-full items-center justify-center px-4 py-8">
-    <a href="/chat/" class="absolute left-4 top-4 text-[22px] font-bold leading-none text-[#2d3748] md:left-8 md:top-8 md:text-[26px]" aria-label="메인으로 이동">
-      <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-    </a>
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
 
-    <div class="w-full max-w-[720px] rounded-[20px] border border-[#e2e8f0] bg-white px-5 pb-6 {% if is_edit %}pt-8{% else %}pt-0{% endif %} shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #petsAddHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #petsAddHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #petsAddHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #petsAddViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
+  #vaccinationDateSheet {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background: rgba(45, 55, 72, 0.28);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease-out;
+  }
+
+  #vaccinationDateSheet.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  #vaccinationDateSheetPanel {
+    width: min(calc(100vw - 16px), 430px);
+    border-radius: 24px 24px 0 0;
+    background: #ffffff;
+    box-shadow: 0 -18px 44px rgba(45, 55, 72, 0.16);
+    transform: translateY(104%);
+    transition: transform 0.24s ease-out;
+  }
+
+  #vaccinationDateSheet.is-open #vaccinationDateSheetPanel {
+    transform: translateY(0);
+  }
+
+  #budgetRangeSheet {
+    position: fixed;
+    inset: 0;
+    z-index: 80;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+    background: rgba(45, 55, 72, 0.28);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease-out;
+  }
+
+  #budgetRangeSheet.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  #budgetRangeSheetPanel {
+    width: min(calc(100vw - 16px), 430px);
+    border-radius: 24px 24px 0 0;
+    background: #ffffff;
+    box-shadow: 0 -18px 44px rgba(45, 55, 72, 0.16);
+    transform: translateY(104%);
+    transition: transform 0.24s ease-out;
+  }
+
+  #budgetRangeSheet.is-open #budgetRangeSheetPanel {
+    transform: translateY(0);
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="petsAddHeader">
+      <div id="petsAddHeaderInner">
+        <div></div>
+        <a href="/chat/" id="petsAddHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <div id="petsAddViewport" class="flex items-start justify-center px-4 py-8 md:items-center">
+      <div class="w-full max-w-[720px] rounded-[20px] border border-[#e2e8f0] bg-white px-5 pb-6 {% if is_edit %}pt-8{% else %}pt-0{% endif %} shadow-[0_6px_20px_rgba(45,55,72,0.04)] md:px-[40px] md:pb-[32px]">
       {% if not is_edit %}
       <div class="grid grid-cols-3 gap-[10px]">
         <span class="h-[6px] rounded-full bg-[#3182ce]"></span>
@@ -23,7 +274,9 @@
           {% if species == "cat" %}고양이 건강/식이 정보{% elif species == "future" %}예비 집사 건강/식이 정보{% else %}강아지 건강/식이 정보{% endif %}
         </span>
       </div>
-      <p class="mt-[14px] text-[15px] leading-snug text-[#718096] md:text-[16px] md:leading-none">건강과 식이 정보를 입력하면 맞춤 추천에 반영할 수 있어요</p>
+      <p class="mt-[14px] max-w-[260px] text-[15px] leading-[1.45] text-[#718096] break-keep md:max-w-none md:text-[16px] md:leading-none">
+        건강과 식이 정보를 입력하면 맞춤 추천에 반영할 수 있어요
+      </p>
 
       <form method="post" action="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/health/{% elif is_edit %}/pets/{{ pet_id }}/edit/health/{% else %}/pets/add/health/{% endif %}" class="mt-[18px]">
         {% csrf_token %}
@@ -63,9 +316,19 @@
               <label class="food-option flex min-h-[42px] flex-1 cursor-pointer items-center justify-center rounded-[8px] border px-2 py-2 text-[14px] {% if value in step3_data.food_preferences %}border-[#3182ce] bg-[#f7fbff] font-bold text-[#3182ce]{% else %}border-[#e2e8f0] bg-white text-[#4a5568]{% endif %}">
                 <input type="checkbox" class="hidden food-checkbox" name="food_preferences" value="{{ value }}" {% if value in step3_data.food_preferences %}checked{% endif %} />
                 {% if species == "dog" and value == "freeze_dried" %}
-                <span class="block text-center leading-[1.1] whitespace-normal">
-                  <span class="block">동결건조/</span>
+                <span class="block text-center text-[13px] leading-[1.15] whitespace-normal break-keep">
+                  <span class="block">동결건조</span>
                   <span class="block">에어드라이</span>
+                </span>
+                {% elif species == "cat" and value == "wet_pouch" %}
+                <span class="block text-center text-[13px] leading-[1.15] whitespace-normal break-keep">
+                  <span class="block">주식</span>
+                  <span class="block">파우치</span>
+                </span>
+                {% elif species == "cat" and value == "freeze_dried" %}
+                <span class="block text-center text-[13px] leading-[1.15] whitespace-normal break-keep">
+                  <span class="block">에어</span>
+                  <span class="block">동결건조</span>
                 </span>
                 {% else %}
                 {{ label }}
@@ -105,15 +368,6 @@
                 placeholder="YYYY-MM-DD"
                 class="h-[42px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] pr-[52px] text-[14px] text-[#2d3748] outline-none placeholder:text-[#a0aec0] focus:border-[#90cdf4]"
               />
-              <input
-                type="date"
-                id="vaccinationDatePicker"
-                value="{{ step3_data.vaccination_date }}"
-                min="2000-01-01"
-                tabindex="-1"
-                aria-hidden="true"
-                class="pointer-events-none absolute right-[10px] top-1/2 h-[1px] w-[1px] -translate-y-1/2 opacity-0"
-              />
               <button
                 type="button"
                 id="vaccinationDatePickerButton"
@@ -130,24 +384,81 @@
             <label class="mb-[8px] block text-[14px] font-bold text-[#4a5568]">
               월 예산대 <span class="text-[#a0aec0]">(선택)</span>
             </label>
-            <select name="budget_range" class="h-[42px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] text-[14px] text-[#2d3748] outline-none focus:border-[#90cdf4]">
-              <option value="">선택해주세요</option>
-              {% for value, label in budget_options %}
-              <option value="{{ value }}" {% if step3_data.budget_range == value %}selected{% endif %}>{{ label }}</option>
-              {% endfor %}
-            </select>
+            <input type="hidden" id="budgetRangeValue" name="budget_range" value="{{ step3_data.budget_range }}" />
+            <button
+              type="button"
+              id="budgetRangeButton"
+              class="flex h-[42px] w-full items-center rounded-[8px] border border-[#e2e8f0] bg-white px-[14px] text-left text-[14px] text-[#2d3748] outline-none transition-colors hover:border-[#cbd5e0]"
+            >
+              <span id="budgetRangeDisplay" class="{% if step3_data.budget_range %}text-[#2d3748]{% else %}text-[#a0aec0]{% endif %}">
+                {% if step3_data.budget_range %}
+                  {% for value, label in budget_options %}{% if step3_data.budget_range == value %}{{ label }}{% endif %}{% endfor %}
+                {% else %}
+                  선택해주세요
+                {% endif %}
+              </span>
+            </button>
           </div>
         </div>
 
-        <div class="mt-[28px] flex flex-col-reverse gap-[10px] md:flex-row md:items-end md:gap-[14px]">
+        <div class="mt-[28px] flex flex-row items-end gap-[10px] md:gap-[14px]">
           <a
             href="{% if is_preview_edit %}/pets/preview/{{ pet_id }}/edit/{% elif is_edit %}/pets/{{ pet_id }}/edit/{% else %}/pets/add/details/{% endif %}"
             id="step3BackLink"
-            class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568] md:w-[128px]"
+            class="flex h-[44px] min-w-[104px] shrink-0 items-center justify-center rounded-[10px] bg-[#edf2f7] px-[16px] text-[16px] font-bold text-[#4a5568] md:w-[128px]"
           >이전으로</a>
           <button type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white">{% if is_edit %}수정 완료{% else %}등록 완료{% endif %}</button>
         </div>
       </form>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="vaccinationDateSheet" aria-hidden="true">
+  <div id="vaccinationDateSheetPanel" role="dialog" aria-modal="true" aria-labelledby="vaccinationDateSheetTitle" class="px-5 pb-6 pt-3">
+    <div class="mx-auto h-[5px] w-[44px] rounded-full bg-[#d7dee8]"></div>
+    <div class="mt-4 flex items-center justify-between">
+      <div>
+        <h2 id="vaccinationDateSheetTitle" class="text-[17px] font-bold text-[#2d3748]">접종일 선택</h2>
+        <p class="mt-1 text-[13px] text-[#718096]">마지막 접종일을 선택해 주세요</p>
+      </div>
+    </div>
+
+    <div class="mt-5 grid grid-cols-3 gap-3">
+      <label class="block">
+        <span class="mb-2 block text-[13px] font-bold text-[#4a5568]">연도</span>
+        <select id="vaccinationYearSelect" class="h-[44px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[14px] text-[#2d3748] outline-none focus:border-[#90cdf4]"></select>
+      </label>
+      <label class="block">
+        <span class="mb-2 block text-[13px] font-bold text-[#4a5568]">월</span>
+        <select id="vaccinationMonthSelect" class="h-[44px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[14px] text-[#2d3748] outline-none focus:border-[#90cdf4]"></select>
+      </label>
+      <label class="block">
+        <span class="mb-2 block text-[13px] font-bold text-[#4a5568]">일</span>
+        <select id="vaccinationDaySelect" class="h-[44px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[14px] text-[#2d3748] outline-none focus:border-[#90cdf4]"></select>
+      </label>
+    </div>
+
+    <div class="mt-6">
+      <button type="button" id="vaccinationDateApplyButton" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#3182ce] text-[15px] font-bold text-white">적용</button>
+    </div>
+  </div>
+</div>
+
+<div id="budgetRangeSheet" aria-hidden="true">
+  <div id="budgetRangeSheetPanel" role="dialog" aria-modal="true" aria-labelledby="budgetRangeSheetTitle" class="px-5 pb-6 pt-3">
+    <div class="mx-auto h-[5px] w-[44px] rounded-full bg-[#d7dee8]"></div>
+    <div class="mt-4">
+      <h2 id="budgetRangeSheetTitle" class="text-[17px] font-bold text-[#2d3748]">월 예산대 선택</h2>
+      <p class="mt-1 text-[13px] text-[#718096]">반려동물에게 쓰는 월 예산대를 골라 주세요</p>
+    </div>
+
+    <div class="mt-5 space-y-2">
+      <button type="button" class="budget-option-button flex h-[46px] w-full items-center rounded-[12px] border border-[#e2e8f0] px-4 text-left text-[14px] font-medium text-[#2d3748]" data-value="" data-label="선택해주세요">선택 안 함</button>
+      {% for value, label in budget_options %}
+      <button type="button" class="budget-option-button flex h-[46px] w-full items-center rounded-[12px] border border-[#e2e8f0] px-4 text-left text-[14px] font-medium text-[#2d3748]" data-value="{{ value }}" data-label="{{ label }}">{{ label }}</button>
+      {% endfor %}
     </div>
   </div>
 </div>
@@ -156,6 +467,9 @@
 {% block scripts %}
 <script>
   (function () {
+    var profileMenu = document.getElementById('profileMenu');
+    var profileMenuWrapper = document.getElementById('profileMenuWrapper');
+
     function syncSelectable(className, inputClass, activeClass, inactiveClass) {
       var labels = Array.from(document.querySelectorAll(className));
       labels.forEach(function (label) {
@@ -177,9 +491,19 @@
 
     var backLink = document.getElementById('step3BackLink');
     var vaccinationDateInput = document.getElementById('vaccinationDateInput');
-    var vaccinationDatePicker = document.getElementById('vaccinationDatePicker');
     var vaccinationDatePickerButton = document.getElementById('vaccinationDatePickerButton');
     var vaccinationDateStatus = document.getElementById('vaccinationDateStatus');
+    var vaccinationDateSheet = document.getElementById('vaccinationDateSheet');
+    var vaccinationDateSheetPanel = document.getElementById('vaccinationDateSheetPanel');
+    var vaccinationYearSelect = document.getElementById('vaccinationYearSelect');
+    var vaccinationMonthSelect = document.getElementById('vaccinationMonthSelect');
+    var vaccinationDaySelect = document.getElementById('vaccinationDaySelect');
+    var vaccinationDateApplyButton = document.getElementById('vaccinationDateApplyButton');
+    var budgetRangeValue = document.getElementById('budgetRangeValue');
+    var budgetRangeButton = document.getElementById('budgetRangeButton');
+    var budgetRangeDisplay = document.getElementById('budgetRangeDisplay');
+    var budgetRangeSheet = document.getElementById('budgetRangeSheet');
+    var budgetOptionButtons = Array.from(document.querySelectorAll('.budget-option-button'));
 
     function clearStatus(node) {
       if (!node) return;
@@ -278,10 +602,106 @@
       return value >= min && value <= max;
     }
 
-    function syncVaccinationPickerBounds() {
-      if (!vaccinationDatePicker) return;
-      vaccinationDatePicker.min = '2000-01-01';
-      vaccinationDatePicker.max = getTodayParts().iso;
+    function getDaysInMonth(year, month) {
+      return new Date(year, month, 0).getDate();
+    }
+
+    function fillYearOptions(selectedYear) {
+      if (!vaccinationYearSelect) return;
+      var today = getTodayParts();
+      var options = ['<option value="">연도</option>'];
+      for (var year = today.year; year >= 2000; year -= 1) {
+        var selected = Number(selectedYear) === year ? ' selected' : '';
+        options.push('<option value="' + year + '"' + selected + '>' + year + '</option>');
+      }
+      vaccinationYearSelect.innerHTML = options.join('');
+    }
+
+    function fillMonthOptions(selectedMonth) {
+      if (!vaccinationMonthSelect) return;
+      var options = ['<option value="">월</option>'];
+      for (var month = 1; month <= 12; month += 1) {
+        var selected = Number(selectedMonth) === month ? ' selected' : '';
+        options.push('<option value="' + month + '"' + selected + '>' + month + '</option>');
+      }
+      vaccinationMonthSelect.innerHTML = options.join('');
+    }
+
+    function fillDayOptions(year, month, selectedDay) {
+      if (!vaccinationDaySelect) return;
+      var maxDay = year && month ? getDaysInMonth(year, month) : 31;
+      var options = ['<option value="">일</option>'];
+      for (var day = 1; day <= maxDay; day += 1) {
+        var selected = Number(selectedDay) === day ? ' selected' : '';
+        options.push('<option value="' + day + '"' + selected + '>' + day + '</option>');
+      }
+      vaccinationDaySelect.innerHTML = options.join('');
+    }
+
+    function syncSheetFromInput() {
+      var today = getTodayParts();
+      var year = today.year;
+      var month = today.month;
+      var day = today.day;
+
+      if (vaccinationDateInput && /^\d{4}-\d{2}-\d{2}$/.test(vaccinationDateInput.value)) {
+        var parts = vaccinationDateInput.value.split('-');
+        year = Number(parts[0]);
+        month = Number(parts[1]);
+        day = Number(parts[2]);
+      }
+
+      fillYearOptions(year);
+      fillMonthOptions(month);
+      fillDayOptions(year, month, day);
+    }
+
+    function closeVaccinationDateSheet() {
+      if (!vaccinationDateSheet) return;
+      vaccinationDateSheet.classList.remove('is-open');
+      vaccinationDateSheet.setAttribute('aria-hidden', 'true');
+    }
+
+    function openVaccinationDateSheet() {
+      if (!vaccinationDateSheet) return;
+      syncSheetFromInput();
+      vaccinationDateSheet.classList.add('is-open');
+      vaccinationDateSheet.setAttribute('aria-hidden', 'false');
+    }
+
+    function syncBudgetOptionState() {
+      if (!budgetOptionButtons.length || !budgetRangeValue) return;
+      budgetOptionButtons.forEach(function (button) {
+        var active = button.dataset.value === budgetRangeValue.value;
+        button.classList.toggle('border-[#3182ce]', active);
+        button.classList.toggle('bg-[#f7fbff]', active);
+        button.classList.toggle('font-bold', active);
+        button.classList.toggle('text-[#3182ce]', active);
+        button.classList.toggle('border-[#e2e8f0]', !active);
+        button.classList.toggle('text-[#2d3748]', !active);
+      });
+    }
+
+    function setBudgetRangeValue(value, label) {
+      if (!budgetRangeValue || !budgetRangeDisplay) return;
+      budgetRangeValue.value = value || '';
+      budgetRangeDisplay.textContent = label || '선택해주세요';
+      budgetRangeDisplay.classList.toggle('text-[#a0aec0]', !value);
+      budgetRangeDisplay.classList.toggle('text-[#2d3748]', !!value);
+      syncBudgetOptionState();
+    }
+
+    function closeBudgetRangeSheet() {
+      if (!budgetRangeSheet) return;
+      budgetRangeSheet.classList.remove('is-open');
+      budgetRangeSheet.setAttribute('aria-hidden', 'true');
+    }
+
+    function openBudgetRangeSheet() {
+      if (!budgetRangeSheet) return;
+      syncBudgetOptionState();
+      budgetRangeSheet.classList.add('is-open');
+      budgetRangeSheet.setAttribute('aria-hidden', 'false');
     }
 
     if (vaccinationDateInput) {
@@ -301,27 +721,96 @@
           return;
         }
         clearStatus(vaccinationDateStatus);
-        if (vaccinationDatePicker && vaccinationDateInput.value) {
-          vaccinationDatePicker.value = vaccinationDateInput.value;
-        }
       });
     }
 
-    if (vaccinationDatePickerButton && vaccinationDatePicker) {
+    if (vaccinationYearSelect && vaccinationMonthSelect) {
+      var handleSheetDateChange = function () {
+        var year = Number(vaccinationYearSelect.value) || getTodayParts().year;
+        var month = Number(vaccinationMonthSelect.value) || 1;
+        var currentDay = Number(vaccinationDaySelect.value) || 1;
+        var maxDay = getDaysInMonth(year, month);
+        if (currentDay > maxDay) {
+          currentDay = maxDay;
+        }
+        fillDayOptions(year, month, currentDay);
+      };
+
+      vaccinationYearSelect.addEventListener('change', handleSheetDateChange);
+      vaccinationMonthSelect.addEventListener('change', handleSheetDateChange);
+    }
+
+    if (vaccinationDatePickerButton) {
       vaccinationDatePickerButton.addEventListener('click', function () {
-        if (typeof vaccinationDatePicker.showPicker === 'function') {
-          vaccinationDatePicker.showPicker();
+        openVaccinationDateSheet();
+      });
+    }
+
+    if (vaccinationDateApplyButton) {
+      vaccinationDateApplyButton.addEventListener('click', function () {
+        if (!vaccinationDateInput || !vaccinationYearSelect || !vaccinationMonthSelect || !vaccinationDaySelect) return;
+        var year = vaccinationYearSelect.value;
+        var month = vaccinationMonthSelect.value;
+        var day = vaccinationDaySelect.value;
+        if (!year || !month || !day) {
+          showStatus(vaccinationDateStatus, '연도, 월, 일을 모두 선택해 주세요');
           return;
         }
-        vaccinationDatePicker.click();
-      });
-
-      vaccinationDatePicker.addEventListener('change', function () {
-        if (!vaccinationDateInput) return;
-        vaccinationDateInput.value = vaccinationDatePicker.value;
+        vaccinationDateInput.value =
+          String(year).padStart(4, '0') + '-' +
+          String(month).padStart(2, '0') + '-' +
+          String(day).padStart(2, '0');
         clearStatus(vaccinationDateStatus);
+        closeVaccinationDateSheet();
       });
     }
+
+    if (vaccinationDateSheet) {
+      vaccinationDateSheet.addEventListener('click', function (event) {
+        if (event.target === vaccinationDateSheet) {
+          closeVaccinationDateSheet();
+        }
+      });
+    }
+
+    if (budgetRangeButton) {
+      budgetRangeButton.addEventListener('click', function () {
+        openBudgetRangeSheet();
+      });
+    }
+
+    if (budgetRangeSheet) {
+      budgetRangeSheet.addEventListener('click', function (event) {
+        if (event.target === budgetRangeSheet) {
+          closeBudgetRangeSheet();
+        }
+      });
+    }
+
+    budgetOptionButtons.forEach(function (button) {
+      button.addEventListener('click', function () {
+        setBudgetRangeValue(button.dataset.value || '', button.dataset.label || '선택해주세요');
+        closeBudgetRangeSheet();
+      });
+    });
+
+    document.addEventListener('keydown', function (event) {
+      if (event.key === 'Escape') {
+        closeVaccinationDateSheet();
+        closeBudgetRangeSheet();
+      }
+    });
+
+    window.toggleProfileMenu = function toggleProfileMenu() {
+      if (!profileMenu) return;
+      profileMenu.classList.toggle('is-open');
+    };
+
+    document.addEventListener('click', function (event) {
+      if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+        profileMenu.classList.remove('is-open');
+      }
+    });
 
     var form = document.querySelector('form');
     if (form) {
@@ -358,8 +847,7 @@
         params.set('neutered', '{{ step2_data.neutered|escapejs }}');
         params.set('vaccination_date', vaccinationDateInput ? vaccinationDateInput.value : '');
 
-        var budgetSelect = document.querySelector('select[name="budget_range"]');
-        params.set('budget_range', budgetSelect ? budgetSelect.value : '');
+        params.set('budget_range', budgetRangeValue ? budgetRangeValue.value : '');
 
         var specialNotesInput = document.querySelector('input[name="special_notes"], textarea[name="special_notes"]');
         params.set('special_notes', specialNotesInput ? specialNotesInput.value : '');
@@ -379,7 +867,7 @@
       });
     }
 
-    syncVaccinationPickerBounds();
+    syncBudgetOptionState();
   })();
 </script>
 {% endblock %}

--- a/services/django/templates/pets/list.html
+++ b/services/django/templates/pets/list.html
@@ -3,6 +3,123 @@
 
 {% block head %}
 <style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #petsHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #petsHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #petsHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #petsViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
   #deletePetModal {
     opacity: 0;
     visibility: hidden;
@@ -13,16 +130,37 @@
     opacity: 1;
     visibility: visible;
   }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+
+  @media (min-width: 768px) {
+    #pageGate > .app-shell {
+      min-height: 100dvh;
+      height: auto;
+      overflow: visible;
+    }
+
+    #petsViewport {
+      position: relative;
+      inset: auto;
+      overflow: visible;
+      padding: 134px 16px 28px;
+    }
+  }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-<div class="relative flex h-screen w-full items-center justify-center px-4 py-8">
+<div id="pageGate" class="min-h-screen bg-[#f7fafc]">
+<div class="app-shell">
 
   <div id="deletePetModal" class="absolute inset-0 z-[60] flex items-center justify-center bg-black/10"
        onclick="closePetDeleteModal(event)">
-    <div class="relative h-[279px] w-[399px] rounded-[20px] border border-[#dbe7f5] bg-white shadow-[0_14px_36px_rgba(45,55,72,0.10)]"
+    <div class="relative h-[279px] w-[min(calc(100vw-32px),399px)] rounded-[20px] border border-[#dbe7f5] bg-white shadow-[0_14px_36px_rgba(45,55,72,0.10)]"
          onclick="event.stopPropagation()">
       <div class="absolute left-1/2 top-[27px] flex h-[81px] w-[81px] -translate-x-1/2 items-center justify-center rounded-full border-[4px] border-[#ef4444]">
         <span class="relative top-[-1px] text-[48px] font-bold leading-none text-[#ef4444]">!</span>
@@ -46,49 +184,107 @@
     </div>
   </div>
 
-  <a href="/chat/" class="absolute left-8 top-8 text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
-    <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-  </a>
-
-  <div class="w-full max-w-[860px] rounded-[20px] border border-[#dbe7f5] bg-white px-10 py-10 shadow-[0_6px_20px_rgba(45,55,72,0.04)]">
-    <div class="flex items-end justify-between gap-4">
-      <div>
-        <h1 class="text-[24px] font-bold text-[#2d3748]">반려동물 정보</h1>
-        <p class="mt-2 text-[14px] text-[#718096]">
-          등록된 반려동물 정보와 예비 집사 프로필을 함께 관리할 수 있습니다
-        </p>
+  <header id="petsHeader">
+    <div id="petsHeaderInner">
+      <div></div>
+      <a href="/chat/" id="petsHeaderLogo" aria-label="메인으로 돌아가기">
+        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+      </a>
+      <div class="justify-self-end min-w-0">
+        <div id="profileMenuWrapper">
+          <button type="button"
+                  class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                  aria-label="프로필 메뉴 열기"
+                  onclick="toggleProfileMenu()">
+            <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="8" r="3.2"></circle>
+              <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+            </svg>
+          </button>
+          <div id="profileMenu">
+            <a href="/profile/"
+               class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+            <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+            <a href="/pets/"
+               class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+            <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+            <a href="/logout/"
+               class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+          </div>
+        </div>
       </div>
-      <div class="text-[14px] font-bold text-[#3182ce]">반려동물 등록 현황: {{ actual_pet_count }} / 5</div>
+    </div>
+  </header>
+  <div id="headerSubnav">
+    <div id="headerSubnavRail">
+      <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+          <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+          <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+          <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+        </svg>
+      </a>
+      <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+        <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="9" cy="20" r="1.5"></circle>
+          <circle cx="18" cy="20" r="1.5"></circle>
+          <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+        </svg>
+      </a>
+      <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+        </svg>
+      </a>
+      <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M7 4.5h10"></path>
+          <path d="M7 9.5h10"></path>
+          <path d="M7 14.5h6"></path>
+          <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+        </svg>
+      </a>
+    </div>
+  </div>
+
+  <div id="petsViewport">
+  <div class="w-full border-t border-[#e8eef6] px-5 py-6 md:px-6">
+    <div class="flex flex-col items-start gap-2 md:flex-row md:items-end md:justify-between md:gap-4">
+      <div class="text-[18px] font-bold text-[#2d3748]">반려동물 정보</div>
+      <div class="text-[14px] font-bold leading-none text-[#3182ce] md:leading-normal">반려동물 등록 현황: {{ actual_pet_count }} / 5</div>
     </div>
 
     <div class="mt-5 h-px w-full bg-[#edf2f7]"></div>
 
     <div class="mt-8 {% if pets|length >= 3 %}max-h-[372px] overflow-y-auto pr-2{% else %}space-y-4{% endif %}">
       {% for pet in pets %}
-      <div class="pet-card flex items-center gap-5 rounded-[14px] border border-[#e2e8f0] bg-white px-4 py-4 shadow-[0_1px_2px_rgba(45,55,72,0.02)] {% if pets|length >= 3 and not forloop.first %}mt-4{% endif %}"
+      <div class="pet-card flex flex-col items-start gap-4 rounded-[14px] border border-[#e2e8f0] bg-white px-4 py-4 shadow-[0_1px_2px_rgba(45,55,72,0.02)] md:flex-row md:items-center md:gap-5 {% if pets|length >= 3 and not forloop.first %}mt-4{% endif %}"
            data-pet-id="{{ pet.pet_id }}">
-        <div class="flex h-[56px] w-[56px] items-center justify-center rounded-full bg-[#edf2f7] text-[24px]">
-          {% if pet.species == "future" %}🏠{% elif pet.species == "cat" %}🐱{% else %}🐶{% endif %}
-        </div>
-        <div class="min-w-0 flex-1">
-          <div class="text-[18px] font-bold text-[#2d3748]">
-            {% if pet.species == "future" %}
-            {{ pet.name }}
-            {% else %}
-            {{ pet.name }} ({{ pet.get_species_display }})
-            {% endif %}
+        <div class="flex w-full items-start gap-4 md:w-auto md:items-center md:gap-5">
+          <div class="flex h-[56px] w-[56px] shrink-0 items-center justify-center rounded-full bg-[#edf2f7] text-[24px]">
+            {% if pet.species == "future" %}🏠{% elif pet.species == "cat" %}🐱{% else %}🐶{% endif %}
           </div>
-          <div class="mt-1 text-[14px] text-[#718096]">
-            {% if pet.species == "future" %}
-            {{ pet.summary }}
-            {% else %}
-            {% if pet.breed %}{{ pet.breed }} · {% endif %}
-            {% if pet.age_unknown %}모름{% else %}{{ pet.age_years }}년 {{ pet.age_months }}개월{% endif %}
-            {% if pet.weight_kg %} · {{ pet.weight_kg|floatformat:-1 }}kg{% endif %}
-            {% endif %}
+          <div class="min-w-0 flex-1">
+            <div class="break-keep text-[17px] font-bold leading-[1.35] text-[#2d3748] md:text-[18px] md:leading-normal">
+              {% if pet.species == "future" %}
+              {{ pet.name }}
+              {% else %}
+              {{ pet.name }} ({{ pet.get_species_display }})
+              {% endif %}
+            </div>
+            <div class="mt-1.5 break-keep text-[13px] leading-[1.55] text-[#718096] md:mt-1 md:text-[14px] md:leading-normal">
+              {% if pet.species == "future" %}
+              {{ pet.summary }}
+              {% else %}
+              {% if pet.breed %}{{ pet.breed }} · {% endif %}
+              {% if pet.age_unknown %}모름{% else %}{{ pet.age_years }}년 {{ pet.age_months }}개월{% endif %}
+              {% if pet.weight_kg %} · {{ pet.weight_kg|floatformat:-1 }}kg{% endif %}
+              {% endif %}
+            </div>
           </div>
         </div>
-        <div class="flex items-center gap-3">
+        <div class="flex w-full items-center justify-end gap-2 border-t border-[#edf2f7] pt-3 md:ml-auto md:w-auto md:justify-end md:gap-3 md:border-t-0 md:pt-0">
           {% if pet.species == "future" %}
           <a href="/pets/add/future/"
              class="flex h-[36px] w-[58px] items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568] transition-colors hover:bg-[#e2e8f0]">
@@ -141,6 +337,7 @@
     </a>
     {% endif %}
   </div>
+  </div>
 
 </div>
 </div>
@@ -149,10 +346,17 @@
 {% block scripts %}
 <script>
 (function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
   var deletePetModal = document.getElementById('deletePetModal');
   var confirmPetDeleteBtn = document.getElementById('confirmPetDeleteBtn');
   var pendingPetDeleteId = null;
   var pendingPetIsPreview = false;
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
 
   window.openPetDeleteModal = function (petId, isPreview) {
     if (!deletePetModal) return;
@@ -184,6 +388,12 @@
       if (form) form.submit();
     });
   }
+
+  document.addEventListener('click', function (event) {
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+  });
 })();
 </script>
 {% endblock %}

--- a/services/django/templates/users/profile.html
+++ b/services/django/templates/users/profile.html
@@ -2,12 +2,157 @@
 {% load static %}
 {% block title %}내 정보 — TailTalk{% endblock %}
 
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #profileHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #profileHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #profileHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #profileViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 18px 16px 28px;
+  }
+
+  #withdrawModal,
+  #paymentModal {
+    position: absolute;
+    inset: 0;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+
+  @media (min-width: 768px) {
+    #pageGate > .app-shell {
+      min-height: 100dvh;
+      height: auto;
+      overflow: visible;
+    }
+
+    #profileViewport {
+      position: relative;
+      inset: auto;
+      overflow: visible;
+      padding: 134px 16px 28px;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-<a href="/chat/" class="fixed left-8 top-8 z-[999] cursor-pointer text-[26px] font-bold leading-none text-[#2d3748]">
-  <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-</a>
-<div class="relative w-full px-4 py-8">
+<div id="pageGate" class="min-h-screen bg-[#f7fafc]">
+<div class="app-shell">
 
   <!-- 탈퇴 모달 -->
   <div id="withdrawModal" class="absolute inset-0 z-[60] hidden items-center justify-center bg-black/10"
@@ -45,19 +190,19 @@
           <div>
             <div class="mb-2 text-[14px] font-bold text-[#4a5568]">카드명</div>
             <input id="paymentCardNameInput" type="text" placeholder="예: 현대카드 M"
-                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
+                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
             <p id="paymentCardNameStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
           </div>
           <div>
             <div class="mb-2 text-[14px] font-bold text-[#4a5568]">카드번호</div>
             <input id="paymentCardNumberInput" type="text" inputmode="numeric" maxlength="19" placeholder="1234 5678 9012 3456"
-                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
+                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
             <p id="paymentCardNumberStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
           </div>
           <div>
             <div class="mb-2 text-[14px] font-bold text-[#4a5568]">유효기간</div>
             <input id="paymentExpiryInput" type="text" inputmode="numeric" maxlength="5" placeholder="MM/YY"
-                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
+                   class="h-[40px] w-full rounded-[10px] border border-[#e2e8f0] bg-white px-3 text-[13px] text-[#4a5568] outline-none focus:border-[#3182ce]" />
             <p id="paymentExpiryStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
           </div>
         </div>
@@ -71,11 +216,73 @@
     </div>
   </div>
 
-  <div class="mx-auto mt-14 w-full max-w-[860px] rounded-[20px] border border-[#e2e8f0] bg-white">
-    <div class="px-8 pt-6 pb-4 text-[24px] font-bold text-[#2d3748]">내 정보</div>
-    <div class="h-px w-full bg-[#e2e8f0]"></div>
+  <header id="profileHeader">
+    <div id="profileHeaderInner">
+      <div></div>
+      <a href="/chat/" id="profileHeaderLogo" aria-label="메인으로 돌아가기">
+        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+      </a>
+      <div class="justify-self-end min-w-0">
+        <div id="profileMenuWrapper">
+          <button type="button"
+                  class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                  aria-label="프로필 메뉴 열기"
+                  onclick="toggleProfileMenu()">
+            <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <circle cx="12" cy="8" r="3.2"></circle>
+              <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+            </svg>
+          </button>
+          <div id="profileMenu">
+            <a href="/profile/"
+               class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+            <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+            <a href="/pets/"
+               class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+            <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+            <a href="/logout/"
+               class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+          </div>
+        </div>
+      </div>
+    </div>
+  </header>
+  <div id="headerSubnav">
+    <div id="headerSubnavRail">
+      <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+          <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+          <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+          <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+        </svg>
+      </a>
+      <a href="/products/" class="header-subnav-link" aria-label="장바구니" title="장바구니">
+        <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <circle cx="9" cy="20" r="1.5"></circle>
+          <circle cx="18" cy="20" r="1.5"></circle>
+          <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+        </svg>
+      </a>
+      <a href="/products/?tab=wishlist" class="header-subnav-link" aria-label="관심 상품" title="관심 상품">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+        </svg>
+      </a>
+      <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+        <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <path d="M7 4.5h10"></path>
+          <path d="M7 9.5h10"></path>
+          <path d="M7 14.5h6"></path>
+          <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+        </svg>
+      </a>
+    </div>
+  </div>
 
-    <form method="post" class="px-8 py-5">
+  <div id="profileViewport">
+  <div class="w-full bg-transparent">
+    <form method="post" class="px-6 py-5">
       {% csrf_token %}
       {% if messages %}
       {% for msg in messages %}
@@ -96,7 +303,7 @@
                      id="nicknameInput"
                      placeholder="한글, 영문, 숫자만 2~12자"
                      maxlength="12"
-                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
+                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-3 text-[12px] text-[#4a5568] outline-none focus:border-[#3182ce] placeholder:text-[#a0aec0]" />
               <p id="nicknameStatus" class="absolute right-0 top-[42px] min-h-[18px] text-right text-[12px]"></p>
             </div>
             <button type="button" id="nicknameCheckButton"
@@ -108,7 +315,7 @@
           <div class="flex items-start gap-3">
             <div class="flex-1">
               <input name="phone" value="{{ profile.phone|default:'' }}" id="phoneInput" placeholder="- 없이 숫자만 입력해 주세요" maxlength="11" inputmode="numeric"
-                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce]" />
+                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-3 text-[12px] text-[#4a5568] outline-none focus:border-[#3182ce] placeholder:text-[#a0aec0]" />
               <input type="hidden" id="phoneVerifiedState" value="{% if profile_phone_verified %}true{% else %}false{% endif %}" />
               <p id="phoneInputStatus" class="mt-1 hidden text-right text-[12px]"></p>
             </div>
@@ -118,7 +325,7 @@
           <div id="phoneVerificationPanel" class="mt-2 hidden items-start gap-3">
             <div class="flex-1">
               <input id="phoneVerificationCodeInput" type="text" inputmode="numeric" maxlength="6" placeholder="인증번호 6자리"
-                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce]" />
+                     class="h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-3 text-[12px] text-[#4a5568] outline-none focus:border-[#3182ce] placeholder:text-[#a0aec0]" />
             </div>
             <button type="button" id="phoneVerifyConfirmButton"
                     class="h-[36px] w-[90px] rounded-[8px] border border-[#2d3748] text-[14px] font-bold text-[#2d3748]">인증 확인</button>
@@ -131,23 +338,23 @@
         <div class="mb-2 text-[14px] font-bold text-[#4a5568]">주소 <span class="text-[12px] font-medium text-[#a0aec0]">(선택)</span></div>
         <div class="flex gap-3">
           <input name="zipcode" id="zipcodeInput" value="{{ profile_zipcode }}" placeholder="우편번호" readonly
-                 class="h-[36px] w-[140px] cursor-not-allowed rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
+                 class="h-[36px] w-[140px] cursor-not-allowed rounded-[8px] border border-[#d7dee8] bg-[#eef2f7] px-3 text-[12px] text-[#4a5568] outline-none placeholder:text-[#718096]" />
           <button type="button" id="postcodeButton"
                   class="h-[36px] w-[110px] rounded-[8px] border border-[#3182ce] text-[14px] font-bold text-[#3182ce]">우편번호 찾기</button>
         </div>
         <input name="address_main" id="addressMainInput" placeholder="기본 주소" readonly
                value="{{ profile_address_main }}"
-               class="mt-2 h-[36px] w-full cursor-not-allowed rounded-[8px] border border-[#e2e8f0] bg-[#f7fafc] px-3 text-[12px] text-[#718096] outline-none placeholder:text-[#718096]" />
+               class="mt-2 h-[36px] w-full cursor-not-allowed rounded-[8px] border border-[#d7dee8] bg-[#eef2f7] px-3 text-[12px] text-[#4a5568] outline-none placeholder:text-[#718096]" />
         <input name="address_detail" id="addressDetailInput" placeholder="상세 주소"
                value="{{ profile_address_detail }}"
-               class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] px-3 text-[12px] text-[#718096] outline-none focus:border-[#3182ce] placeholder:text-[#718096]" />
+               class="mt-2 h-[36px] w-full rounded-[8px] border border-[#e2e8f0] bg-white px-3 text-[12px] text-[#4a5568] outline-none focus:border-[#3182ce] placeholder:text-[#a0aec0]" />
         <p id="addressStatus" class="mt-1 min-h-[16px] text-right text-[12px]"></p>
       </div>
 
       <div class="mt-6 h-px w-full bg-[#e2e8f0]"></div>
 
       <div class="mt-4 text-[18px] font-bold text-[#2d3748]">2. 결제 수단</div>
-      <div class="mt-3 w-full rounded-[12px] border border-[#e2e8f0] bg-[#f7fafc] px-4 py-3.5 md:max-w-[calc(50%-0.5rem)]">
+      <div class="mt-3 w-full rounded-[12px] border border-[#e2e8f0] bg-white px-4 py-3.5 md:max-w-[calc(50%-0.5rem)]">
           <div class="flex items-center justify-between gap-4">
           <div class="min-w-0 flex-1">
             <div id="paymentMethodSummary" class="text-[13px] {% if profile_payment_method %}text-[#4a5568]{% else %}text-[#718096]{% endif %}">{{ profile_payment_method|default:"저장된 결제 수단이 없습니다" }}</div>
@@ -167,7 +374,7 @@
 
       <!-- 로그인 계정 -->
       <div class="mt-4 text-[18px] font-bold text-[#2d3748]">3. 로그인 계정</div>
-      <div class="mt-3 w-full max-w-[250px] rounded-[10px] border border-[#e2e8f0] bg-[#f7fafc] px-3 py-2.5">
+      <div class="mt-3 w-full max-w-[250px] rounded-[10px] border border-[#e2e8f0] bg-white px-3 py-2.5">
         {% if social_accounts.kakao %}
         <div class="flex items-center gap-3">
           <div class="flex h-7 w-7 items-center justify-center rounded-full bg-[#FEE500]">
@@ -211,7 +418,7 @@
       </div>
 
       <div class="mt-4">
-        <div class="flex w-full max-w-[195px] items-center gap-2 rounded-[10px] border border-[#e2e8f0] px-3 py-2">
+        <div class="flex w-full max-w-[195px] items-center gap-2 rounded-[10px] border border-[#e2e8f0] bg-white px-3 py-2">
           <span class="text-[13px] font-medium leading-none text-[#4a5568]">마케팅 푸시 동의</span>
           <div class="ml-auto flex h-[20px] items-center">
             <button type="button" id="marketingToggle"
@@ -225,9 +432,9 @@
       </div>
 
       <!-- 버튼 -->
-      <div class="mt-5 flex {% if setup_mode %}justify-center{% else %}flex-col gap-3 md:flex-row{% endif %}">
+      <div class="mt-5 flex {% if setup_mode %}justify-center{% else %}flex-row gap-3{% endif %}">
         {% if not setup_mode %}
-        <a href="/chat/" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold text-[#4a5568]">취소</a>
+        <a href="/chat/" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] border border-[#e2e8f0] bg-white text-[16px] font-bold text-[#4a5568]">취소</a>
         {% endif %}
         <button type="submit"
                 class="flex h-[44px] {% if setup_mode %}w-full max-w-[320px]{% else %}flex-1{% endif %} items-center justify-center rounded-[10px] bg-[#3182ce] text-[16px] font-bold text-white hover:bg-[#2b6cb0]">
@@ -242,14 +449,28 @@
 
     </form>
   </div>
+  </div>
 
 </div>
 </div>
 {% endblock %}
 
 {% block scripts %}
-<script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
 <script>
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
+
+  document.addEventListener('click', function (event) {
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+  });
+
   window.closeWithdrawModal = function (e) {
     if (e && e.target !== document.getElementById('withdrawModal')) return;
     document.getElementById('withdrawModal').style.display = 'none';
@@ -402,6 +623,56 @@
     var confirmedNickname = initialNickname;
     var initialPhone = phoneInput ? phoneInput.value.replace(/\D/g, '').slice(0, 11) : '';
     var verifiedPhoneValue = phoneVerifiedStateInput && phoneVerifiedStateInput.value === 'true' ? initialPhone : '';
+    var profileDraftKey = 'tailtalk-profile-draft';
+
+    function saveProfileDraft() {
+      var draft = {
+        nickname: input ? input.value : '',
+        phone: phoneInput ? phoneInput.value : '',
+        zipcode: zipcodeInput ? zipcodeInput.value : '',
+        address_main: addressMainInput ? addressMainInput.value : '',
+        address_detail: addressDetailInput ? addressDetailInput.value : '',
+      };
+      sessionStorage.setItem(profileDraftKey, JSON.stringify(draft));
+    }
+
+    function restoreProfileDraft() {
+      var raw = sessionStorage.getItem(profileDraftKey);
+      if (!raw) return;
+      try {
+        var draft = JSON.parse(raw);
+        if (input && draft.nickname) input.value = draft.nickname;
+        if (phoneInput && draft.phone) phoneInput.value = draft.phone;
+        if (zipcodeInput && draft.zipcode) zipcodeInput.value = draft.zipcode;
+        if (addressMainInput && draft.address_main) addressMainInput.value = draft.address_main;
+        if (addressDetailInput && typeof draft.address_detail === 'string') addressDetailInput.value = draft.address_detail;
+      } catch (error) {}
+    }
+
+    restoreProfileDraft();
+
+    var params = new URLSearchParams(window.location.search);
+    if (zipcodeInput && params.has('zipcode')) {
+      zipcodeInput.value = params.get('zipcode') || '';
+    }
+    if (addressMainInput && params.has('address_main')) {
+      addressMainInput.value = params.get('address_main') || '';
+    }
+    if (params.has('zipcode') || params.has('address_main')) {
+      sessionStorage.removeItem(profileDraftKey);
+      if (addressStatus) {
+        addressStatus.textContent = '';
+      }
+      if (addressDetailInput) {
+        addressDetailInput.focus();
+      }
+      if (history.replaceState) {
+        params.delete('zipcode');
+        params.delete('address_main');
+        var nextUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
+        history.replaceState({}, '', nextUrl);
+      }
+    }
 
     function setStatus(text, color) {
       status.textContent = text;
@@ -437,7 +708,8 @@
       var phoneValue = phoneInput.value.replace(/\D/g, '').slice(0, 11);
       var isVerified = getPhoneVerifiedState() && !!phoneValue && phoneValue === verifiedPhoneValue;
       phoneInput.readOnly = isVerified;
-      phoneInput.classList.toggle('bg-[#f7fafc]', isVerified);
+      phoneInput.classList.toggle('bg-[#eef2f7]', isVerified);
+      phoneInput.classList.toggle('border-[#d7dee8]', isVerified);
       phoneInput.classList.toggle('cursor-not-allowed', isVerified);
     }
 
@@ -760,40 +1032,12 @@
       });
     }
 
-    if (
-      postcodeButton &&
-      zipcodeInput &&
-      addressMainInput &&
-      addressDetailInput &&
-      addressStatus &&
-      window.daum &&
-      window.daum.Postcode
-    ) {
+    if (postcodeButton) {
       postcodeButton.addEventListener('click', function () {
-        new window.daum.Postcode({
-          oncomplete: function (data) {
-            var extraAddress = '';
-
-            if (data.userSelectedType === 'R') {
-              if (data.bname && /[동|로|가]$/g.test(data.bname)) {
-                extraAddress += data.bname;
-              }
-              if (data.buildingName && data.apartment === 'Y') {
-                extraAddress += extraAddress ? ', ' + data.buildingName : data.buildingName;
-              }
-            }
-
-            zipcodeInput.value = data.zonecode || '';
-            addressMainInput.value = data.roadAddress || data.jibunAddress || '';
-
-            if (extraAddress) {
-              addressMainInput.value += ' (' + extraAddress + ')';
-            }
-
-            addressStatus.textContent = '';
-            addressDetailInput.focus();
-          }
-        }).open();
+        saveProfileDraft();
+        var nextParams = new URLSearchParams(window.location.search);
+        var returnUrl = '/profile/' + (nextParams.toString() ? '?' + nextParams.toString() : '');
+        window.location.href = '/profile/address-search/?return=' + encodeURIComponent(returnUrl);
       });
     }
 


### PR DESCRIPTION
## 요약
회원 영역 공통 헤더/서브내비를 적용하고 프로필 및 반려동물 화면 UI를 함께 정리했습니다.

## 변경 사항
- 내 정보, 반려동물 정보, 반려동물 등록 플로우에 공통 헤더/서브내비/프로필 배지를 적용했습니다
- 내 정보 페이지의 배경, 읽기 전용 입력칸, 데스크톱 스크롤 동작을 가독성 중심으로 정리했습니다
- 반려동물 정보 목록 제목 영역과 등록/수정 플로우의 데스크톱 높이/스크롤 동작을 정리했습니다

## 관련 이슈
- closes #308
- closes #309
- closes #310

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 회원 영역 페이지 전환 시 상단 구조 일관성과 프로필/반려동물 화면의 데스크톱 높이 동작을 중점적으로 봐주세요.