### PR TITLE
[frontend] 구조 변경 반영 사용자 영역 UI 재이식 (#318)

### DIFF
--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -59,7 +59,7 @@ class ChatPageTests(TestCase):
         response = self.client.get(reverse("chat"))
 
         self.assertEqual(response.status_code, 200)
-        self.assertContains(response, "/products/?tab=wishlist")
+        self.assertContains(response, "/wishlist/")
         self.assertContains(response, "관심 상품")
 
     def test_chat_page_allows_chat_when_profile_complete_but_no_pet(self):

--- a/services/django/orders/api/core.py
+++ b/services/django/orders/api/core.py
@@ -32,21 +32,21 @@ ORDER_STATUS_META = {
         "tone": "info",
         "can_reorder": True,
         "detail_hint": "상품 준비가 시작되면\n배송 상태가 업데이트됩니다",
-        "cta_label": "같은 구성 다시 담기",
+        "cta_label": "다시 담기",
     },
     "shipping": {
         "label": "배송 중",
         "tone": "info",
         "can_reorder": True,
         "detail_hint": "상품이 배송 중입니다\n필요한 구성은 다시 주문할 수 있어요",
-        "cta_label": "같은 구성 다시 담기",
+        "cta_label": "다시 담기",
     },
     "completed": {
         "label": "배송 완료",
         "tone": "success",
         "can_reorder": True,
         "detail_hint": "배송이 완료된 주문입니다\n필요한 상품은 다시 주문할 수 있어요",
-        "cta_label": "다시 주문하기",
+        "cta_label": "다시 담기",
     },
     "cancelled": {
         "label": "주문 취소",
@@ -78,18 +78,7 @@ def error_response(detail, *, code, status_code, field=None, missing_fields=None
 
 
 def _display_product_name(brand_name, goods_name):
-    if not goods_name:
-        return ""
-
-    normalized_brand = (brand_name or "").strip()
-    normalized_name = goods_name.strip()
-
-    if normalized_brand and normalized_name.lower().startswith(normalized_brand.lower()):
-        trimmed = normalized_name[len(normalized_brand):].lstrip(" -_/|")
-        if trimmed:
-            return trimmed
-
-    return normalized_name
+    return (goods_name or "").strip()
 
 
 def serialize_product_summary(product: Product) -> dict:

--- a/services/django/orders/page_urls.py
+++ b/services/django/orders/page_urls.py
@@ -1,10 +1,12 @@
 from django.urls import path
 
-from .pages import catalog, order_complete, order_list, used_products
+from .pages import catalog, checkout, order_complete, order_list, used_products, wishlist_products
 
 urlpatterns = [
     path("orders/", order_list, name="order_list"),
     path("orders/complete/<uuid:order_id>/", order_complete, name="order_complete"),
     path("products/", used_products, name="used_products"),
+    path("wishlist/", wishlist_products, name="wishlist_products"),
+    path("checkout/", checkout, name="checkout"),
     path("catalog/", catalog, name="catalog"),
 ]

--- a/services/django/orders/pages/__init__.py
+++ b/services/django/orders/pages/__init__.py
@@ -1,9 +1,11 @@
-from .views_catalog import catalog, used_products
+from .views_catalog import catalog, checkout, used_products, wishlist_products
 from .views_order_pages import order_complete, order_list
 
 __all__ = [
     "catalog",
+    "checkout",
     "order_complete",
     "order_list",
     "used_products",
+    "wishlist_products",
 ]

--- a/services/django/orders/pages/core.py
+++ b/services/django/orders/pages/core.py
@@ -1,10 +1,11 @@
+from collections import defaultdict
 from urllib.parse import parse_qs, urlencode, urlparse
 
 from django.db.models import Case, DecimalField, IntegerField, Q, Value, When
 from django.db.models.functions import Coalesce
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
 
 from chat.models import ChatSession
 from products.catalog_menu import build_catalog_menu_context
@@ -23,18 +24,7 @@ def _product_summary(product):
 
 
 def _display_product_name(brand_name, goods_name):
-    if not goods_name:
-        return ""
-
-    normalized_brand = (brand_name or "").strip()
-    normalized_name = goods_name.strip()
-
-    if normalized_brand and normalized_name.lower().startswith(normalized_brand.lower()):
-        trimmed = normalized_name[len(normalized_brand):].lstrip(" -_/|")
-        if trimmed:
-            return trimmed
-
-    return normalized_name
+    return (goods_name or "").strip()
 
 
 def _display_delivery_address(value):
@@ -82,27 +72,89 @@ def _recommended_note(index):
     return notes[index % len(notes)]
 
 
+def _build_catalog_filter_tree(catalog_menu_sections):
+    tree = {"pets": [], "brands": {}}
+
+    for section in catalog_menu_sections:
+        pet_label = section.get("label") or ""
+        pet_entry = {"label": pet_label, "categories": []}
+        for category in section.get("categories", []):
+            category_label = category.get("label") or ""
+            groups = []
+            for group in category.get("groups", []):
+                items = []
+                for item in group.get("items", []):
+                    query = parse_qs(urlparse(item.get("href") or "").query)
+                    subcategory_value = (query.get("subcategory") or [""])[0]
+                    if not subcategory_value:
+                        continue
+                    items.append(
+                        {
+                            "label": item.get("label") or subcategory_value,
+                            "value": subcategory_value,
+                        }
+                    )
+                if items:
+                    groups.append({"label": group.get("label") or "", "items": items})
+            pet_entry["categories"].append({"label": category_label, "groups": groups})
+        tree["pets"].append(pet_entry)
+
+    brand_map = defaultdict(lambda: defaultdict(lambda: defaultdict(set)))
+    rows = Product.objects.filter(soldout_yn=False).values_list("pet_type", "category", "subcategory", "brand_name")[:10000]
+    for pet_types, categories, subcategories, brand_name in rows:
+        if not brand_name:
+            continue
+        normalized_pet_types = [value for value in (pet_types or []) if value]
+        normalized_categories = [value for value in (categories or []) if value]
+        normalized_subcategories = [value for value in (subcategories or []) if value]
+        for pet_value in normalized_pet_types:
+            for category_value in normalized_categories:
+                for subcategory_value in normalized_subcategories:
+                    brand_map[pet_value][category_value][subcategory_value].add(brand_name)
+
+    tree["brands"] = {
+        pet_value: {
+            category_value: {
+                subcategory_value: sorted(values)
+                for subcategory_value, values in subcategory_map.items()
+            }
+            for category_value, subcategory_map in category_map.items()
+        }
+        for pet_value, category_map in brand_map.items()
+    }
+    return tree
+
+
+def _member_nav_indicator_state(user):
+    cart, _ = Cart.objects.get_or_create(user=user)
+    wishlist, _ = Wishlist.objects.get_or_create(user=user)
+    return {
+        "member_nav_has_cart_items": cart.items.exists(),
+        "member_nav_has_wishlist_items": wishlist.items.exists(),
+    }
+
+
 ORDER_STATUS_VIEW_META = {
     "pending": {
         "label": "주문 접수",
         "class": "bg-[#fef3c7] text-[#b45309]",
         "can_reorder": True,
         "detail_hint": "상품 준비가 시작되면\n배송 상태가 업데이트됩니다",
-        "cta_label": "같은 구성 다시 담기",
+        "cta_label": "다시 담기",
     },
     "shipping": {
         "label": "배송 중",
         "class": "bg-[#dbeafe] text-[#2563eb]",
         "can_reorder": True,
         "detail_hint": "상품이 배송 중입니다\n필요한 구성은 다시 주문할 수 있어요",
-        "cta_label": "같은 구성 다시 담기",
+        "cta_label": "다시 담기",
     },
     "completed": {
         "label": "배송 완료",
         "class": "bg-[#dcfce7] text-[#15803d]",
         "can_reorder": True,
         "detail_hint": "배송이 완료된 주문입니다\n필요한 상품은 다시 주문할 수 있어요",
-        "cta_label": "다시 주문하기",
+        "cta_label": "다시 담기",
     },
     "cancelled": {
         "label": "주문 취소",
@@ -607,7 +659,7 @@ def _order_groups():
             "status_class": "bg-[#dbeafe] text-[#2563eb]",
             "can_reorder": True,
             "detail_hint": "상품이 배송 중입니다\n필요한 구성은 다시 주문할 수 있어요",
-            "cta_label": "같은 구성 다시 담기",
+            "cta_label": "다시 담기",
             "recipient": "왈냥",
             "recipient_phone": "010-1234-5678",
             "delivery_address": "서울 강동구 올림픽로 123, 101동 1203호",
@@ -624,7 +676,7 @@ def _order_groups():
             "status_class": "bg-[#dcfce7] text-[#15803d]",
             "can_reorder": True,
             "detail_hint": "배송이 완료된 주문입니다\n필요한 상품은 다시 주문할 수 있어요",
-            "cta_label": "다시 주문하기",
+            "cta_label": "다시 담기",
             "recipient": "왈냥",
             "recipient_phone": "010-1234-5678",
             "delivery_address": "서울 강동구 올림픽로 123, 101동 1203호",
@@ -733,19 +785,50 @@ def order_list(request):
             "order_current_status": options["status_filter"],
             "order_current_ordering": options["ordering_key"],
             "order_demo_mode": demo_mode,
+            **_member_nav_indicator_state(request.user),
         },
     )
 
 
 @login_required
 def used_products(request):
-    items, wishlist_items = _load_user_product_panels(request.user)
+    if (request.GET.get("tab") or "").strip().lower() == "wishlist":
+        return redirect("wishlist_products")
+
+    return _render_used_products(request, active_tab="cart")
+
+
+@login_required
+def wishlist_products(request):
+    return _render_used_products(request, active_tab="wishlist")
+
+
+@login_required
+def checkout(request):
+    selected_items_query = (request.GET.get("items") or "").strip()
+    selected_goods_ids = [item.strip() for item in selected_items_query.split(",") if item.strip()]
+    context = _build_products_page_context(
+        request.user,
+        active_tab="cart",
+        selected_goods_ids=selected_goods_ids or None,
+    )
+    if context["item_count"] == 0:
+        return redirect("used_products")
+    return render(request, "orders/checkout.html", context)
+
+
+def _build_products_page_context(user, *, active_tab, selected_goods_ids=None):
+    items, wishlist_items = _load_user_product_panels(user)
+    if selected_goods_ids is not None:
+        selected_goods_ids = {str(goods_id).strip() for goods_id in selected_goods_ids if str(goods_id).strip()}
+        items = [item for item in items if str(item["goods_id"]) in selected_goods_ids]
+
     product_total = sum(item["price"] * item["quantity"] for item in items)
     discount = 0
     shipping_fee = 0 if product_total >= 30000 else 3000
     final_total = product_total - discount + shipping_fee
-    profile = getattr(request.user, "profile", None)
-    recipient_name = getattr(profile, "nickname", "") or request.user.email.split("@")[0] or "주문자 정보 미등록"
+    profile = getattr(user, "profile", None)
+    recipient_name = getattr(profile, "nickname", "") or user.email.split("@")[0] or "주문자 정보 미등록"
     address = getattr(profile, "address", "") or ""
     address_parts = [part.strip() for part in address.split("|", 1)] if address else []
     base_address = address_parts[0] if address_parts else "배송지 정보가 아직 등록되지 않았어요"
@@ -759,35 +842,37 @@ def used_products(request):
     for item in wishlist_items:
         item["price_label"] = _format_price(item["price"])
 
-    active_tab = (request.GET.get("tab") or "cart").strip().lower()
-    if active_tab not in {"cart", "wishlist"}:
-        active_tab = "cart"
+    return {
+        "cart_items": items,
+        "wishlist_items": wishlist_items,
+        "item_count": sum(item["quantity"] for item in items),
+        "wishlist_count": len(wishlist_items),
+        "product_total": _format_price(product_total),
+        "product_total_raw": product_total,
+        "discount_total": _format_price(discount),
+        "shipping_fee": "무료" if shipping_fee == 0 else _format_price(shipping_fee),
+        "final_total": _format_price(final_total),
+        "recipient_name": recipient_name,
+        "delivery_base_address": base_address,
+        "delivery_detail_address": detail_address,
+        "recipient_phone": phone,
+        "delivery_postal_code": postal_code,
+        "delivery_message": "",
+        "payment_method": payment_method,
+        "coupon_summary": "적용된 쿠폰 없음",
+        "mileage_summary": "사용 가능 3,200원",
+        "discount_total_raw": discount,
+        "shipping_fee_raw": shipping_fee,
+        "active_tab": active_tab,
+        **_member_nav_indicator_state(user),
+    }
 
+
+def _render_used_products(request, *, active_tab):
     return render(
         request,
         "orders/products.html",
-        {
-            "cart_items": items,
-            "wishlist_items": wishlist_items,
-            "item_count": sum(item["quantity"] for item in items),
-            "wishlist_count": len(wishlist_items),
-            "product_total": _format_price(product_total),
-            "discount_total": _format_price(discount),
-            "shipping_fee": "무료" if shipping_fee == 0 else _format_price(shipping_fee),
-            "final_total": _format_price(final_total),
-            "recipient_name": recipient_name,
-            "delivery_base_address": base_address,
-            "delivery_detail_address": detail_address,
-            "recipient_phone": phone,
-            "delivery_postal_code": postal_code,
-            "delivery_message": "",
-            "payment_method": payment_method,
-            "coupon_summary": "적용된 쿠폰 없음",
-            "mileage_summary": "사용 가능 3,200원",
-            "discount_total_raw": discount,
-            "shipping_fee_raw": shipping_fee,
-            "active_tab": active_tab,
-        },
+        _build_products_page_context(request.user, active_tab=active_tab),
     )
 
 
@@ -1004,6 +1089,7 @@ def catalog(request):
             }
             for value in hidden_brand_values
         ],
+        "catalog_filter_tree": _build_catalog_filter_tree(catalog_menu_sections),
         "catalog_query_all": _catalog_querystring(current_params, page=None),
         "catalog_clear_category_query": _catalog_querystring(current_params, category=None, subcategory=None, brand=None, page=None),
         "catalog_clear_detail_query": _catalog_querystring(current_params, subcategory=None, brand=None, page=None),
@@ -1011,6 +1097,7 @@ def catalog(request):
         "catalog_current_session_id": session_id,
         "catalog_recommended_session": recommended_session,
         "catalog_recommended_items": recommended_items,
+        **_member_nav_indicator_state(request.user),
     }
     return render(request, "orders/catalog.html", context)
 
@@ -1032,5 +1119,6 @@ def order_complete(request, order_id):
             "active_tab": "orders",
             "order_completion": _serialize_order_completion(order),
             "order_entry": entry,
+            **_member_nav_indicator_state(request.user),
         },
     )

--- a/services/django/orders/pages/views_catalog.py
+++ b/services/django/orders/pages/views_catalog.py
@@ -1,6 +1,8 @@
-from .core import catalog, used_products
+from .core import catalog, checkout, used_products, wishlist_products
 
 __all__ = [
     "catalog",
+    "checkout",
     "used_products",
+    "wishlist_products",
 ]

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -522,7 +522,7 @@ class OrderReadApiTests(TestCase):
         self.assertEqual(len(order["items"]), 2)
         self.assertTrue(order["can_reorder"])
         self.assertEqual(order["status_meta"]["tone"], "info")
-        self.assertEqual(order["status_meta"]["cta_label"], "같은 구성 다시 담기")
+        self.assertEqual(order["status_meta"]["cta_label"], "다시 담기")
         self.assertEqual(response.data["filters"]["status"], "all")
         self.assertEqual(response.data["filters"]["ordering"], "latest")
         self.assertEqual(response.data["pagination"]["total_count"], 1)

--- a/services/django/static/css/main.css
+++ b/services/django/static/css/main.css
@@ -7,12 +7,42 @@ html, body {
   margin: 0;
   padding: 0;
   height: 100%;
+  scrollbar-gutter: stable both-edges;
 }
 
 body {
   background: #ffffff;
   color: #171717;
   font-family: "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR", "Malgun Gothic", Arial, sans-serif;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  html,
+  body,
+  * {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.72) transparent;
+  }
+
+  *::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  *::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  *::-webkit-scrollbar-thumb {
+    border: 2px solid transparent;
+    border-radius: 9999px;
+    background-clip: padding-box;
+    background-color: rgba(148, 163, 184, 0.72);
+  }
+
+  *:hover::-webkit-scrollbar-thumb {
+    background-color: rgba(100, 116, 139, 0.82);
+  }
 }
 
 a,
@@ -73,7 +103,7 @@ input:disabled {
   position: absolute;
   display: inline-flex;
   align-items: center;
-  justify-content: flex-start;
+  justify-content: center;
   gap: 8px;
   border: 0;
   background: transparent;

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -9,7 +9,7 @@
 
   #pageGate {
     min-height: 100dvh;
-    background: #f7fafc;
+    background: #f8f9fb;
   }
 
   #pageGate > .app-shell {
@@ -19,7 +19,7 @@
     height: 100dvh;
     margin: 0 auto;
     overflow: hidden;
-    background: #f7fafc;
+    background: #f8f9fb;
   }
 
   #sidebar {
@@ -50,7 +50,7 @@
     position: absolute;
     inset: 0;
     z-index: 10;
-    background: #f7fafc;
+    background: #f8f9fb;
   }
 
   #mainHeader {
@@ -120,6 +120,17 @@
     background: #f8fbff;
   }
 
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
   #workspaceShell {
     position: absolute;
     inset: 116px 0 0 0;
@@ -131,7 +142,7 @@
     inset: 0;
     display: flex;
     overflow: hidden;
-    background: #f7fafc;
+    background: #f8f9fb;
   }
 
   #chatSection {
@@ -139,30 +150,78 @@
     min-width: 0;
     flex: 1 1 auto;
     flex-direction: column;
-    background: #f7fafc;
+    background: #f8f9fb;
   }
 
   #chatScrollArea {
     position: relative;
     flex: 1 1 auto;
     overflow-y: auto;
-    padding: 24px 20px 88px;
+    padding: 18px 16px 88px;
   }
 
   #chatEmptyState {
     position: absolute;
     left: 50%;
     top: clamp(160px, 23vh, 240px);
-    width: min(760px, calc(100% - 48px));
+    width: min(680px, calc(100% - 40px));
     transform: translateX(-50%);
     text-align: center;
   }
 
   #guestHeroTitle {
-    font-size: 32px;
+    max-width: none;
+    margin: 0 auto;
+    font-size: clamp(28px, 5.8vw, 34px);
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.28;
+    letter-spacing: -0.03em;
     color: #1a202c;
+    white-space: nowrap;
+  }
+
+  #guestHeroMessage {
+    width: auto;
+    max-width: none;
+    margin: 14px auto 0;
+    font-size: clamp(15px, 3.4vw, 16px);
+    line-height: 1.65;
+    color: #718096;
+    white-space: nowrap;
+  }
+
+  #guestHeroLoginLink {
+    margin-top: 28px;
+  }
+
+  .guest-hero-mobile-break {
+    display: none;
+  }
+
+  @media (max-width: 420px) {
+    #chatEmptyState {
+      width: calc(100% - 32px);
+    }
+
+    #guestHeroTitle {
+      max-width: 11.8em;
+      font-size: clamp(26px, 7.4vw, 30px);
+      line-height: 1.3;
+      white-space: normal;
+      word-break: keep-all;
+    }
+
+    #guestHeroMessage {
+      width: min(320px, 100%);
+      font-size: 15px;
+      line-height: 1.6;
+      white-space: normal;
+      word-break: keep-all;
+    }
+
+    .guest-hero-mobile-break {
+      display: block;
+    }
   }
 
   #chatThread {
@@ -170,7 +229,7 @@
     width: 100%;
     max-width: 760px;
     margin: 0 auto;
-    padding-top: 24px;
+    padding-top: 18px;
     position: relative;
   }
 
@@ -790,7 +849,8 @@
       {% if is_member_view %}
       <div id="headerSubnav">
         <div id="headerSubnavRail">
-          <a href="{% if is_preview_member %}#{% else %}/catalog/{% endif %}"
+          <a id="headerCatalogLink"
+             href="{% if is_preview_member %}#{% else %}/catalog/{% endif %}"
              class="header-subnav-link"
              aria-label="상품 목록"
              title="상품 목록"
@@ -803,7 +863,7 @@
             </svg>
           </a>
           <a href="{% if is_preview_member %}#{% else %}/products/{% endif %}"
-             class="header-subnav-link"
+             class="header-subnav-link {% if member_nav_has_cart_items %}has-indicator{% endif %}"
              aria-label="장바구니"
              title="장바구니"
              {% if is_preview_member %}onclick="return false"{% endif %}>
@@ -813,8 +873,8 @@
               <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
             </svg>
           </a>
-          <a href="{% if is_preview_member %}#{% else %}/products/?tab=wishlist{% endif %}"
-             class="header-subnav-link"
+          <a href="{% if is_preview_member %}#{% else %}/wishlist/{% endif %}"
+             class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}"
              aria-label="관심 상품"
              title="관심 상품"
              {% if is_preview_member %}onclick="return false"{% endif %}>
@@ -845,12 +905,12 @@
               <div id="chatEmptyState">
                 {% if not chat_enabled %}
                 <div id="guestHeroTitle">
-                  <span class="text-[#3182ce]">Tail</span><span>Talk와 함께하는 스마트 반려 생활</span>
+                  <span class="text-[#3182ce]">Tail</span><span>Talk와 함께하는</span><br class="guest-hero-mobile-break"><span> 스마트 반려 생활</span>
                 </div>
                 {% endif %}
                 {% if not chat_enabled %}
-                <p class="mt-[14px] text-[16px] text-[#718096]">로그인 후 챗봇과 대화를 시작하고 맞춤 추천을 받아보세요</p>
-                <a href="/login/" class="mt-[32px] inline-flex items-center gap-[4px] font-bold text-[#2563eb] hover:text-[#1d4ed8]">
+                <p id="guestHeroMessage">로그인 후 챗봇과 대화를 시작하고<br class="guest-hero-mobile-break"> 맞춤 추천을 받아보세요</p>
+                <a id="guestHeroLoginLink" href="/login/" class="inline-flex items-center gap-[4px] font-bold text-[#2563eb] hover:text-[#1d4ed8]">
                   이미 계정이 있나요? 로그인
                 </a>
                 {% endif %}
@@ -1021,6 +1081,7 @@
     var SESSION_RECOMMENDED_PRODUCTS_STORAGE_PREFIX = 'tailtalk_session_recommended_products:';
     var chatActionToastTimer = null;
     var activeMessageAbortController = null;
+    var headerCatalogLink = document.getElementById('headerCatalogLink');
     var defaultMessagePlaceholder = messageInput ? messageInput.getAttribute('placeholder') || '메시지를 입력하세요...' : '메시지를 입력하세요...';
     var chatApiAccessToken = '{{ chat_api_access_token|default:""|escapejs }}';
 
@@ -1031,6 +1092,15 @@
     }
 
     var csrfToken = getCookie('csrftoken');
+
+    function updateCatalogSessionLink() {
+      if (!headerCatalogLink) return;
+      if (!activeSessionId) {
+        headerCatalogLink.setAttribute('href', '/catalog/');
+        return;
+      }
+      headerCatalogLink.setAttribute('href', '/catalog/?session=' + encodeURIComponent(activeSessionId));
+    }
 
     function buildApiHeaders(headers) {
       var merged = Object.assign({}, headers || {});
@@ -2054,6 +2124,7 @@
           var sessionId = item.getAttribute('data-id');
           if (!sessionId) return;
           activeSessionId = sessionId;
+          updateCatalogSessionLink();
           applySessionProfileState(sessionId);
           updateHistoryActiveState();
 
@@ -2216,6 +2287,7 @@
         }),
       }).then(function (data) {
         activeSessionId = data.session_id;
+        updateCatalogSessionLink();
         ensureSessionState(activeSessionId).targetPetId = data.target_pet_id || '';
         ensureSessionState(activeSessionId).profileContextType = data.profile_context_type || 'none';
         ensureSessionState(activeSessionId).profilePromptResolved = profilePromptResolved;
@@ -2227,6 +2299,7 @@
 
     window.resetChatState = function () {
       activeSessionId = null;
+      updateCatalogSessionLink();
       activePetId = '';
       profilePromptResolved = false;
       pendingPromptMessage = '';
@@ -2321,6 +2394,7 @@
 
       function submitWithSession(sessionId) {
         activeSessionId = sessionId;
+        updateCatalogSessionLink();
         updateHistoryActiveState();
 
         var state = ensureSessionState(sessionId);
@@ -2554,6 +2628,7 @@
     }
     updatePetSummaryDisplay();
     syncPetDropdownOptionState();
+    updateCatalogSessionLink();
     updateRecommendationLauncher();
     renderRecommendationPanel([]);
     bindHistoryItems();

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -3,10 +3,143 @@
 
 {% block head %}
 <style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #catalogHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #catalogHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #catalogHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #catalogViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 24px 16px 28px;
+  }
+
   html,
   body,
   body.bg-white {
-    background: #f7fafc !important;
+    background: #f8f9fb !important;
   }
 
   .catalog-chip {
@@ -33,6 +166,9 @@
   }
 
   .catalog-card {
+    display: flex;
+    position: relative;
+    flex-direction: column;
     transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
   }
 
@@ -42,19 +178,55 @@
     border-color: #cbd5e0;
   }
 
+  @media (hover: none) and (pointer: coarse) {
+    .catalog-card:hover {
+      transform: none;
+      box-shadow: 0 8px 24px rgba(45, 55, 72, 0.04);
+      border-color: #e2e8f0;
+    }
+  }
+
   .catalog-thumb {
     aspect-ratio: 1 / 1;
+  }
+
+  .catalog-card-body {
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .catalog-card-title {
+    display: -webkit-box;
+    overflow: hidden;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    min-height: calc(1em * 1.45 * 2);
   }
 
   .wishlist-heart svg:last-child {
     display: none;
   }
 
+  .catalog-card-meta {
+    margin-top: auto;
+    padding-top: 12px;
+  }
+
   .wishlist-heart {
     color: #4a5568;
   }
 
+  .wishlist-heart:hover {
+    color: #2d3748;
+  }
+
   .wishlist-heart.is-active {
+    color: #e53e3e;
+  }
+
+  .wishlist-heart.is-active:hover {
     color: #e53e3e;
   }
 
@@ -73,15 +245,147 @@
     pointer-events: auto;
   }
 
-  .catalog-sort-select {
-    appearance: none;
-    -webkit-appearance: none;
-    -moz-appearance: none;
-    background-image: linear-gradient(45deg, transparent 50%, #718096 50%), linear-gradient(135deg, #718096 50%, transparent 50%);
-    background-position: calc(100% - 18px) calc(50% - 1px), calc(100% - 13px) calc(50% - 1px);
-    background-size: 5px 5px, 5px 5px;
-    background-repeat: no-repeat;
-    padding-right: 38px;
+  .catalog-sort-select.hidden-native {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 0;
+    height: 0;
+  }
+
+  .catalog-sort-dropdown {
+    position: relative;
+    width: 148px;
+  }
+
+  .catalog-sort-trigger {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    height: 36px;
+    padding: 0 14px;
+    border: 1px solid #dbe7f5;
+    border-radius: 9999px;
+    background: #fff;
+    color: #4a5568;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1;
+    transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
+  }
+
+  .catalog-sort-trigger:hover,
+  .catalog-sort-trigger.is-open {
+    border-color: #c5d7ee;
+    background: #f8fbff;
+  }
+
+  .catalog-sort-trigger-text {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .catalog-sort-trigger-caret {
+    flex: none;
+    margin-left: 8px;
+    color: #90a4b8;
+    transition: transform 160ms ease;
+  }
+
+  .catalog-sort-trigger.is-open .catalog-sort-trigger-caret {
+    transform: rotate(180deg);
+  }
+
+  .catalog-sort-option-panel {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    z-index: 20;
+    width: 100%;
+    overflow: hidden;
+    border: 1px solid #dbe7f5;
+    border-radius: 16px;
+    background: #fff;
+    box-shadow: 0 12px 24px rgba(45, 55, 72, 0.08);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-4px);
+    transition: opacity 160ms ease, transform 160ms ease;
+  }
+
+  .catalog-sort-option-panel.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .catalog-sort-option {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    width: 100%;
+    min-height: 42px;
+    padding: 0 14px;
+    color: #4a5568;
+    font-size: 12px;
+    font-weight: 600;
+    line-height: 1.4;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .catalog-sort-option:hover {
+    background: #f8fbff;
+  }
+
+  .catalog-sort-option-check {
+    color: #3182ce;
+    opacity: 0;
+  }
+
+  .catalog-sort-option.is-active {
+    color: #2d3748;
+    background: #f8fbff;
+  }
+
+  .catalog-sort-option.is-active .catalog-sort-option-check {
+    opacity: 1;
+  }
+
+  .catalog-filter-trigger {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    height: 32px;
+    padding: 0 12px;
+    border: 1px solid #c5d7ee;
+    border-radius: 9999px;
+    background: #edf6ff;
+    color: #3182ce;
+    font-size: 11px;
+    font-weight: 700;
+    line-height: 1;
+    transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
+  }
+
+  .catalog-filter-trigger:hover {
+    border-color: #90cdf4;
+    background: #dbeafe;
+  }
+
+  .catalog-filter-trigger.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 6px;
+    right: 8px;
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #ef4444;
   }
 
   .catalog-more-summary {
@@ -103,24 +407,276 @@
     content: "－";
   }
 
-  .catalog-session-drawer {
-    transition: transform 200ms ease, opacity 200ms ease, visibility 200ms ease;
+  #catalogSessionLauncher {
+    position: absolute;
+    right: 10.5px;
+    bottom: 16px;
+    z-index: 20;
+    display: flex;
+    height: 40px;
+    width: 40px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.72);
+    background: #e2e8f0;
+    color: #ffffff;
+    overflow: hidden;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
+    transition: transform 0.22s ease, opacity 0.22s ease, border-color 0.22s ease, background 0.22s ease, color 0.22s ease, box-shadow 0.22s ease;
   }
 
-  .catalog-session-drawer.is-open {
+  #catalogSessionLauncher.is-ready {
+    background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+    color: #fff;
+  }
+
+  #catalogSessionLauncher svg {
+    transform: scale(1);
+    transition: transform 0.18s ease;
+  }
+
+  #catalogSessionOverlay {
+    position: absolute;
+    inset: 0;
+    z-index: 45;
+    background: rgba(15, 23, 42, 0.16);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease;
+  }
+
+  #catalogSessionOverlay.is-open {
     opacity: 1;
-    visibility: visible;
-    transform: translateY(-50%) translateX(0);
+    pointer-events: auto;
   }
 
-  .catalog-session-drawer-toggle {
-    transition: transform 180ms ease, box-shadow 180ms ease;
-    margin-right: -1px;
+  #catalogSessionPanel {
+    position: absolute;
+    right: 12px;
+    bottom: 64px;
+    width: min(calc(100% - 24px), 392px);
+    max-height: min(68vh, 560px);
+    overflow: hidden;
+    border: 1px solid #dbe7f5;
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.96);
+    box-shadow: 0 24px 48px rgba(15, 23, 42, 0.16);
+    opacity: 0;
+    pointer-events: none;
+    transform-origin: calc(100% - 20px) calc(100% - 16px);
+    transform: translateY(16px) scale(0.2);
+    transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1), opacity 0.2s ease;
+    backdrop-filter: blur(12px);
   }
 
-  .catalog-session-drawer.is-open .catalog-session-drawer-toggle {
-    box-shadow: 0 12px 24px rgba(45, 55, 72, 0.12);
+  #catalogSessionOverlay.is-open #catalogSessionPanel {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0) scale(1);
   }
+
+  #catalogFilterOverlay {
+    position: absolute;
+    inset: 0;
+    z-index: 44;
+    background: rgba(15, 23, 42, 0.16);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.22s ease;
+  }
+
+  #catalogFilterOverlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  #catalogFilterPanel {
+    position: absolute;
+    top: 0;
+    right: 0;
+    height: 100%;
+    width: min(calc(100% - 24px), 352px);
+    overflow-y: auto;
+    border-left: 1px solid #dbe7f5;
+    background: rgba(255, 255, 255, 0.98);
+    box-shadow: -18px 0 36px rgba(15, 23, 42, 0.12);
+    transform: translateX(100%);
+    transition: transform 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+    backdrop-filter: blur(12px);
+  }
+
+  .catalog-filter-panel-footer {
+    position: sticky;
+    bottom: 0;
+    display: flex;
+    gap: 10px;
+    padding: 14px 16px 16px;
+    border-top: 1px solid #edf2f7;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  .catalog-filter-panel-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 42px;
+    border-radius: 9999px;
+    font-size: 13px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  #catalogFilterOverlay.is-open #catalogFilterPanel {
+    transform: translateX(0);
+  }
+
+  @media (min-width: 1024px) {
+    #catalogFilterOverlay {
+      display: none;
+    }
+  }
+
+  @media (max-width: 1023px) {
+    .catalog-results-head {
+      gap: 12px;
+    }
+
+    .catalog-results-title {
+      position: relative;
+      min-width: 0;
+      flex: 1 1 100%;
+      padding-right: 244px;
+    }
+
+    .catalog-results-label {
+      display: flex;
+      align-items: center;
+      min-height: 32px;
+      line-height: 1;
+      margin: 0;
+    }
+
+    .catalog-results-sort-mobile {
+      position: absolute;
+      top: 0;
+      right: 0;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      margin-top: 0;
+    }
+
+    .catalog-results-sort-mobile .catalog-sort-dropdown {
+      width: 128px;
+    }
+
+    .catalog-results-sort-mobile .catalog-sort-trigger {
+      height: 32px;
+      padding: 0 12px;
+      font-size: 11px;
+    }
+
+    .catalog-results-sort-mobile .catalog-sort-info-trigger {
+      height: 22px;
+      width: 22px;
+      font-size: 10px;
+    }
+  }
+
+  @media (min-width: 768px) and (max-width: 1023px) {
+    .catalog-results-title {
+      position: relative;
+      padding-right: 0;
+    }
+
+    .catalog-results-sort-mobile {
+      position: absolute;
+      top: 0;
+      right: 0;
+      margin-left: 0;
+    }
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+
+    .catalog-results-title {
+      padding-right: 196px;
+    }
+
+    .catalog-product-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .catalog-card {
+      border-radius: 18px;
+    }
+
+    .catalog-card-body {
+      padding: 12px;
+    }
+
+    .catalog-card-brand {
+      font-size: 11px;
+    }
+
+    .catalog-card-title {
+      min-height: 38px;
+      margin-top: 6px;
+      font-size: 14px;
+      line-height: 1.35;
+      display: -webkit-box;
+      -webkit-box-orient: vertical;
+      -webkit-line-clamp: 2;
+      overflow: hidden;
+    }
+
+    .catalog-card-meta {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 32px;
+      margin-top: auto;
+      padding-top: 10px;
+      gap: 8px;
+      align-items: end;
+    }
+
+    .catalog-card-price {
+      font-size: 16px;
+    }
+
+    .catalog-card-review {
+      margin-top: 2px;
+      font-size: 11px;
+      line-height: 1.25;
+    }
+
+    .catalog-card-action {
+      height: 32px;
+      width: 32px;
+      font-size: 20px;
+    }
+
+    .catalog-card-wishlist {
+      height: 32px;
+      width: 32px;
+      transform: none;
+    }
+
+    .catalog-results-breadcrumb-separator {
+      display: none;
+    }
+
+    .catalog-results-active-filters {
+      display: none;
+    }
+  }
+
   @media (max-width: 767px) {
     .catalog-header-stack {
       flex-direction: column;
@@ -131,25 +687,79 @@
 {% endblock %}
 
 {% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="mx-auto max-w-[1320px] px-4 py-8 md:px-6">
-    <div class="catalog-header-stack flex items-center justify-between gap-4">
-      <div>
-        <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
+<div id="pageGate" class="min-h-screen bg-[#f7fafc]">
+  <div class="app-shell">
+    <header id="catalogHeader">
+      <div id="catalogHeaderInner">
+        <div></div>
+        <a href="/chat/" id="catalogHeaderLogo" aria-label="메인으로 돌아가기">
           <span class="text-[#3182ce]">Tail</span><span>Talk</span>
         </a>
-        <p class="mt-3 text-[28px] font-bold text-[#2d3748]">상품 목록</p>
-        <p class="mt-2 text-[14px] leading-[1.7] text-[#718096]">반려동물 유형과 카테고리 기준으로 전체 상품을 탐색해보세요</p>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="flex flex-wrap items-center gap-2">
-        <a href="/chat/" class="inline-flex h-[40px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-4 text-[13px] font-semibold text-[#4a5568]">채팅으로 돌아가기</a>
-        <a href="/products/" class="inline-flex h-[40px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">장바구니 / 관심상품</a>
+    </header>
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link is-active" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
       </div>
     </div>
-
-    <div class="mt-8 grid gap-6 lg:grid-cols-[280px_minmax(0,1fr)]">
-      <aside class="space-y-4">
-        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+    <div id="catalogViewport">
+    <div class="mb-0 pl-2">
+      <h1 class="text-[24px] font-bold leading-[1.25] text-[#2d3748]">상품 목록</h1>
+      <div class="mt-3 h-px w-full bg-[#e8eef6]"></div>
+    </div>
+    <div class="mt-3 grid gap-6 md:grid-cols-1 lg:grid-cols-[280px_minmax(0,1fr)]">
+      <aside class="order-2 hidden space-y-4 lg:order-1 lg:block">
+        <section class="rounded-[24px] border border-[#e2e8f0] bg-white p-5">
           <p class="text-[13px] font-bold text-[#90a4b8]">반려동물</p>
           <div class="mt-3 flex flex-wrap gap-2">
             <a href="/catalog/" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if not catalog_current_pet %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">전체</a>
@@ -160,11 +770,11 @@
         </section>
 
         {% if catalog_current_pet %}
-        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+        <section class="rounded-[24px] border border-[#e2e8f0] bg-white p-5">
           <div class="flex h-[24px] items-center justify-between gap-3">
             <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">카테고리</p>
             {% if catalog_current_category %}
-            <a href="/catalog/{% if catalog_clear_category_query %}?{{ catalog_clear_category_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            <a href="/catalog/{% if catalog_clear_category_query %}?{{ catalog_clear_category_query }}{% endif %}" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none">초기화</a>
             {% endif %}
           </div>
           <div class="mt-3 flex flex-wrap gap-2">
@@ -177,18 +787,14 @@
 
         {% if catalog_group_options %}
         <section class="relative rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
-          {% if catalog_current_category != '사료' %}
           <div class="flex h-[24px] items-center justify-between gap-3">
             <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">세부 항목</p>
             {% if catalog_current_subcategory or catalog_current_brand %}
-            <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none">초기화</a>
             {% endif %}
           </div>
-          {% elif catalog_current_subcategory or catalog_current_brand %}
-          <a href="/catalog/{% if catalog_clear_detail_query %}?{{ catalog_clear_detail_query }}{% endif %}" class="absolute right-5 top-5 inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
-          {% endif %}
           {% for group in catalog_group_options %}
-          <div class="{% if not forloop.first %}mt-5 border-t border-[#edf2f7] pt-5{% else %}{% if catalog_current_category == '사료' %}mt-0{% else %}mt-3{% endif %}{% endif %}">
+          <div class="{% if not forloop.first %}mt-5 border-t border-[#edf2f7] pt-5{% else %}mt-3{% endif %}">
             {% if group.label != '전체' %}
             <p class="text-[13px] font-bold text-[#90a4b8]">{{ group.label }}</p>
             {% endif %}
@@ -207,7 +813,7 @@
           <div class="flex h-[24px] items-center justify-between gap-3">
             <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">브랜드 (가나다순)</p>
             {% if catalog_current_brand %}
-            <a href="/catalog/{% if catalog_clear_brand_query %}?{{ catalog_clear_brand_query }}{% endif %}" class="inline-flex h-[24px] items-center text-[12px] font-semibold leading-none text-[#7aa6e9]">초기화</a>
+            <a href="/catalog/{% if catalog_clear_brand_query %}?{{ catalog_clear_brand_query }}{% endif %}" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none">초기화</a>
             {% endif %}
           </div>
           <div class="mt-3 flex flex-wrap gap-2">
@@ -231,36 +837,83 @@
         {% endif %}
       </aside>
 
-      <section class="min-w-0">
+      <section class="order-1 min-w-0 lg:order-2">
         <div class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
           <div class="space-y-4">
-            <div class="flex flex-wrap items-start justify-between gap-4">
-              <div>
-              <p class="text-[14px] font-semibold text-[#90a4b8]">{% if catalog_current_keyword %}“{{ catalog_current_keyword }}” 검색 결과{% else %}검색 결과{% endif %}</p>
-              <p class="mt-2 text-[26px] font-bold text-[#2d3748]">{{ catalog_count }}개 상품</p>
-              </div>
-              <div class="flex flex-wrap items-center justify-end gap-2">
-              {% if catalog_current_pet %}
-              <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_pet }}</span>
-              {% endif %}
-              {% if catalog_current_category %}
-              {% if catalog_current_pet %}
-              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
-              {% endif %}
-              <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_category }}</span>
-              {% endif %}
-              {% if catalog_current_subcategory %}
-              {% if catalog_current_category %}
-              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
-              {% endif %}
-              <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_subcategory }}</span>
-              {% endif %}
-              {% if catalog_current_brand %}
-              {% if catalog_current_subcategory or catalog_current_category or catalog_current_pet %}
-              <span class="text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
-              {% endif %}
-              <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_brand }}</span>
-              {% endif %}
+            <div class="catalog-results-head flex flex-wrap items-start justify-between gap-4">
+              <div class="catalog-results-title min-w-0 w-full">
+                <p class="catalog-results-label min-w-0 text-[14px] font-semibold text-[#90a4b8]">{% if catalog_current_keyword %}“{{ catalog_current_keyword }}” 검색 결과{% else %}검색 결과{% endif %}</p>
+                <div class="catalog-results-sort-mobile flex items-center gap-2 lg:hidden">
+                  <button type="button"
+                          class="catalog-filter-trigger {% if catalog_current_pet or catalog_current_category or catalog_current_subcategory or catalog_current_brand %}has-indicator{% endif %}"
+                          onclick="openCatalogFilterPanel()">
+                    <svg viewBox="0 0 20 20" class="h-[12px] w-[12px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                      <path d="M3 5h14"></path>
+                      <path d="M6 10h8"></path>
+                      <path d="M8.5 15h3"></path>
+                    </svg>
+                    <span>필터</span>
+                  </button>
+                  <div class="catalog-sort-dropdown">
+                    <button type="button"
+                            id="catalogSortTriggerMobile"
+                            class="catalog-sort-trigger"
+                            aria-haspopup="listbox"
+                            aria-expanded="false"
+                            onclick="toggleCatalogSortDropdown('mobile')">
+                      <span id="catalogSortTriggerTextMobile" class="catalog-sort-trigger-text">정렬</span>
+                      <svg class="catalog-sort-trigger-caret h-[12px] w-[12px]" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                        <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"></path>
+                      </svg>
+                    </button>
+                    <div id="catalogSortOptionsMobile" class="catalog-sort-option-panel" role="listbox" aria-label="상품 정렬">
+                      {% for option in catalog_sort_options %}
+                      <button type="button"
+                              class="catalog-sort-option {% if option.is_active %}is-active{% endif %}"
+                              onclick="selectCatalogSort('/catalog/{% if option.query %}?{{ option.query }}{% endif %}', '{{ option.label|escapejs }}')">
+                        <span>{{ option.label }}</span>
+                        <span class="catalog-sort-option-check">✓</span>
+                      </button>
+                      {% endfor %}
+                    </div>
+                  </div>
+                  <div class="catalog-sort-tooltip-wrap relative">
+                    <button type="button"
+                            class="catalog-sort-info-trigger inline-flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold leading-none text-[#718096]"
+                            aria-label="TailTalk 추천순 설명">
+                      i
+                    </button>
+                    <div class="catalog-sort-tooltip pointer-events-none absolute right-0 top-[28px] z-10 w-[240px] rounded-[16px] border border-[#dbe7f5] bg-white p-3 text-[12px] leading-[1.6] text-[#4a5568] opacity-0 shadow-[0_12px_24px_rgba(45,55,72,0.08)] transition-all duration-150 ease-out">
+                      TailTalk 추천순은 상품 점수와<br>리뷰 수를 함께 반영해 정렬합니다
+                    </div>
+                  </div>
+                </div>
+                <div class="mt-4 flex w-full flex-wrap items-center gap-2 md:grid md:grid-cols-[auto_minmax(0,1fr)] md:items-center">
+                  <p class="text-[26px] font-bold leading-none text-[#2d3748]">{{ catalog_count }}개 상품</p>
+                  <div class="catalog-results-active-filters hidden md:flex md:flex-wrap md:items-center md:justify-end md:gap-2 md:text-right md:justify-self-end">
+                    {% if catalog_current_pet %}
+                    <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_pet }}</span>
+                    {% endif %}
+                    {% if catalog_current_category %}
+                    {% if catalog_current_pet %}
+                    <span class="catalog-results-breadcrumb-separator text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+                    {% endif %}
+                    <span class="inline-flex h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_category }}</span>
+                    {% endif %}
+                    {% if catalog_current_subcategory %}
+                    {% if catalog_current_category %}
+                    <span class="catalog-results-breadcrumb-separator text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+                    {% endif %}
+                    <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_subcategory }}</span>
+                    {% endif %}
+                    {% if catalog_current_brand %}
+                    {% if catalog_current_subcategory or catalog_current_category or catalog_current_pet %}
+                    <span class="catalog-results-breadcrumb-separator text-[13px] font-semibold text-[#a0aec0]">&gt;</span>
+                    {% endif %}
+                    <span class="inline-flex min-h-[32px] items-center justify-center rounded-full bg-[#edf2f7] px-3 py-1 text-[12px] font-semibold text-[#4a5568]">{{ catalog_current_brand }}</span>
+                    {% endif %}
+                  </div>
+                </div>
               </div>
             </div>
             <div class="flex flex-wrap items-center gap-3">
@@ -275,26 +928,49 @@
                          name="q"
                          value="{{ catalog_current_keyword }}"
                          maxlength="50"
-                         placeholder="상품명 또는 브랜드로 검색"
-                         class="h-[42px] w-full rounded-full border border-[#dbe7f5] bg-[#fbfdff] pl-4 pr-[88px] text-[13px] font-medium text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]">
+                         placeholder="검색"
+                         class="h-[42px] w-full rounded-full border border-[#dbe7f5] bg-white pl-4 pr-[76px] text-[13px] font-medium text-[#2d3748] outline-none transition-colors placeholder:text-[#a0aec0] focus:border-[#90cdf4]">
                   <button type="submit"
-                          class="absolute right-[6px] top-1/2 inline-flex h-[30px] -translate-y-1/2 items-center justify-center rounded-full bg-[#2d3748] px-4 text-[12px] font-semibold text-white transition-colors hover:bg-[#1f2937]">
+                          class="absolute right-[6px] top-1/2 inline-flex h-[30px] -translate-y-1/2 items-center justify-center rounded-full bg-[#2d3748] px-3.5 text-[12px] font-semibold text-white transition-colors hover:bg-[#1f2937]">
                     검색
                   </button>
                 </div>
               </form>
-              <div class="relative">
+              <div class="relative hidden lg:block">
                 <div class="flex h-[36px] items-center gap-2">
-                  <select id="catalogSort"
-                          class="catalog-sort-select h-[36px] rounded-full border border-[#dbe7f5] bg-white pl-4 text-[12px] font-semibold text-[#4a5568] outline-none transition-colors focus:border-[#90cdf4]"
-                          onchange="if (this.value) { window.location.href = this.value; }">
-                    {% for option in catalog_sort_options %}
-                    <option value="/catalog/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>{{ option.label }}</option>
-                    {% endfor %}
-                  </select>
+                  <div class="catalog-sort-dropdown">
+                    <select id="catalogSort"
+                            class="catalog-sort-select hidden-native"
+                            onchange="if (this.value) { window.location.href = this.value; }">
+                      {% for option in catalog_sort_options %}
+                      <option value="/catalog/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>{{ option.label }}</option>
+                      {% endfor %}
+                    </select>
+                    <button type="button"
+                            id="catalogSortTrigger"
+                            class="catalog-sort-trigger"
+                            aria-haspopup="listbox"
+                            aria-expanded="false"
+                            onclick="toggleCatalogSortDropdown()">
+                      <span id="catalogSortTriggerText" class="catalog-sort-trigger-text">정렬</span>
+                      <svg class="catalog-sort-trigger-caret h-[12px] w-[12px]" viewBox="0 0 20 20" fill="none" aria-hidden="true">
+                        <path d="M5 7.5 10 12.5 15 7.5" stroke="currentColor" stroke-width="1.7" stroke-linecap="round" stroke-linejoin="round"></path>
+                      </svg>
+                    </button>
+                    <div id="catalogSortOptions" class="catalog-sort-option-panel" role="listbox" aria-label="상품 정렬">
+                      {% for option in catalog_sort_options %}
+                      <button type="button"
+                              class="catalog-sort-option {% if option.is_active %}is-active{% endif %}"
+                              onclick="selectCatalogSort('/catalog/{% if option.query %}?{{ option.query }}{% endif %}', '{{ option.label|escapejs }}')">
+                        <span>{{ option.label }}</span>
+                        <span class="catalog-sort-option-check">✓</span>
+                      </button>
+                      {% endfor %}
+                    </div>
+                  </div>
                   <div class="catalog-sort-tooltip-wrap relative">
                     <button type="button"
-                            class="catalog-sort-trigger inline-flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold leading-none text-[#718096]"
+                            class="catalog-sort-info-trigger inline-flex h-[24px] w-[24px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white text-[11px] font-bold leading-none text-[#718096]"
                             aria-label="TailTalk 추천순 설명">
                       i
                     </button>
@@ -309,48 +985,43 @@
         </div>
 
         {% if catalog_items %}
-        <div class="mt-6 grid gap-5 sm:grid-cols-2 xl:grid-cols-3">
+        <div class="catalog-product-grid mt-6 grid gap-5 sm:grid-cols-2">
           {% for item in catalog_items %}
           <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
-            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-thumb block overflow-hidden bg-[#f8fbff]">
+            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-thumb relative block overflow-hidden bg-[#f8fbff]">
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+              <button type="button"
+                      class="catalog-card-wishlist wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}absolute bottom-3 right-3 z-[1] inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-white/80 bg-white/95 leading-none shadow-[0_8px_20px_rgba(15,23,42,0.12)] backdrop-blur-sm transition-colors"
+                      aria-label="관심 상품 상태 변경"
+                      data-product-id="{{ item.product_id }}"
+                      onclick="event.preventDefault(); event.stopPropagation(); toggleCatalogWishlist(this)">
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+                </svg>
+              </button>
             </a>
-            <div class="p-5">
-              <div class="flex items-start justify-between gap-3">
-                <p class="min-w-0 truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
-                <button type="button"
-                        class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:text-[#e53e3e]"
-                        aria-label="관심 상품 상태 변경"
-                        data-product-id="{{ item.product_id }}"
-                        onclick="toggleCatalogWishlist(this)">
-                  <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                  </svg>
-                  <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
-                  </svg>
-                </button>
-              </div>
-              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="mt-2 block min-h-[48px] text-[17px] font-bold leading-[1.45] text-[#2d3748] hover:text-[#3182ce]">
+            <div class="catalog-card-body p-4">
+              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-card-title text-[17px] font-bold leading-[1.45] text-[#2d3748] hover:text-[#3182ce]">
                 {{ item.name }}
               </a>
-              <p class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
-              <div class="mt-4 flex items-end justify-between gap-3">
+              <div class="catalog-card-meta mt-3 flex items-end justify-between gap-3">
                 <div>
-                  <p class="text-[20px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
-                  <p class="mt-1 flex items-center gap-1 text-[12px] text-[#a0aec0]">
+                  <p class="catalog-card-price text-[20px] font-bold text-[#2d3748]">₩ {{ item.price_label|cut:"원" }}</p>
+                  <p class="catalog-card-review mt-1 flex items-center gap-1 text-[12px] text-[#a0aec0]">
                     {% if item.rating %}
                     <span class="text-[#f6ad55]">★</span>
                     <span>{{ item.rating }}</span>
-                    <span>·</span>
-                    <span>리뷰 {{ item.review_count }}</span>
+                    <span>({{ item.review_count }})</span>
                     {% else %}
-                    <span>리뷰 {{ item.review_count }}</span>
+                    <span>리뷰 ({{ item.review_count }})</span>
                     {% endif %}
                   </p>
                 </div>
                   <button type="button"
-                          class="inline-flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[24px] font-semibold leading-none text-white"
+                          class="catalog-card-action inline-flex h-[38px] w-[38px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[24px] font-semibold leading-none text-white"
                           data-product-id="{{ item.product_id }}"
                           data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
                           aria-label="장바구니에 상품 추가"
@@ -380,11 +1051,87 @@
         <div class="mt-6 flex min-h-[420px] flex-col items-center justify-center rounded-[24px] border border-dashed border-[#dbe7f5] bg-white px-6 py-10 text-center shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
           <div class="text-[38px] text-[#7aa6e9]">🔎</div>
           <p class="mt-4 text-[22px] font-bold text-[#2d3748]">조건에 맞는 상품이 없습니다</p>
-          <p class="mt-3 max-w-[420px] text-[14px] leading-[1.7] text-[#718096]">선택한 반려동물 유형이나 카테고리를 조금 넓혀서 다시 탐색해보세요.</p>
+          <p class="mt-3 max-w-[420px] text-[14px] leading-[1.7] text-[#718096]">조건을 조금 넓혀서 다시 탐색해보세요.</p>
           <a href="/catalog/{% if catalog_clear_category_query %}?{{ catalog_clear_category_query }}{% endif %}" class="mt-6 inline-flex h-[42px] items-center justify-center rounded-full bg-[#2d3748] px-5 text-[13px] font-semibold text-white">필터 초기화</a>
         </div>
         {% endif %}
       </section>
+</div>
+</div>
+</div>
+</div>
+</div>
+
+<div id="catalogFilterOverlay" aria-hidden="true" onclick="closeCatalogFilterPanel(event)">
+  <div id="catalogFilterPanel" onclick="event.stopPropagation()">
+    <div class="sticky top-0 z-[1] border-b border-[#edf2f7] bg-white/95 px-5 py-4 backdrop-blur">
+      <div class="flex items-center justify-between gap-3">
+        <div class="min-w-0">
+          <div class="flex items-center gap-2">
+            <span class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full bg-[#edf6ff] text-[#3182ce]">
+              <svg viewBox="0 0 20 20" class="h-[14px] w-[14px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M3 5h14"></path>
+                <path d="M6 10h8"></path>
+                <path d="M8.5 15h3"></path>
+              </svg>
+            </span>
+            <p class="relative top-[1px] text-[17px] font-bold leading-none text-[#2d3748]">필터</p>
+          </div>
+        </div>
+        <button type="button"
+                class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full bg-[#f8fafc] text-[18px] leading-none text-[#718096]"
+                aria-label="필터 닫기"
+                onclick="closeCatalogFilterPanel()">
+          ×
+        </button>
+      </div>
+    </div>
+    <div class="space-y-4 px-4 py-4">
+      <section class="rounded-[24px] border border-[#e2e8f0] bg-white p-5">
+        <p class="text-[13px] font-bold text-[#90a4b8]">반려동물</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <a href="/catalog/" data-filter-href="/catalog/" onclick="event.preventDefault(); setCatalogFilterDraft(this.dataset.filterHref)" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if not catalog_current_pet %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">전체</a>
+          {% for option in catalog_menu_sections %}
+          <a href="{{ option.href }}" data-filter-href="{{ option.href }}" onclick="event.preventDefault(); setCatalogFilterDraft(this.dataset.filterHref)" class="catalog-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">{{ option.label }}</a>
+          {% endfor %}
+        </div>
+      </section>
+
+      <section id="catalogFilterCategorySection" class="rounded-[24px] border border-[#e2e8f0] bg-white p-5 {% if not catalog_current_pet %}hidden{% endif %}">
+        <div class="flex h-[24px] items-center justify-between gap-3">
+          <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">카테고리</p>
+          <button type="button" id="catalogFilterCategoryReset" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none {% if not catalog_current_category %}hidden{% endif %}" onclick="resetCatalogFilterLevel('category')">초기화</button>
+        </div>
+        <div id="catalogFilterCategoryOptions" class="mt-3 flex flex-wrap gap-2"></div>
+      </section>
+
+      <section id="catalogFilterDetailSection" class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)] {% if not catalog_current_category %}hidden{% endif %}">
+        <div class="flex h-[24px] items-center justify-between gap-3">
+          <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">세부 항목</p>
+          <button type="button" id="catalogFilterDetailReset" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none {% if not catalog_current_subcategory and not catalog_current_brand %}hidden{% endif %}" onclick="resetCatalogFilterLevel('detail')">초기화</button>
+        </div>
+        <div id="catalogFilterDetailGroups" class="mt-3"></div>
+      </section>
+
+      <section id="catalogFilterBrandSection" class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+        <div class="flex h-[24px] items-center justify-between gap-3">
+          <p class="flex h-[24px] items-center text-[13px] font-bold leading-none text-[#90a4b8]">브랜드 (가나다순)</p>
+          <button type="button" id="catalogFilterBrandReset" class="inline-flex h-[24px] items-center bg-transparent text-[12px] font-semibold leading-none text-[#7aa6e9] shadow-none {% if not catalog_current_brand %}hidden{% endif %}" onclick="resetCatalogFilterLevel('brand')">초기화</button>
+        </div>
+        <div id="catalogFilterBrandOptions" class="mt-3 flex flex-wrap gap-2"></div>
+      </section>
+    </div>
+    <div class="catalog-filter-panel-footer">
+      <button type="button"
+              class="catalog-filter-panel-button flex-1 border border-[#dbe7f5] bg-white text-[#4a5568]"
+              onclick="resetCatalogFilters()">
+        초기화
+      </button>
+      <button type="button"
+              class="catalog-filter-panel-button flex-1 bg-[#2d3748] text-white"
+              onclick="applyCatalogFilterDraft()">
+        적용
+      </button>
     </div>
   </div>
 </div>
@@ -394,23 +1141,26 @@
   오류가 발생했습니다.
 </div>
 
-<div id="catalogSessionDrawer"
+<div id="catalogSessionOverlay"
      data-current-session-id="{{ catalog_current_session_id|default:'' }}"
-     class="catalog-session-drawer fixed right-0 top-1/2 z-[65] flex -translate-y-1/2 translate-x-[calc(100%-48px)] items-center opacity-100 visible">
-  <button type="button"
-          id="catalogSessionDrawerToggle"
-          class="catalog-session-drawer-toggle inline-flex h-[120px] w-[48px] self-center items-center justify-center rounded-l-[20px] border border-r-0 border-[#dbe7f5] bg-white text-[12px] font-bold tracking-[0.08em] text-[#4a5568] shadow-[0_8px_20px_rgba(45,55,72,0.08)]"
-          onclick="toggleCatalogSessionDrawer()">
-    <span class="[writing-mode:vertical-rl]">추천 상품</span>
-  </button>
-  <aside class="h-[min(78vh,680px)] w-[360px] overflow-hidden rounded-l-[24px] border border-[#dbe7f5] bg-white shadow-[0_18px_40px_rgba(45,55,72,0.12)]">
-    <div class="flex items-center justify-between border-b border-[#edf2f7] px-5 py-4">
-      <div>
-        <p class="text-[16px] font-bold text-[#2d3748]">추천 상품</p>
-        <p id="catalogSessionDrawerSubtitle" class="mt-1 text-[12px] text-[#90a4b8]">{% if catalog_recommended_session %}현재 채팅 세션에서 추천된 상품{% else %}추천 세션이 연결되지 않았어요{% endif %}</p>
+     aria-hidden="true"
+     onclick="closeCatalogSessionDrawer(event)">
+  <div id="catalogSessionPanel" onclick="event.stopPropagation()">
+    <div class="border-b border-[#edf2f7] px-5 py-4">
+      <div class="relative flex items-start justify-between gap-3">
+        <div class="min-w-0 pt-[1px]">
+          <p class="text-[17px] font-bold text-[#2d3748]">추천 상품</p>
+          <p id="catalogSessionDrawerSubtitle" class="mt-1 text-[12px] text-[#90a4b8]">{% if catalog_recommended_session %}현재 채팅 세션에서 추천된 상품{% endif %}</p>
+        </div>
+        <button type="button"
+                class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full bg-[#f8fafc] text-[18px] leading-none text-[#718096]"
+                aria-label="추천 상품 닫기"
+                onclick="closeCatalogSessionDrawer()">
+          ×
+        </button>
       </div>
     </div>
-    <div id="catalogSessionDrawerBody" class="h-[calc(100%-69px)] overflow-y-auto px-4 py-4">
+    <div id="catalogSessionDrawerBody" class="max-h-[calc(min(68vh,560px)-78px)] overflow-y-auto px-4 py-4">
       {% if catalog_recommended_items %}
       <div class="space-y-3">
         {% for item in catalog_recommended_items %}
@@ -420,12 +1170,11 @@
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
             </a>
             <div class="min-w-0 flex-1">
-              <p class="truncate text-[11px] font-semibold text-[#90a4b8]">{{ item.brand_name }}</p>
-              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="mt-1 block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">{{ item.name }}</a>
+              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">{{ item.name }}</a>
               <p class="mt-2 text-[12px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
               <div class="mt-3 flex items-end justify-between gap-3">
                 <div>
-                  <p class="text-[16px] font-bold text-[#2d3748]">{{ item.price_label }}</p>
+                  <p class="text-[16px] font-bold text-[#2d3748]">₩ {{ item.price_label|cut:"원" }}</p>
                   <p class="mt-1 flex items-center gap-1 text-[11px] text-[#a0aec0]">
                     {% if item.rating %}
                     <span class="text-[#f6ad55]">★</span>
@@ -437,7 +1186,7 @@
                 </div>
                 <div class="flex items-center gap-2">
                   <button type="button"
-                          class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:text-[#e53e3e]"
+                          class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors"
                           aria-label="관심 상품 상태 변경"
                           data-product-id="{{ item.product_id }}"
                           onclick="toggleCatalogWishlist(this)">
@@ -454,7 +1203,7 @@
                           data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
                           aria-label="장바구니에 상품 추가"
                           onclick="addCatalogToCart(this)">
-                    <span class="relative top-[-1px]">+</span>
+                    <span>+</span>
                   </button>
                 </div>
               </div>
@@ -472,20 +1221,62 @@
       </div>
       {% endif %}
     </div>
-  </aside>
+  </div>
 </div>
+{{ catalog_filter_tree|json_script:"catalogFilterTreeData" }}
+<button type="button"
+        id="catalogSessionLauncher"
+        aria-label="추천 상품 열기"
+        onclick="toggleCatalogSessionDrawer()">
+  <svg aria-hidden="true" class="h-[24px] w-[24px]" viewBox="0 0 28 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M14 4 16.45 10.55 23 13 16.45 15.45 14 22 11.55 15.45 5 13 11.55 10.55 14 4Z" fill="white"/>
+    <path d="M21.6 5.8 22.5 8.1 24.8 9 22.5 9.9 21.6 12.2 20.7 9.9 18.4 9 20.7 8.1 21.6 5.8Z" fill="white"/>
+    <path d="M8.2 17.6 9 19.6 11 20.4 9 21.2 8.2 23.2 7.4 21.2 5.4 20.4 7.4 19.6 8.2 17.6Z" fill="white"/>
+  </svg>
+</button>
 {% endblock %}
 
 {% block scripts %}
 <script>
 (function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
+  var headerCartNavLink = document.querySelector('.header-subnav-link[href="/products/"]');
+  var headerWishlistNavLink = document.querySelector('.header-subnav-link[href="/wishlist/"]');
   var catalogFeedbackToast = document.getElementById('catalogFeedbackToast');
   var catalogToastTimer = null;
-  var catalogSessionDrawer = document.getElementById('catalogSessionDrawer');
+  var catalogSessionDrawer = document.getElementById('catalogSessionOverlay');
   var catalogSessionDrawerBody = document.getElementById('catalogSessionDrawerBody');
   var catalogSessionDrawerSubtitle = document.getElementById('catalogSessionDrawerSubtitle');
+  var catalogSessionLauncher = document.getElementById('catalogSessionLauncher');
+  var catalogFilterOverlay = document.getElementById('catalogFilterOverlay');
+  var catalogFilterPanel = document.getElementById('catalogFilterPanel');
+  var catalogFilterCategorySection = document.getElementById('catalogFilterCategorySection');
+  var catalogFilterDetailSection = document.getElementById('catalogFilterDetailSection');
+  var catalogFilterBrandSection = document.getElementById('catalogFilterBrandSection');
+  var catalogFilterCategoryOptions = document.getElementById('catalogFilterCategoryOptions');
+  var catalogFilterCategoryReset = document.getElementById('catalogFilterCategoryReset');
+  var catalogFilterDetailGroups = document.getElementById('catalogFilterDetailGroups');
+  var catalogFilterDetailReset = document.getElementById('catalogFilterDetailReset');
+  var catalogFilterBrandOptions = document.getElementById('catalogFilterBrandOptions');
+  var catalogFilterBrandReset = document.getElementById('catalogFilterBrandReset');
+  var catalogFilterTreeNode = document.getElementById('catalogFilterTreeData');
+  var catalogSortSelect = document.getElementById('catalogSort');
+  var catalogSortTrigger = document.getElementById('catalogSortTrigger');
+  var catalogSortTriggerText = document.getElementById('catalogSortTriggerText');
+  var catalogSortOptions = document.getElementById('catalogSortOptions');
+  var catalogSortTriggerMobile = document.getElementById('catalogSortTriggerMobile');
+  var catalogSortTriggerTextMobile = document.getElementById('catalogSortTriggerTextMobile');
+  var catalogSortOptionsMobile = document.getElementById('catalogSortOptionsMobile');
   var catalogCurrentSessionId = catalogSessionDrawer ? (catalogSessionDrawer.getAttribute('data-current-session-id') || '') : '';
   var SESSION_RECOMMENDED_PRODUCTS_STORAGE_PREFIX = 'tailtalk_session_recommended_products:';
+  var catalogFilterDraft = null;
+  var catalogFilterTree = catalogFilterTreeNode ? JSON.parse(catalogFilterTreeNode.textContent || '{}') : { pets: [], brands: {} };
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
 
   function getCsrfToken() {
     var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
@@ -534,6 +1325,373 @@
     }, 2400);
   }
 
+  function refreshCatalogNavIndicators() {
+    return Promise.all([
+      requestJson('/api/orders/cart/'),
+      requestJson('/api/orders/wishlist/'),
+    ]).then(function (results) {
+      var cartData = results[0] || {};
+      var wishlistData = results[1] || {};
+      if (headerCartNavLink) {
+        headerCartNavLink.classList.toggle('has-indicator', !!(cartData.items && cartData.items.length));
+      }
+      if (headerWishlistNavLink) {
+        headerWishlistNavLink.classList.toggle('has-indicator', !!(wishlistData.items && wishlistData.items.length));
+      }
+    }).catch(function () {
+      return null;
+    });
+  }
+
+  function setCatalogNavIndicatorState(type, active) {
+    if (type === 'cart' && headerCartNavLink) {
+      headerCartNavLink.classList.toggle('has-indicator', !!active);
+    }
+    if (type === 'wishlist' && headerWishlistNavLink) {
+      headerWishlistNavLink.classList.toggle('has-indicator', !!active);
+    }
+  }
+
+  function readCatalogFilterState(urlString) {
+    var url = new URL(urlString || window.location.pathname + window.location.search, window.location.origin);
+    var params = url.searchParams;
+    return {
+      pet: params.get('pet') || '',
+      category: params.get('category') || '',
+      subcategory: params.get('subcategory') || '',
+      brand: params.get('brand') || '',
+    };
+  }
+
+  function normalizeCatalogFilterState(state) {
+    var next = {
+      pet: state && state.pet ? state.pet : '',
+      category: state && state.category ? state.category : '',
+      subcategory: state && state.subcategory ? state.subcategory : '',
+      brand: state && state.brand ? state.brand : '',
+    };
+
+    if (!next.pet) {
+      next.category = '';
+      next.subcategory = '';
+      return next;
+    }
+
+    if (!next.category) {
+      next.subcategory = '';
+    }
+
+    return next;
+  }
+
+  function getCatalogBaseParams() {
+    var params = new URLSearchParams(window.location.search);
+    ['pet', 'category', 'subcategory', 'brand', 'page'].forEach(function (key) {
+      params.delete(key);
+    });
+    return params;
+  }
+
+  function getCatalogHrefForState(state) {
+    var normalized = normalizeCatalogFilterState(state);
+    var params = getCatalogBaseParams();
+    if (normalized.pet) params.set('pet', normalized.pet);
+    if (normalized.category) params.set('category', normalized.category);
+    if (normalized.subcategory) params.set('subcategory', normalized.subcategory);
+    if (normalized.brand) params.set('brand', normalized.brand);
+    return '/catalog/' + (params.toString() ? '?' + params.toString() : '');
+  }
+
+  function findCatalogPetNode(pet) {
+    return (catalogFilterTree.pets || []).find(function (entry) {
+      return entry.label === pet;
+    }) || null;
+  }
+
+  function findCatalogCategoryNode(pet, category) {
+    var petNode = findCatalogPetNode(pet);
+    if (!petNode) return null;
+    return (petNode.categories || []).find(function (entry) {
+      return entry.label === category;
+    }) || null;
+  }
+
+  function getCatalogBrandsForState(state) {
+    var allBrandTree = catalogFilterTree.brands || {};
+
+    function collectBrandsFromCategoryMap(categoryMap) {
+      var merged = [];
+      Object.keys(categoryMap || {}).forEach(function (subcategoryKey) {
+        merged = merged.concat(categoryMap[subcategoryKey] || []);
+      });
+      return Array.from(new Set(merged)).sort();
+    }
+
+    function collectBrandsFromPetMap(petMap) {
+      var merged = [];
+      Object.keys(petMap || {}).forEach(function (categoryKey) {
+        merged = merged.concat(collectBrandsFromCategoryMap(petMap[categoryKey] || {}));
+      });
+      return Array.from(new Set(merged)).sort();
+    }
+
+    if (state.pet && state.category && state.subcategory) {
+      var exactPetBrands = allBrandTree[state.pet] || {};
+      var exactCategoryBrands = exactPetBrands[state.category] || {};
+      return exactCategoryBrands[state.subcategory] || [];
+    }
+
+    if (state.pet && state.category) {
+      var categoryPetBrands = allBrandTree[state.pet] || {};
+      return collectBrandsFromCategoryMap(categoryPetBrands[state.category] || {});
+    }
+
+    if (state.pet) {
+      return collectBrandsFromPetMap(allBrandTree[state.pet] || {});
+    }
+
+    var mergedAll = [];
+    Object.keys(allBrandTree).forEach(function (petKey) {
+      mergedAll = mergedAll.concat(collectBrandsFromPetMap(allBrandTree[petKey] || {}));
+    });
+    return Array.from(new Set(mergedAll)).sort();
+  }
+
+  function renderCatalogDraftChip(label, state, active) {
+    return ''
+      + '<button type="button"'
+      + ' class="catalog-chip inline-flex min-h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 py-2 text-[12px] font-semibold ' + (active ? 'is-active' : 'bg-[#f8fbff] text-[#4a5568]') + '"'
+      + ' data-pet="' + escapeHtml(state.pet || '') + '"'
+      + ' data-category="' + escapeHtml(state.category || '') + '"'
+      + ' data-subcategory="' + escapeHtml(state.subcategory || '') + '"'
+      + ' data-brand="' + escapeHtml(state.brand || '') + '"'
+      + ' onclick="event.preventDefault(); event.stopPropagation(); setCatalogFilterDraftFromElement(this)">'
+      + escapeHtml(label)
+      + '</button>';
+  }
+
+  function renderCatalogFilterDraftSections() {
+    var draft = normalizeCatalogFilterState(catalogFilterDraft || readCatalogFilterState());
+    var petNode = findCatalogPetNode(draft.pet);
+    var categoryNode = findCatalogCategoryNode(draft.pet, draft.category);
+    var brands = getCatalogBrandsForState(draft);
+
+    if (catalogFilterCategoryOptions) {
+      catalogFilterCategoryOptions.innerHTML = petNode
+        ? (petNode.categories || []).map(function (entry) {
+            return renderCatalogDraftChip(entry.label, {
+              pet: draft.pet,
+              category: entry.label,
+              subcategory: '',
+              brand: '',
+            }, draft.category === entry.label);
+          }).join('')
+        : '';
+    }
+    if (catalogFilterCategoryReset) {
+      catalogFilterCategoryReset.classList.toggle('hidden', !draft.category);
+    }
+
+    if (catalogFilterDetailGroups) {
+      if (!categoryNode) {
+        catalogFilterDetailGroups.innerHTML = '';
+      } else {
+        catalogFilterDetailGroups.innerHTML = (categoryNode.groups || []).map(function (group, index) {
+          var itemsMarkup = (group.items || []).map(function (item) {
+            return renderCatalogDraftChip(item.label, {
+              pet: draft.pet,
+              category: draft.category,
+              subcategory: item.value,
+              brand: '',
+            }, draft.subcategory === item.value);
+          }).join('');
+          return ''
+            + '<div class="' + (index > 0 ? 'mt-5 border-t border-[#edf2f7] pt-5' : '') + '">'
+            +   (group.label && group.label !== '전체' ? '<p class="text-[13px] font-bold text-[#90a4b8]">' + escapeHtml(group.label) + '</p>' : '')
+            +   '<div class="' + (group.label && group.label !== '전체' ? 'mt-3 ' : '') + 'flex flex-wrap gap-2">' + itemsMarkup + '</div>'
+            + '</div>';
+        }).join('');
+      }
+    }
+    if (catalogFilterDetailReset) {
+      catalogFilterDetailReset.classList.toggle('hidden', !draft.subcategory && !draft.brand);
+    }
+
+    if (catalogFilterBrandOptions) {
+      catalogFilterBrandOptions.innerHTML = brands.map(function (brandLabel) {
+        return renderCatalogDraftChip(brandLabel, {
+          pet: draft.pet,
+          category: draft.category,
+          subcategory: draft.subcategory,
+          brand: brandLabel,
+        }, draft.brand === brandLabel);
+      }).join('');
+    }
+    if (catalogFilterBrandReset) {
+      catalogFilterBrandReset.classList.toggle('hidden', !draft.brand);
+    }
+  }
+
+  function sameCatalogFilterState(a, b) {
+    return !!a && !!b
+      && (a.pet || '') === (b.pet || '')
+      && (a.category || '') === (b.category || '')
+      && (a.subcategory || '') === (b.subcategory || '')
+      && (a.brand || '') === (b.brand || '');
+  }
+
+  function syncCatalogFilterSectionVisibility() {
+    var draft = normalizeCatalogFilterState(catalogFilterDraft || readCatalogFilterState());
+    if (catalogFilterCategorySection) {
+      catalogFilterCategorySection.classList.toggle('hidden', !draft.pet);
+    }
+    if (catalogFilterDetailSection) {
+      catalogFilterDetailSection.classList.toggle('hidden', !draft.category);
+    }
+    if (catalogFilterBrandSection) {
+      catalogFilterBrandSection.classList.remove('hidden');
+    }
+  }
+
+  function syncCatalogFilterDraftUI() {
+    if (!catalogFilterPanel || !catalogFilterDraft) return;
+    catalogFilterDraft = normalizeCatalogFilterState(catalogFilterDraft);
+    catalogFilterPanel.querySelectorAll('[data-filter-href]').forEach(function (node) {
+      var targetState = normalizeCatalogFilterState(readCatalogFilterState(node.getAttribute('data-filter-href') || ''));
+      var isActive = false;
+      if (!targetState.pet && !targetState.category && !targetState.subcategory && !targetState.brand) {
+        isActive = !catalogFilterDraft.pet;
+      } else if (targetState.pet && !targetState.category && !targetState.subcategory && !targetState.brand) {
+        isActive = targetState.pet === catalogFilterDraft.pet;
+      } else {
+        isActive = sameCatalogFilterState(targetState, catalogFilterDraft);
+      }
+      node.classList.toggle('is-active', isActive);
+      if (isActive) {
+        node.classList.remove('bg-[#f8fbff]', 'text-[#4a5568]');
+      } else if (!node.classList.contains('bg-[#f8fbff]')) {
+        node.classList.add('bg-[#f8fbff]', 'text-[#4a5568]');
+      }
+    });
+    syncCatalogFilterSectionVisibility();
+    renderCatalogFilterDraftSections();
+  }
+
+  window.setCatalogFilterDraftFromElement = function (node) {
+    if (!node) return;
+    catalogFilterDraft = normalizeCatalogFilterState({
+      pet: node.getAttribute('data-pet') || '',
+      category: node.getAttribute('data-category') || '',
+      subcategory: node.getAttribute('data-subcategory') || '',
+      brand: node.getAttribute('data-brand') || '',
+    });
+    syncCatalogFilterDraftUI();
+  };
+
+  window.setCatalogFilterDraft = function (href) {
+    if (!href) return;
+    catalogFilterDraft = normalizeCatalogFilterState(readCatalogFilterState(href));
+    syncCatalogFilterDraftUI();
+  };
+
+  window.applyCatalogFilterDraft = function () {
+    var draft = normalizeCatalogFilterState(catalogFilterDraft || readCatalogFilterState());
+    var params = new URLSearchParams(window.location.search);
+    ['pet', 'category', 'subcategory', 'brand'].forEach(function (key) {
+      params.delete(key);
+      if (draft[key]) {
+        params.set(key, draft[key]);
+      }
+    });
+    params.delete('page');
+    window.location.href = '/catalog/' + (params.toString() ? '?' + params.toString() : '');
+  };
+
+  window.resetCatalogFilters = function () {
+    var params = new URLSearchParams(window.location.search);
+    ['pet', 'category', 'subcategory', 'brand', 'page'].forEach(function (key) {
+      params.delete(key);
+    });
+    var nextHref = '/catalog/' + (params.toString() ? '?' + params.toString() : '');
+    if (catalogFilterOverlay) {
+      catalogFilterOverlay.classList.remove('is-open');
+      window.setTimeout(function () {
+        window.location.href = nextHref;
+      }, 120);
+      return;
+    }
+    window.location.href = nextHref;
+  };
+
+  window.resetCatalogFilterLevel = function (level) {
+    var draft = normalizeCatalogFilterState(catalogFilterDraft || readCatalogFilterState());
+    if (level === 'category') {
+      draft.category = '';
+      draft.subcategory = '';
+      draft.brand = '';
+    } else if (level === 'detail') {
+      draft.subcategory = '';
+      draft.brand = '';
+    } else if (level === 'brand') {
+      draft.brand = '';
+    }
+    catalogFilterDraft = normalizeCatalogFilterState(draft);
+    syncCatalogFilterDraftUI();
+  };
+
+  function syncCatalogSortTriggerLabel() {
+    if (!catalogSortSelect) return;
+    var selectedOption = catalogSortSelect.options[catalogSortSelect.selectedIndex];
+    var label = selectedOption ? selectedOption.textContent : '정렬';
+    if (catalogSortTriggerText) catalogSortTriggerText.textContent = label;
+    if (catalogSortTriggerTextMobile) catalogSortTriggerTextMobile.textContent = label;
+  }
+
+  function closeCatalogSortDropdown(target) {
+    if ((!target || target === 'desktop') && catalogSortOptions && catalogSortTrigger) {
+      catalogSortOptions.classList.remove('is-open');
+      catalogSortTrigger.classList.remove('is-open');
+      catalogSortTrigger.setAttribute('aria-expanded', 'false');
+    }
+    if ((!target || target === 'mobile') && catalogSortOptionsMobile && catalogSortTriggerMobile) {
+      catalogSortOptionsMobile.classList.remove('is-open');
+      catalogSortTriggerMobile.classList.remove('is-open');
+      catalogSortTriggerMobile.setAttribute('aria-expanded', 'false');
+    }
+  }
+
+  window.toggleCatalogSortDropdown = function (target) {
+    var isMobile = target === 'mobile';
+    var trigger = isMobile ? catalogSortTriggerMobile : catalogSortTrigger;
+    var panel = isMobile ? catalogSortOptionsMobile : catalogSortOptions;
+    if (!trigger || !panel) return;
+    var isOpen = panel.classList.contains('is-open');
+    if (isOpen) {
+      closeCatalogSortDropdown(target);
+      return;
+    }
+    closeCatalogSortDropdown();
+    panel.classList.add('is-open');
+    trigger.classList.add('is-open');
+    trigger.setAttribute('aria-expanded', 'true');
+  };
+
+  window.selectCatalogSort = function (href, label) {
+    if (catalogSortSelect) {
+      catalogSortSelect.value = href;
+    }
+    if (catalogSortTriggerText) {
+      catalogSortTriggerText.textContent = label || '정렬';
+    }
+    if (catalogSortTriggerTextMobile) {
+      catalogSortTriggerTextMobile.textContent = label || '정렬';
+    }
+    closeCatalogSortDropdown();
+    if (href) {
+      window.location.href = href;
+    }
+  };
+
   function escapeHtml(value) {
     return String(value || '')
       .replace(/&/g, '&amp;')
@@ -552,13 +1710,18 @@
     }
   }
 
+  function compactPriceLabel(value) {
+    var raw = String(value || '').trim();
+    if (!raw || raw === '가격 정보 없음') return raw || '가격 정보 없음';
+    return '₩ ' + raw.replace(/원/g, '').trim();
+  }
+
   function drawerItemMarkup(item) {
     var productId = escapeHtml(item.product_id || item.goods_id || '');
     var productUrl = escapeHtml(item.product_url || '');
-    var brandName = escapeHtml(item.brand_name || item.brand || '');
     var productName = escapeHtml(item.product_name || item.name || '추천 상품');
     var summary = escapeHtml(item.summary || '');
-    var priceLabel = escapeHtml(item.price_label || item.price || '가격 정보 없음');
+    var priceLabel = escapeHtml(compactPriceLabel(item.price_label || item.price || '가격 정보 없음'));
     var rating = item.rating ? escapeHtml(item.rating) : '';
     var reviewCount = escapeHtml(item.review_count || item.reviews || '0');
     var thumbnailUrl = escapeHtml(item.thumbnail_url || '');
@@ -569,8 +1732,7 @@
       + '      <img src="' + thumbnailUrl + '" alt="' + productName + '" class="h-full w-full object-cover">'
       + '    </a>'
       + '    <div class="min-w-0 flex-1">'
-      + (brandName ? '      <p class="truncate text-[11px] font-semibold text-[#90a4b8]">' + brandName + '</p>' : '')
-      + '      <a href="' + productUrl + '" target="_blank" rel="noreferrer" class="mt-1 block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">' + productName + '</a>'
+      + '      <a href="' + productUrl + '" target="_blank" rel="noreferrer" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">' + productName + '</a>'
       + (summary ? '      <p class="mt-2 text-[12px] leading-[1.6] text-[#718096]">' + summary + '</p>' : '')
       + '      <div class="mt-3 flex items-end justify-between gap-3">'
       + '        <div>'
@@ -581,12 +1743,12 @@
       + '          </p>'
       + '        </div>'
       + '        <div class="flex items-center gap-2">'
-      + '          <button type="button" class="wishlist-heart inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:text-[#e53e3e]" aria-label="관심 상품 상태 변경" data-product-id="' + productId + '" onclick="toggleCatalogWishlist(this)">'
+      + '          <button type="button" class="wishlist-heart inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors" aria-label="관심 상품 상태 변경" data-product-id="' + productId + '" onclick="toggleCatalogWishlist(this)">'
       + '            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>'
       + '            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>'
       + '          </button>'
       + '          <button type="button" class="inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[16px] font-semibold leading-none text-white" data-product-id="' + productId + '" data-in-cart="0" aria-label="장바구니에 상품 추가" onclick="addCatalogToCart(this)">'
-      + '            <span class="relative top-[-1px]">+</span>'
+      + '            <span>+</span>'
       + '          </button>'
       + '        </div>'
       + '      </div>'
@@ -608,8 +1770,12 @@
   function renderCatalogSessionDrawerItems(items) {
     if (!catalogSessionDrawerBody) return;
     var normalizedItems = Array.isArray(items) ? items : [];
+    if (catalogSessionLauncher) {
+      catalogSessionLauncher.classList.toggle('is-ready', normalizedItems.length > 0);
+      catalogSessionLauncher.setAttribute('aria-disabled', normalizedItems.length ? 'false' : 'true');
+    }
     if (catalogSessionDrawerSubtitle) {
-      catalogSessionDrawerSubtitle.textContent = catalogCurrentSessionId ? '현재 채팅 세션에서 추천된 상품' : '추천 세션이 연결되지 않았어요';
+      catalogSessionDrawerSubtitle.textContent = catalogCurrentSessionId ? '현재 채팅 세션에서 추천된 상품' : '';
     }
     if (!normalizedItems.length) {
       catalogSessionDrawerBody.innerHTML = drawerEmptyMarkup(!!catalogCurrentSessionId);
@@ -623,23 +1789,50 @@
     catalogSessionDrawer.classList.toggle('is-open');
   };
 
-  window.closeCatalogSessionDrawer = function () {
+  window.openCatalogFilterPanel = function () {
+    if (!catalogFilterOverlay) return;
+    catalogFilterDraft = normalizeCatalogFilterState(readCatalogFilterState());
+    syncCatalogFilterDraftUI();
+    catalogFilterOverlay.classList.add('is-open');
+  };
+
+  window.closeCatalogFilterPanel = function (event) {
+    if (!catalogFilterOverlay) return;
+    if (event && event.target !== catalogFilterOverlay) return;
+    catalogFilterOverlay.classList.remove('is-open');
+  };
+
+  window.closeCatalogSessionDrawer = function (event) {
+    if (event && catalogSessionDrawer && event.target !== catalogSessionDrawer) return;
     if (!catalogSessionDrawer) return;
     catalogSessionDrawer.classList.remove('is-open');
   };
 
   document.addEventListener('mousedown', function (event) {
-    if (!catalogSessionDrawer || !catalogSessionDrawer.classList.contains('is-open')) return;
-    if (catalogSessionDrawer.contains(event.target)) return;
-    closeCatalogSessionDrawer();
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+    var desktopDropdown = catalogSortTrigger ? catalogSortTrigger.closest('.catalog-sort-dropdown') : null;
+    var mobileDropdown = catalogSortTriggerMobile ? catalogSortTriggerMobile.closest('.catalog-sort-dropdown') : null;
+    if (desktopDropdown && !desktopDropdown.contains(event.target) && mobileDropdown && !mobileDropdown.contains(event.target)) {
+      closeCatalogSortDropdown();
+    } else if (desktopDropdown && !desktopDropdown.contains(event.target) && !mobileDropdown) {
+      closeCatalogSortDropdown('desktop');
+    } else if (mobileDropdown && !mobileDropdown.contains(event.target) && !desktopDropdown) {
+      closeCatalogSortDropdown('mobile');
+    } else if (desktopDropdown && mobileDropdown && !desktopDropdown.contains(event.target) && !mobileDropdown.contains(event.target)) {
+      closeCatalogSortDropdown();
+    }
   });
 
   if (catalogCurrentSessionId) {
     var storedItems = readStoredSessionRecommendations(catalogCurrentSessionId);
-    if (storedItems.length) {
-      renderCatalogSessionDrawerItems(storedItems);
-    }
+    renderCatalogSessionDrawerItems(storedItems);
+  } else {
+    renderCatalogSessionDrawerItems([]);
   }
+
+  syncCatalogSortTriggerLabel();
 
   window.addEventListener('storage', function (event) {
     if (!catalogCurrentSessionId) return;
@@ -650,7 +1843,7 @@
   window.toggleCatalogWishlist = function (button) {
     var productId = button && button.dataset ? button.dataset.productId : '';
     if (!productId) {
-      showCatalogToast('상품 식별 정보를 찾을 수 없습니다.');
+      showCatalogToast('상품 식별 정보를 찾을 수 없습니다');
       return;
     }
 
@@ -660,16 +1853,20 @@
       body: JSON.stringify({ product_id: productId }),
     }).then(function () {
       button.classList.toggle('is-active', !isActive);
-      showCatalogToast(isActive ? '관심 상품에서 제거했습니다.' : '관심 상품에 저장했습니다.');
+      if (!isActive) {
+        setCatalogNavIndicatorState('wishlist', true);
+      }
+      refreshCatalogNavIndicators();
+      showCatalogToast(isActive ? '관심상품에서 뺐어요' : '관심상품에 담았어요');
     }).catch(function (error) {
-      showCatalogToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+      showCatalogToast(error.message || '관심상품을 변경하지 못했어요');
     });
   };
 
   window.addCatalogToCart = function (button) {
     var productId = button && button.dataset ? button.dataset.productId : '';
     if (!productId) {
-      showCatalogToast('상품 식별 정보를 찾을 수 없습니다.');
+      showCatalogToast('상품 식별 정보를 찾을 수 없습니다');
       return;
     }
 
@@ -681,9 +1878,11 @@
       }),
     }).then(function () {
       button.dataset.inCart = '1';
-      showCatalogToast('장바구니에 상품을 담았습니다.');
+      setCatalogNavIndicatorState('cart', true);
+      refreshCatalogNavIndicators();
+      showCatalogToast('장바구니에 담았어요');
     }).catch(function (error) {
-      showCatalogToast(error.message || '장바구니에 상품을 담지 못했습니다.');
+      showCatalogToast(error.message || '장바구니에 담지 못했어요');
     });
   };
 })();

--- a/services/django/templates/orders/checkout.html
+++ b/services/django/templates/orders/checkout.html
@@ -1,0 +1,1561 @@
+{% extends "base.html" %}
+{% block title %}주문 정보 — TailTalk{% endblock %}
+
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #checkoutHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #checkoutHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #checkoutHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #checkoutViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 24px 16px 32px;
+  }
+
+  html,
+  body,
+  body.bg-white {
+    background: #f8f9fb !important;
+  }
+
+  .checkout-sheet {
+    display: flex;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease;
+  }
+
+  .checkout-sheet.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .checkout-sheet-panel {
+    width: 100%;
+    max-width: 560px;
+    border-radius: 28px 28px 0 0;
+    background: #fff;
+    box-shadow: 0 -20px 50px rgba(15, 23, 42, 0.18);
+    transform: translateY(28px);
+    opacity: 0;
+    transition: transform 240ms ease, opacity 220ms ease;
+  }
+
+  .checkout-sheet.is-open .checkout-sheet-panel {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  .discount-modal {
+    display: flex;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 220ms ease;
+  }
+
+  .discount-modal.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .discount-sheet-panel {
+    width: 100%;
+    max-width: 560px;
+    border-radius: 28px 28px 0 0;
+    background: #fff;
+    box-shadow: 0 -20px 50px rgba(15, 23, 42, 0.18);
+    transform: translateY(28px);
+    opacity: 0;
+    transition: transform 240ms ease, opacity 220ms ease;
+  }
+
+  .discount-modal.is-open .discount-sheet-panel {
+    transform: translateY(0);
+    opacity: 1;
+  }
+
+  @media (min-width: 768px) {
+    .discount-sheet-panel {
+      border-radius: 24px;
+      box-shadow: 0 20px 60px rgba(15, 23, 42, 0.24);
+    }
+  }
+
+  .checkout-sheet-field {
+    display: block;
+  }
+
+  .checkout-sheet-field + .checkout-sheet-field {
+    margin-top: 12px;
+  }
+
+  .checkout-sheet-label {
+    display: block;
+    margin-bottom: 6px;
+    font-size: 12px;
+    font-weight: 600;
+    color: #718096;
+  }
+
+  .checkout-sheet-input {
+    height: 44px;
+    width: 100%;
+    border: 1px solid #dbe7f5;
+    border-radius: 14px;
+    background: #f8fbff;
+    padding: 0 14px;
+    font-size: 14px;
+    font-weight: 500;
+    color: #2d3748;
+    outline: none;
+  }
+
+  .checkout-sheet-input:focus {
+    border-color: #90cdf4;
+    background: #fff;
+  }
+
+  .checkout-sheet-input.is-invalid {
+    border-color: #fca5a5;
+    background: #fff5f5;
+  }
+
+  .checkout-sheet-helper {
+    margin-top: 6px;
+    font-size: 12px;
+    line-height: 1.45;
+    color: #718096;
+  }
+
+  .checkout-sheet-helper.is-error {
+    color: #dc2626;
+  }
+
+  .checkout-address-row {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    height: 44px;
+    width: 100%;
+    border: 1px solid #d7dee8;
+    border-radius: 14px;
+    overflow: hidden;
+    background: #eef2f7;
+    padding: 0 12px;
+  }
+
+  .checkout-address-postal {
+    flex: 0 0 5ch;
+    width: 5ch;
+    min-width: 0;
+    border: 0;
+    background: transparent;
+    font-size: 13px;
+    font-weight: 600;
+    color: #4a5568;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    outline: none;
+  }
+
+  .checkout-address-postal::placeholder {
+    color: #718096;
+  }
+
+  .checkout-address-divider {
+    width: 1px;
+    align-self: stretch;
+    background: #d7dee8;
+  }
+
+  .checkout-address-main {
+    min-width: 0;
+    flex: 1 1 auto;
+    border: 0;
+    background: transparent;
+    font-size: 14px;
+    font-weight: 500;
+    color: #2d3748;
+    outline: none;
+  }
+
+  .checkout-address-postal[readonly],
+  .checkout-address-main[readonly] {
+    cursor: not-allowed;
+  }
+
+  .checkout-address-search-cell {
+    display: inline-flex;
+    flex: 0 0 34px;
+    align-self: stretch;
+    align-items: center;
+    justify-content: center;
+    margin: 0 -12px 0 -8px;
+    background: #ffffff;
+  }
+
+  .checkout-address-search-trigger {
+    display: inline-flex;
+    width: 100%;
+    height: 100%;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    color: #3182ce;
+  }
+
+  .checkout-address-main::placeholder,
+  .checkout-sheet-input::placeholder {
+    color: #a0aec0;
+  }
+
+  .checkout-payment-option {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    border: 1px solid #dbe7f5;
+    border-radius: 16px;
+    background: #fff;
+    padding: 14px 16px;
+    text-align: left;
+    transition: border-color 160ms ease, background-color 160ms ease;
+  }
+
+  .checkout-payment-option + .checkout-payment-option {
+    margin-top: 10px;
+  }
+
+  .checkout-payment-option.is-active {
+    border-color: #90cdf4;
+    background: #f8fbff;
+  }
+
+  .checkout-payment-option-badge {
+    display: inline-flex;
+    height: 22px;
+    min-width: 22px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1.5px solid #cbd5e0;
+    color: transparent;
+    transition: border-color 160ms ease, background-color 160ms ease, color 160ms ease;
+  }
+
+  .checkout-payment-option.is-active .checkout-payment-option-badge {
+    border-color: #2d3748;
+    background: #2d3748;
+    color: #fff;
+  }
+
+  .checkout-confirm-modal {
+    display: none;
+  }
+
+  .checkout-confirm-modal.is-open {
+    display: flex;
+  }
+
+  .checkout-feedback-toast {
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 10px) scale(0.98);
+    transition: opacity 180ms ease, transform 180ms ease;
+  }
+
+  .checkout-feedback-toast.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0) scale(1);
+  }
+
+  #mileageInput::-webkit-outer-spin-button,
+  #mileageInput::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+  }
+
+  #mileageInput {
+    -moz-appearance: textfield;
+    appearance: textfield;
+  }
+
+  #deliveryMessageInput {
+    resize: none;
+  }
+
+  #deliveryMessageSelect {
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12' fill='none'%3E%3Cpath d='M3 4.5L6 7.5L9 4.5' stroke='%23718096' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'/%3E%3C/svg%3E");
+    background-position: right 14px center;
+    background-repeat: no-repeat;
+    background-size: 12px 12px;
+  }
+
+  #deliveryMessageSelect.hidden-native {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+  }
+
+  #deliveryMessageDropdown {
+    position: relative;
+  }
+
+  #deliveryMessageTrigger {
+    display: flex;
+    height: 44px;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    overflow: hidden;
+    color: #4a5568;
+    font-size: 13px;
+    font-weight: 500;
+  }
+
+  #deliveryMessageTriggerLabel {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  #deliveryMessageOptionPanel {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 20;
+    overflow: hidden;
+    border: 1px solid #dbe7f5;
+    border-radius: 16px;
+    background: #fff;
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.12);
+  }
+
+  #deliveryMessageOptionPanel.hidden {
+    display: none;
+  }
+
+  .delivery-message-option {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    min-height: 44px;
+    padding: 10px 14px;
+    text-align: left;
+    font-size: 13px;
+    font-weight: 500;
+    line-height: 1.45;
+    color: #4a5568;
+    background: #fff;
+  }
+
+  .delivery-message-option + .delivery-message-option {
+    border-top: 1px solid #edf2f7;
+  }
+
+  .delivery-message-option:hover {
+    background: #f8fbff;
+  }
+
+  .delivery-message-option.is-active {
+    color: #2d3748;
+    background: #f8fbff;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+  }
+
+  @media (min-width: 768px) {
+    .checkout-sheet {
+      align-items: center;
+      justify-content: center;
+    }
+
+    .checkout-sheet-panel {
+      border-radius: 24px;
+      box-shadow: 0 24px 60px rgba(15, 23, 42, 0.18);
+      transform: translateY(16px) scale(0.985);
+    }
+
+    .checkout-sheet.is-open .checkout-sheet-panel {
+      transform: translateY(0) scale(1);
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="checkoutHeader">
+      <div id="checkoutHeaderInner">
+        <div></div>
+        <a href="/chat/" id="checkoutHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/" class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/" class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/" class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link is-active {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+    <div id="checkoutViewport">
+      <div class="mb-5 pl-2">
+        <h1 class="text-[24px] font-bold leading-[1.25] text-[#2d3748]">주문 정보</h1>
+        <div class="mt-3 h-px w-full bg-[#e8eef6]"></div>
+      </div>
+
+      <div class="grid gap-6">
+        <section class="rounded-[24px] border border-[#dbe7f5] bg-white p-5 shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-[14px] font-semibold text-[#90a4b8]">주문 예정 상품</p>
+              <p class="mt-2 text-[24px] font-bold text-[#2d3748]">총 {{ item_count }}개 상품</p>
+            </div>
+            <a href="/products/" class="inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white px-4 text-[12px] font-semibold text-[#4a5568]">장바구니 수정</a>
+          </div>
+          <div class="mt-5 space-y-4">
+            {% for item in cart_items %}
+            <article class="flex items-start gap-3 {% if not forloop.last %}border-b border-[#e2e8f0] pb-4{% endif %} md:items-center">
+              <div class="h-[60px] w-[60px] shrink-0 overflow-hidden rounded-[16px] bg-[#f8fbff]">
+                {% if item.thumbnail_url %}
+                <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+                {% else %}
+                <div class="flex h-full w-full items-center justify-center text-[18px] font-bold text-[#90a4b8]">?</div>
+                {% endif %}
+              </div>
+              <div class="min-w-0 flex-1">
+                <p class="text-[15px] font-bold leading-[1.45] text-[#2d3748] line-clamp-2">{{ item.name }}</p>
+                <p class="mt-1 text-[12px] text-[#718096]">{{ item.quantity }}개 · 개당 {{ item.price_label }}</p>
+                <div class="mt-2 text-left md:hidden">
+                  <p class="text-[16px] font-bold text-[#2d3748]">{{ item.line_total_label }}</p>
+                </div>
+              </div>
+              <div class="hidden shrink-0 text-right md:block">
+                <p class="text-[16px] font-bold text-[#2d3748]">{{ item.line_total_label }}</p>
+              </div>
+            </article>
+            {% endfor %}
+          </div>
+        </section>
+
+        <section id="orderSummaryPanel"
+                 data-recipient-name="{{ recipient_name }}"
+                 data-recipient-phone="{{ recipient_phone }}"
+                 data-postal-code="{{ delivery_postal_code|default:'' }}"
+                 data-delivery-address-main="{{ delivery_base_address }}"
+                 data-delivery-address-detail="{{ delivery_detail_address }}"
+                 data-delivery-address="{{ delivery_base_address }} | {{ delivery_detail_address }}"
+                 data-payment-method="{{ payment_method }}"
+                 class="rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)]">
+          <div class="grid gap-3 md:grid-cols-2">
+            <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0 flex-1">
+                  <p class="text-[13px] font-semibold text-[#2563eb]">배송 정보</p>
+                  <p id="checkoutRecipientName" class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
+                  <p id="checkoutDeliveryBaseAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
+                  <p id="checkoutDeliveryDetailAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
+                  <p id="checkoutRecipientPhone" class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
+                </div>
+                <button type="button" id="openDeliverySheetBtn" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</button>
+              </div>
+            </div>
+            <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+              <div class="flex items-start justify-between gap-4">
+                <div class="min-w-0 flex-1">
+                  <p class="text-[13px] font-semibold text-[#2563eb]">결제 수단</p>
+                  <p id="checkoutPaymentMethod" class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
+                </div>
+                <button type="button" id="openPaymentSheetBtn" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+            <p class="text-[13px] font-semibold text-[#2563eb]">배송 메시지</p>
+            <div id="deliveryMessageDropdown" class="mt-3 rounded-[16px] border border-[#dbe7f5] bg-[#f8fbff] px-4">
+              <button type="button" id="deliveryMessageTrigger" aria-haspopup="listbox" aria-expanded="false">
+                <span id="deliveryMessageTriggerLabel">직접 입력</span>
+                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true" class="shrink-0 text-[#718096]">
+                  <path d="M3 4.5L6 7.5L9 4.5" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+              </button>
+              <div id="deliveryMessageOptionPanel" class="hidden" role="listbox">
+                <button type="button" class="delivery-message-option" data-delivery-option="직접 입력">직접 입력</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="문 앞에 놓아주세요">문 앞에 놓아주세요</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="배송 전에 미리 연락해 주세요">배송 전에 미리 연락해 주세요</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="부재 시 경비실에 맡겨 주세요">부재 시 경비실에 맡겨 주세요</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="부재 시 전화 또는 문자 남겨 주세요">부재 시 전화 또는 문자 남겨 주세요</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="배송 시 벨은 누르지 말아 주세요">배송 시 벨은 누르지 말아 주세요</button>
+                <button type="button" class="delivery-message-option" data-delivery-option="도착 후 문 앞 사진을 남겨 주세요">도착 후 문 앞 사진을 남겨 주세요</button>
+              </div>
+              <select id="deliveryMessageSelect" data-initial-message="{{ delivery_message }}" class="hidden-native h-[44px] w-full bg-transparent pr-8 text-[13px] font-medium text-[#4a5568] outline-none">
+                <option value="직접 입력">직접 입력</option>
+                <option value="문 앞에 놓아주세요">문 앞에 놓아주세요</option>
+                <option value="배송 전에 미리 연락해 주세요">배송 전에 미리 연락해 주세요</option>
+                <option value="부재 시 경비실에 맡겨 주세요">부재 시 경비실에 맡겨 주세요</option>
+                <option value="부재 시 전화 또는 문자 남겨 주세요">부재 시 전화 또는 문자 남겨 주세요</option>
+                <option value="배송 시 벨은 누르지 말아 주세요">배송 시 벨은 누르지 말아 주세요</option>
+                <option value="도착 후 문 앞 사진을 남겨 주세요">도착 후 문 앞 사진을 남겨 주세요</option>
+              </select>
+            </div>
+            <input id="deliveryMessageInput" type="text" maxlength="100" value="{{ delivery_message }}" placeholder="직접 입력"
+                   class="checkout-sheet-input mt-2 hidden !text-[13px] !font-medium">
+          </div>
+
+          <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
+            <div class="flex items-start justify-between gap-4">
+              <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
+              <button type="button" id="openDiscountModalBtn" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
+            </div>
+            <div class="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
+              <div class="min-w-0">
+                <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
+                <p id="couponSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
+              </div>
+              <div class="min-w-0 md:pl-4">
+                <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
+                <p id="mileageSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
+              </div>
+            </div>
+          </div>
+
+          <div class="mt-5 rounded-[18px] bg-[#f8fbff] px-4 py-4">
+            <p class="text-[13px] font-semibold text-[#2563eb]">결제 금액</p>
+            <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+              <div class="flex items-center justify-between">
+                <span>상품 금액</span>
+                <span class="font-semibold text-[#2d3748]" id="productTotalAmount">{{ product_total }}</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span>할인 적용</span>
+                <span class="font-semibold text-[#2563eb]" id="discountTotalAmount">- {{ discount_total }}</span>
+              </div>
+              <div class="flex items-center justify-between">
+                <span>배송비</span>
+                <span class="font-semibold text-[#2d3748]" id="shippingFeeAmount">{{ shipping_fee }}</span>
+              </div>
+            </div>
+            <div class="mt-4 border-t border-[#dbe7f5] pt-4">
+              <div class="flex items-center justify-between">
+                <span class="text-[14px] font-semibold text-[#4a5568]">최종 결제 금액</span>
+                <span class="text-[24px] font-bold text-[#2563eb]" id="finalTotalAmount">{{ final_total }}</span>
+              </div>
+            </div>
+          </div>
+
+          <button type="button" id="submitOrderBtn" class="mt-6 inline-flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[15px] font-bold text-white shadow-[0_10px_24px_rgba(45,55,72,0.18)]">주문하기</button>
+        </section>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div id="checkoutFeedbackToast" class="checkout-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">오류가 발생했습니다.</div>
+
+<div id="deliveryInfoSheet" class="checkout-sheet fixed inset-0 z-[65] items-end bg-[rgba(15,23,42,0.38)] px-0 md:px-4" onclick="closeDeliverySheet(event)">
+  <div class="checkout-sheet-panel px-5 pb-6 pt-5 md:px-6 md:pb-6 md:pt-6" onclick="event.stopPropagation()">
+    <div class="mx-auto mb-4 h-1.5 w-12 rounded-full bg-[#e2e8f0] md:hidden"></div>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-[22px] font-bold text-[#2d3748]">배송 정보 수정</p>
+      </div>
+      <button type="button" class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]" onclick="closeDeliverySheet()" aria-label="배송 정보 시트 닫기">X</button>
+    </div>
+    <div class="mt-5">
+      <label class="checkout-sheet-field">
+        <span class="checkout-sheet-label">수령인</span>
+        <input id="deliverySheetRecipientInput" type="text" class="checkout-sheet-input">
+      </label>
+      <label class="checkout-sheet-field">
+        <span class="checkout-sheet-label">연락처</span>
+        <input id="deliverySheetPhoneInput" type="text" class="checkout-sheet-input">
+      </label>
+      <label class="checkout-sheet-field">
+        <span class="checkout-sheet-label">주소</span>
+        <div class="checkout-address-row">
+          <input id="deliverySheetPostalCodeInput" type="text" class="checkout-address-postal" placeholder="우편" readonly>
+          <span class="checkout-address-divider" aria-hidden="true"></span>
+          <input id="deliverySheetBaseAddressInput" type="text" class="checkout-address-main" placeholder="기본 주소" readonly>
+          <span class="checkout-address-divider" aria-hidden="true"></span>
+          <span class="checkout-address-search-cell" aria-hidden="true">
+            <span class="checkout-address-search-trigger">
+              <svg viewBox="0 0 24 24" class="h-[16px] w-[16px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+                <circle cx="11" cy="11" r="6"></circle>
+                <path d="M20 20l-3.5-3.5"></path>
+              </svg>
+            </span>
+          </span>
+        </div>
+        <input id="deliverySheetDetailAddressInput" type="text" class="checkout-sheet-input mt-2" placeholder="상세 주소">
+      </label>
+    </div>
+    <div class="mt-6 flex gap-3">
+      <button type="button" class="flex h-[46px] flex-1 items-center justify-center rounded-[14px] bg-[#edf2f7] text-[14px] font-semibold text-[#4a5568]" onclick="closeDeliverySheet()">취소</button>
+      <button type="button" id="saveDeliverySheetBtn" class="flex h-[46px] flex-1 items-center justify-center rounded-[14px] bg-[#2d3748] text-[14px] font-semibold text-white">적용하기</button>
+    </div>
+  </div>
+</div>
+
+<div id="paymentMethodSheet" class="checkout-sheet fixed inset-0 z-[65] items-end bg-[rgba(15,23,42,0.38)] px-0 md:px-4" onclick="closePaymentSheet(event)">
+  <div class="checkout-sheet-panel px-5 pb-6 pt-5 md:px-6 md:pb-6 md:pt-6" onclick="event.stopPropagation()">
+    <div class="mx-auto mb-4 h-1.5 w-12 rounded-full bg-[#e2e8f0] md:hidden"></div>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-[22px] font-bold text-[#2d3748]">결제 수단 수정</p>
+        <p class="mt-1 text-[13px] text-[#718096]">주문에 사용할 결제 수단을 선택해 주세요</p>
+      </div>
+      <button type="button" class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]" onclick="closePaymentSheet()" aria-label="결제 수단 시트 닫기">X</button>
+    </div>
+    <div class="mt-5">
+      <button type="button" class="checkout-payment-option" data-payment-option="간편 결제">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">간편 결제</p>
+          <p class="mt-1 text-[12px] text-[#718096]">등록된 간편 결제로 바로 결제</p>
+        </div>
+        <span class="checkout-payment-option-badge">✓</span>
+      </button>
+      <button type="button" class="checkout-payment-option" data-payment-option="신용/체크카드">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">신용/체크카드</p>
+          <p class="mt-1 text-[12px] text-[#718096]">기본 등록 카드로 결제</p>
+        </div>
+        <span class="checkout-payment-option-badge">✓</span>
+      </button>
+      <button type="button" class="checkout-payment-option" data-payment-option="무통장 입금">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">무통장 입금</p>
+          <p class="mt-1 text-[12px] text-[#718096]">입금 확인 후 주문이 접수됩니다</p>
+        </div>
+        <span class="checkout-payment-option-badge">✓</span>
+      </button>
+    </div>
+    <div class="mt-6 flex gap-3">
+      <button type="button" class="flex h-[46px] flex-1 items-center justify-center rounded-[14px] bg-[#edf2f7] text-[14px] font-semibold text-[#4a5568]" onclick="closePaymentSheet()">취소</button>
+      <button type="button" id="savePaymentSheetBtn" class="flex h-[46px] flex-1 items-center justify-center rounded-[14px] bg-[#2d3748] text-[14px] font-semibold text-white">적용하기</button>
+    </div>
+  </div>
+</div>
+
+<div id="checkoutConfirmModal" class="checkout-confirm-modal fixed inset-0 z-[60] items-center justify-center bg-black/10 px-4" onclick="closeCheckoutConfirmModal(event)">
+  <div class="w-full max-w-[420px] rounded-[20px] border border-[#dbe7f5] bg-white px-8 pb-7 pt-8 shadow-[0_14px_36px_rgba(45,55,72,0.10)]" onclick="event.stopPropagation()">
+    <div class="mx-auto flex h-[81px] w-[81px] items-center justify-center rounded-full border-[4px] border-[#3182ce]">
+      <span class="relative top-[-1px] text-[44px] font-bold leading-none text-[#3182ce]">?</span>
+    </div>
+    <p class="mt-6 text-center text-[19px] font-bold leading-none text-[#2d3748]">주문을 진행할까요?</p>
+    <p class="mt-4 text-center text-[14px] leading-[1.6] text-[#718096]">배송 정보와 결제 금액을 확인한 뒤<br>주문이 접수됩니다.</p>
+    <div class="mt-6 rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-3">
+      <div class="flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">최종 결제 금액</span>
+        <span id="checkoutConfirmAmount" class="font-bold text-[#2563eb]">0원</span>
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">수령인</span>
+        <span id="checkoutConfirmRecipient" class="text-right font-semibold text-[#2d3748]"></span>
+      </div>
+      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
+        <span class="font-semibold text-[#90a4b8]">연락처</span>
+        <span id="checkoutConfirmPhone" class="text-right font-semibold text-[#2d3748]"></span>
+      </div>
+      <div class="mt-2 flex items-start justify-between gap-3 text-[13px]">
+        <span class="shrink-0 font-semibold text-[#90a4b8]">배송지</span>
+        <span id="checkoutConfirmAddress" class="text-right font-semibold leading-[1.6] text-[#2d3748]"></span>
+      </div>
+    </div>
+    <div class="mt-6 flex h-[42px] items-center justify-between gap-3">
+      <button type="button" onclick="closeCheckoutConfirmModal()" class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">취소</button>
+      <button type="button" id="confirmCheckoutSubmitBtn" class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#3182ce] text-[14px] font-bold text-white">주문하기</button>
+    </div>
+  </div>
+</div>
+
+<div id="discountBenefitModal" class="discount-modal fixed inset-0 z-[65] items-end bg-[rgba(15,23,42,0.38)] px-0 md:px-4" onclick="closeDiscountModal(event)">
+  <div class="discount-sheet-panel px-5 pb-6 pt-5 md:px-6 md:pb-6 md:pt-6" onclick="event.stopPropagation()">
+    <div class="mx-auto mb-4 h-1.5 w-12 rounded-full bg-[#e2e8f0] md:hidden"></div>
+    <div class="flex items-start justify-between gap-4">
+      <div>
+        <p class="text-[22px] font-bold text-[#2d3748]">할인 혜택 적용</p>
+        <p class="mt-1 text-[13px] text-[#718096]">쿠폰과 마일리지를 선택하면 주문 정보에 바로 반영됩니다.</p>
+      </div>
+      <button type="button" class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]" onclick="closeDiscountModal()" aria-label="할인 혜택 모달 닫기">X</button>
+    </div>
+    <div class="mt-5 inline-flex rounded-full border border-[#dbe7f5] bg-[#f8fbff] p-[4px]">
+      <button type="button" id="discountTabCoupon" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">쿠폰</button>
+      <button type="button" id="discountTabMileage" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">마일리지</button>
+    </div>
+    <div id="discountPanelCoupon" class="mt-5 space-y-3">
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="none" data-coupon-label="적용된 쿠폰 없음" data-coupon-discount="0">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">쿠폰 적용 안 함</p>
+          <p class="mt-1 text-[12px] text-[#718096]">할인을 적용하지 않고 현재 금액으로 주문합니다.</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#718096]">0원</span>
+      </button>
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="new-member" data-coupon-label="신규회원 3,000원 할인" data-coupon-discount="3000">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">신규회원 3,000원 할인</p>
+          <p class="mt-1 text-[12px] text-[#718096]">30,000원 이상 결제 시 사용 가능</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#2563eb]">-3,000원</span>
+      </button>
+      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="pet-care" data-coupon-label="펫케어 5,000원 할인" data-coupon-discount="5000">
+        <div>
+          <p class="text-[14px] font-semibold text-[#2d3748]">펫케어 5,000원 할인</p>
+          <p class="mt-1 text-[12px] text-[#718096]">60,000원 이상 결제 시 사용 가능</p>
+        </div>
+        <span class="text-[13px] font-semibold text-[#2563eb]">-5,000원</span>
+      </button>
+    </div>
+    <div id="discountPanelMileage" class="mt-5 hidden">
+      <div class="rounded-[18px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-4">
+        <div class="flex items-center justify-between gap-4">
+          <div>
+            <p class="text-[14px] font-semibold text-[#2d3748]">사용 가능한 마일리지</p>
+            <p class="mt-1 text-[12px] text-[#718096]">보유 마일리지 3,200원</p>
+          </div>
+          <button type="button" id="useAllMileageBtn" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">전액 사용</button>
+        </div>
+        <label class="mt-4 block">
+          <span class="text-[12px] font-semibold text-[#2d3748]">사용할 마일리지</span>
+          <div class="mt-2 flex items-center rounded-[14px] border border-[#dbe7f5] bg-white px-4">
+            <input id="mileageInput" type="number" min="0" max="3200" step="100" value="0" class="h-[48px] w-full bg-transparent text-[15px] font-semibold text-[#2d3748] outline-none">
+            <span class="shrink-0 text-[13px] font-semibold text-[#718096]">원</span>
+          </div>
+        </label>
+      </div>
+    </div>
+    <div class="mt-6 flex items-center justify-between gap-4 rounded-[18px] bg-[#f8fbff] px-4 py-4">
+      <div>
+        <p class="text-[12px] font-semibold text-[#718096]">예상 할인 금액</p>
+        <p id="discountModalPreviewAmount" class="mt-1 text-[22px] font-bold text-[#2563eb]">- 0원</p>
+      </div>
+      <button type="button" id="applyDiscountBtn" class="inline-flex h-[46px] items-center justify-center rounded-[14px] bg-[#2d3748] px-5 text-[14px] font-semibold text-white">적용하기</button>
+    </div>
+  </div>
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var orderSummaryPanel = document.getElementById('orderSummaryPanel');
+  var checkoutFeedbackToast = document.getElementById('checkoutFeedbackToast');
+  var openDeliverySheetBtn = document.getElementById('openDeliverySheetBtn');
+  var openPaymentSheetBtn = document.getElementById('openPaymentSheetBtn');
+  var deliveryInfoSheet = document.getElementById('deliveryInfoSheet');
+  var paymentMethodSheet = document.getElementById('paymentMethodSheet');
+  var deliverySheetRecipientInput = document.getElementById('deliverySheetRecipientInput');
+  var deliverySheetPhoneInput = document.getElementById('deliverySheetPhoneInput');
+  var deliverySheetPostalCodeInput = document.getElementById('deliverySheetPostalCodeInput');
+  var deliverySheetBaseAddressInput = document.getElementById('deliverySheetBaseAddressInput');
+  var deliverySheetDetailAddressInput = document.getElementById('deliverySheetDetailAddressInput');
+  var saveDeliverySheetBtn = document.getElementById('saveDeliverySheetBtn');
+  var paymentOptions = Array.prototype.slice.call(document.querySelectorAll('.checkout-payment-option'));
+  var savePaymentSheetBtn = document.getElementById('savePaymentSheetBtn');
+  var checkoutRecipientName = document.getElementById('checkoutRecipientName');
+  var checkoutDeliveryBaseAddress = document.getElementById('checkoutDeliveryBaseAddress');
+  var checkoutDeliveryDetailAddress = document.getElementById('checkoutDeliveryDetailAddress');
+  var checkoutRecipientPhone = document.getElementById('checkoutRecipientPhone');
+  var checkoutPaymentMethod = document.getElementById('checkoutPaymentMethod');
+  var deliveryMessageSelect = document.getElementById('deliveryMessageSelect');
+  var deliveryMessageDropdown = document.getElementById('deliveryMessageDropdown');
+  var deliveryMessageTrigger = document.getElementById('deliveryMessageTrigger');
+  var deliveryMessageTriggerLabel = document.getElementById('deliveryMessageTriggerLabel');
+  var deliveryMessageOptionPanel = document.getElementById('deliveryMessageOptionPanel');
+  var deliveryMessageOptions = Array.prototype.slice.call(document.querySelectorAll('.delivery-message-option'));
+  var deliveryMessageCustomField = document.getElementById('deliveryMessageCustomField');
+  var deliveryMessageInput = document.getElementById('deliveryMessageInput');
+  var submitOrderBtn = document.getElementById('submitOrderBtn');
+  var checkoutConfirmModal = document.getElementById('checkoutConfirmModal');
+  var checkoutConfirmAmount = document.getElementById('checkoutConfirmAmount');
+  var checkoutConfirmRecipient = document.getElementById('checkoutConfirmRecipient');
+  var checkoutConfirmPhone = document.getElementById('checkoutConfirmPhone');
+  var checkoutConfirmAddress = document.getElementById('checkoutConfirmAddress');
+  var confirmCheckoutSubmitBtn = document.getElementById('confirmCheckoutSubmitBtn');
+  var couponSummaryText = document.getElementById('couponSummaryText');
+  var mileageSummaryText = document.getElementById('mileageSummaryText');
+  var discountModal = document.getElementById('discountBenefitModal');
+  var openDiscountModalBtn = document.getElementById('openDiscountModalBtn');
+  var discountTabCoupon = document.getElementById('discountTabCoupon');
+  var discountTabMileage = document.getElementById('discountTabMileage');
+  var discountPanelCoupon = document.getElementById('discountPanelCoupon');
+  var discountPanelMileage = document.getElementById('discountPanelMileage');
+  var couponOptions = Array.prototype.slice.call(document.querySelectorAll('.discount-coupon-option'));
+  var mileageInput = document.getElementById('mileageInput');
+  var useAllMileageBtn = document.getElementById('useAllMileageBtn');
+  var applyDiscountBtn = document.getElementById('applyDiscountBtn');
+  var discountModalPreviewAmount = document.getElementById('discountModalPreviewAmount');
+  var productTotalRaw = {{ product_total_raw }};
+  var shippingFeeRaw = {{ shipping_fee_raw }};
+  var selectedCouponId = 'none';
+  var selectedCouponLabel = '{{ coupon_summary|escapejs }}';
+  var selectedCouponDiscount = {{ discount_total_raw }};
+  var selectedMileageValue = 0;
+  var discountMode = 'coupon';
+  var selectedPaymentMethod = '';
+  var initialCardPaymentSummary = '';
+  var toastTimer = null;
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
+
+  function formatPrice(value) {
+    return new Intl.NumberFormat('ko-KR').format(value) + '원';
+  }
+
+  function getCsrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function requestJson(url, options) {
+    return fetch(url, Object.assign({
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRFToken': getCsrfToken(),
+      },
+      credentials: 'same-origin',
+    }, options || {})).then(function (response) {
+      return response.json().catch(function () { return {}; }).then(function (data) {
+        if (!response.ok) {
+          throw new Error(data.detail || data.message || '요청 처리에 실패했습니다.');
+        }
+        return data;
+      });
+    });
+  }
+
+  function showCheckoutToast(message) {
+    if (!checkoutFeedbackToast) return;
+    checkoutFeedbackToast.textContent = message || '요청 처리에 실패했습니다.';
+    checkoutFeedbackToast.classList.add('is-open');
+    if (toastTimer) {
+      window.clearTimeout(toastTimer);
+    }
+    toastTimer = window.setTimeout(function () {
+      checkoutFeedbackToast.classList.remove('is-open');
+    }, 1800);
+  }
+
+  function splitAddressParts(value) {
+    var parts = String(value || '').split('|');
+    return {
+      base: (parts[0] || '').trim(),
+      detail: (parts[1] || '').trim(),
+    };
+  }
+
+  function normalizeDeliveryFieldValue(value) {
+    var normalized = String(value || '').trim();
+    if (
+      !normalized ||
+      normalized === '배송지 정보가 아직 등록되지 않았어요' ||
+      normalized === '기본 배송지가 아직 등록되지 않았습니다' ||
+      normalized === '상세 주소 정보가 아직 없습니다'
+    ) {
+      return '';
+    }
+    return normalized;
+  }
+
+  function formatPhoneNumber(value) {
+    var digits = String(value || '').replace(/\D/g, '').slice(0, 11);
+    if (digits.length <= 3) return digits;
+    if (digits.length <= 7) return digits.slice(0, 3) + '-' + digits.slice(3);
+    return digits.slice(0, 3) + '-' + digits.slice(3, 7) + '-' + digits.slice(7);
+  }
+
+  function extractPhoneDigits(value) {
+    return String(value || '').replace(/\D/g, '').slice(0, 11);
+  }
+
+  function validatePhoneNumber(value) {
+    return /^01\d-\d{3,4}-\d{4}$/.test(String(value || '').trim());
+  }
+
+  function syncDeliveryPhoneState() {
+    if (!deliverySheetPhoneInput) return true;
+    var formattedValue = formatPhoneNumber(deliverySheetPhoneInput.value);
+    var isValid = !formattedValue || validatePhoneNumber(formattedValue);
+    deliverySheetPhoneInput.classList.toggle('is-invalid', !isValid);
+    return isValid;
+  }
+
+  function syncSummaryFields() {
+    if (!orderSummaryPanel) return;
+    if (checkoutRecipientName) checkoutRecipientName.textContent = (orderSummaryPanel.dataset.recipientName || '').trim() || '수령인 정보가 아직 없습니다';
+    if (checkoutDeliveryBaseAddress) checkoutDeliveryBaseAddress.textContent = (orderSummaryPanel.dataset.deliveryAddressMain || '').trim() || '기본 배송지가 아직 등록되지 않았습니다';
+    if (checkoutDeliveryDetailAddress) checkoutDeliveryDetailAddress.textContent = (orderSummaryPanel.dataset.deliveryAddressDetail || '').trim() || '상세 주소 정보가 아직 없습니다';
+    if (checkoutRecipientPhone) checkoutRecipientPhone.textContent = (orderSummaryPanel.dataset.recipientPhone || '').trim() || '연락처 정보가 아직 없습니다';
+    if (checkoutPaymentMethod) checkoutPaymentMethod.textContent = (orderSummaryPanel.dataset.paymentMethod || '').trim() || '결제 수단 정보가 아직 없습니다';
+  }
+
+  function validateCheckoutState() {
+    if (!orderSummaryPanel) {
+      return { valid: false, message: '주문 정보를 확인하지 못했습니다.' };
+    }
+    var recipientName = (orderSummaryPanel.dataset.recipientName || '').trim();
+    var recipientPhone = (orderSummaryPanel.dataset.recipientPhone || '').trim();
+    var addressParts = splitAddressParts(orderSummaryPanel.dataset.deliveryAddress || '');
+    var paymentMethod = (orderSummaryPanel.dataset.paymentMethod || '').trim();
+
+    if (!recipientName || recipientName === '주문자 정보 미등록') {
+      return { valid: false, message: '수령인 정보를 먼저 확인해 주세요.' };
+    }
+    if (!recipientPhone || recipientPhone.indexOf('없습니다') !== -1) {
+      return { valid: false, message: '연락처 정보를 먼저 확인해 주세요.' };
+    }
+    if (!addressParts.base || addressParts.base.indexOf('없습니다') !== -1) {
+      return { valid: false, message: '배송지 정보를 먼저 등록해 주세요.' };
+    }
+    if (!paymentMethod || paymentMethod.indexOf('없습니다') !== -1) {
+      return { valid: false, message: '결제 수단 정보를 먼저 등록해 주세요.' };
+    }
+    return { valid: true, message: '' };
+  }
+
+  function syncCheckoutNotice() {
+    return;
+  }
+
+  function updateDiscountSummaryTexts() {
+    if (couponSummaryText) {
+      couponSummaryText.textContent = selectedCouponLabel || '적용된 쿠폰 없음';
+    }
+    if (mileageSummaryText) {
+      mileageSummaryText.textContent = selectedMileageValue > 0 ? '사용 ' + formatPrice(selectedMileageValue) : '사용 가능 3,200원';
+    }
+  }
+
+  function updateDiscountPreview() {
+    if (!discountModalPreviewAmount) return;
+    discountModalPreviewAmount.textContent = '- ' + formatPrice(selectedCouponDiscount + selectedMileageValue);
+  }
+
+  function updateCheckoutSummary() {
+    var shippingFee = productTotalRaw > 0 && productTotalRaw < 30000 ? shippingFeeRaw : 0;
+    var discountTotal = selectedCouponDiscount + selectedMileageValue;
+    var finalTotal = Math.max(productTotalRaw - discountTotal, 0) + shippingFee;
+    var discountNode = document.getElementById('discountTotalAmount');
+    var shippingNode = document.getElementById('shippingFeeAmount');
+    var finalNode = document.getElementById('finalTotalAmount');
+
+    if (discountNode) discountNode.textContent = '- ' + formatPrice(discountTotal);
+    if (shippingNode) shippingNode.textContent = shippingFee === 0 ? '무료' : formatPrice(shippingFee);
+    if (finalNode) finalNode.textContent = formatPrice(finalTotal);
+  }
+
+  function syncDeliveryMessageField() {
+    if (!deliveryMessageSelect || !deliveryMessageInput) return;
+    var isCustom = deliveryMessageSelect.value === '직접 입력';
+    deliveryMessageInput.classList.toggle('hidden', !isCustom);
+    if (deliveryMessageTriggerLabel) {
+      deliveryMessageTriggerLabel.textContent = deliveryMessageSelect.value || '직접 입력';
+    }
+    deliveryMessageOptions.forEach(function (option) {
+      var isActive = option.getAttribute('data-delivery-option') === deliveryMessageSelect.value;
+      option.classList.toggle('is-active', isActive);
+    });
+    if (isCustom) {
+      deliveryMessageInput.value = '';
+    } else {
+      deliveryMessageInput.value = deliveryMessageSelect.value;
+    }
+  }
+
+  function initDeliveryMessageField() {
+    if (!deliveryMessageSelect || !deliveryMessageInput) return;
+    var initialMessage = (deliveryMessageSelect.dataset.initialMessage || '').trim();
+    if (!initialMessage) {
+      deliveryMessageSelect.value = '직접 입력';
+      deliveryMessageInput.value = '';
+      syncDeliveryMessageField();
+      return;
+    }
+
+    var hasPreset = Array.prototype.some.call(deliveryMessageSelect.options, function (option) {
+      return option.value === initialMessage;
+    });
+
+    if (hasPreset && initialMessage !== '직접 입력') {
+      deliveryMessageSelect.value = initialMessage;
+    } else {
+      deliveryMessageSelect.value = '직접 입력';
+      deliveryMessageInput.value = initialMessage;
+    }
+    syncDeliveryMessageField();
+  }
+
+  function syncPaymentOptions() {
+    paymentOptions.forEach(function (option) {
+      var isActive = option.getAttribute('data-payment-option') === selectedPaymentMethod;
+      option.classList.toggle('is-active', isActive);
+    });
+  }
+
+  function resolvePaymentOptionFromSummary(summary) {
+    var normalized = String(summary || '').trim();
+    if (!normalized) return '';
+    if (normalized === '간편 결제') return '간편 결제';
+    if (normalized === '무통장 입금') return '무통장 입금';
+    return '신용/체크카드';
+  }
+
+  window.closeDeliverySheet = function (event) {
+    if (!deliveryInfoSheet) return;
+    if (event && event.target !== deliveryInfoSheet) return;
+    deliveryInfoSheet.classList.remove('is-open');
+  };
+
+  window.openDeliverySheet = function () {
+    if (!orderSummaryPanel || !deliveryInfoSheet) return;
+    if (deliverySheetRecipientInput) deliverySheetRecipientInput.value = normalizeDeliveryFieldValue(orderSummaryPanel.dataset.recipientName || '');
+    if (deliverySheetPhoneInput) deliverySheetPhoneInput.value = normalizeDeliveryFieldValue(orderSummaryPanel.dataset.recipientPhone || '');
+    if (deliverySheetPostalCodeInput) deliverySheetPostalCodeInput.value = normalizeDeliveryFieldValue(orderSummaryPanel.dataset.postalCode || '');
+    if (deliverySheetBaseAddressInput) deliverySheetBaseAddressInput.value = normalizeDeliveryFieldValue(orderSummaryPanel.dataset.deliveryAddressMain || '');
+    if (deliverySheetDetailAddressInput) deliverySheetDetailAddressInput.value = normalizeDeliveryFieldValue(orderSummaryPanel.dataset.deliveryAddressDetail || '');
+    deliveryInfoSheet.classList.add('is-open');
+  };
+
+  window.closePaymentSheet = function (event) {
+    if (!paymentMethodSheet) return;
+    if (event && event.target !== paymentMethodSheet) return;
+    paymentMethodSheet.classList.remove('is-open');
+  };
+
+  window.openPaymentSheet = function () {
+    if (!orderSummaryPanel || !paymentMethodSheet) return;
+    if (!initialCardPaymentSummary) {
+      var existingPaymentSummary = (orderSummaryPanel.dataset.paymentMethod || '').trim();
+      if (existingPaymentSummary && existingPaymentSummary !== '간편 결제' && existingPaymentSummary !== '무통장 입금') {
+        initialCardPaymentSummary = existingPaymentSummary;
+      }
+    }
+    selectedPaymentMethod = resolvePaymentOptionFromSummary(orderSummaryPanel.dataset.paymentMethod || '');
+    syncPaymentOptions();
+    paymentMethodSheet.classList.add('is-open');
+  };
+
+  function closeDeliveryMessageDropdown() {
+    if (!deliveryMessageOptionPanel || !deliveryMessageTrigger) return;
+    deliveryMessageOptionPanel.classList.add('hidden');
+    deliveryMessageTrigger.setAttribute('aria-expanded', 'false');
+  }
+
+  function openDeliveryMessageDropdown() {
+    if (!deliveryMessageOptionPanel || !deliveryMessageTrigger) return;
+    deliveryMessageOptionPanel.classList.remove('hidden');
+    deliveryMessageTrigger.setAttribute('aria-expanded', 'true');
+  }
+
+  function getDeliveryMessageValue() {
+    if (!deliveryMessageSelect) return '';
+    if (deliveryMessageSelect.value === '직접 입력') {
+      return deliveryMessageInput ? (deliveryMessageInput.value || '').trim() : '';
+    }
+    return deliveryMessageSelect.value;
+  }
+
+  function setDiscountTab(mode) {
+    discountMode = mode;
+    var couponActive = mode === 'coupon';
+    if (discountPanelCoupon) discountPanelCoupon.classList.toggle('hidden', !couponActive);
+    if (discountPanelMileage) discountPanelMileage.classList.toggle('hidden', couponActive);
+    if (discountTabCoupon) {
+      discountTabCoupon.classList.toggle('bg-[#2d3748]', couponActive);
+      discountTabCoupon.classList.toggle('text-white', couponActive);
+      discountTabCoupon.classList.toggle('text-[#718096]', !couponActive);
+    }
+    if (discountTabMileage) {
+      discountTabMileage.classList.toggle('bg-[#2d3748]', !couponActive);
+      discountTabMileage.classList.toggle('text-white', !couponActive);
+      discountTabMileage.classList.toggle('text-[#718096]', couponActive);
+    }
+  }
+
+  function highlightSelectedCoupon() {
+    couponOptions.forEach(function (option) {
+      var isSelected = option.getAttribute('data-coupon-id') === selectedCouponId;
+      option.classList.toggle('border-[#90cdf4]', isSelected);
+      option.classList.toggle('bg-[#f8fbff]', isSelected);
+    });
+  }
+
+  window.closeDiscountModal = function (event) {
+    if (!discountModal) return;
+    if (event && event.target !== discountModal) return;
+    discountModal.classList.remove('is-open');
+  };
+
+  window.openDiscountModal = function () {
+    if (!discountModal) return;
+    if (mileageInput) mileageInput.value = String(selectedMileageValue);
+    highlightSelectedCoupon();
+    updateDiscountPreview();
+    setDiscountTab('coupon');
+    discountModal.classList.add('is-open');
+  };
+
+  function updateConfirmSummary() {
+    if (checkoutConfirmAmount) {
+      var finalTotalNode = document.getElementById('finalTotalAmount');
+      checkoutConfirmAmount.textContent = finalTotalNode ? finalTotalNode.textContent : '0원';
+    }
+    if (checkoutConfirmRecipient) {
+      checkoutConfirmRecipient.textContent = orderSummaryPanel ? ((orderSummaryPanel.dataset.recipientName || '').trim() || '수령인 정보가 아직 없습니다') : '';
+    }
+    if (checkoutConfirmPhone) {
+      checkoutConfirmPhone.textContent = orderSummaryPanel ? ((orderSummaryPanel.dataset.recipientPhone || '').trim() || '연락처 정보가 아직 없습니다') : '';
+    }
+    if (checkoutConfirmAddress) {
+      var addressParts = splitAddressParts(orderSummaryPanel ? (orderSummaryPanel.dataset.deliveryAddress || '') : '');
+      checkoutConfirmAddress.textContent = [addressParts.base, addressParts.detail].filter(Boolean).join(', ') || '배송지 정보가 아직 없습니다';
+    }
+  }
+
+  window.closeCheckoutConfirmModal = function (event) {
+    if (!checkoutConfirmModal) return;
+    if (event && event.target !== checkoutConfirmModal) return;
+    checkoutConfirmModal.classList.remove('is-open');
+    if (confirmCheckoutSubmitBtn) {
+      confirmCheckoutSubmitBtn.disabled = false;
+      confirmCheckoutSubmitBtn.textContent = '주문하기';
+    }
+  };
+
+  function setSubmitLoading(isLoading) {
+    if (!submitOrderBtn) return;
+    submitOrderBtn.disabled = isLoading;
+    submitOrderBtn.textContent = isLoading ? '주문 처리 중...' : '주문하기';
+    submitOrderBtn.classList.toggle('opacity-60', isLoading);
+  }
+
+  function setConfirmCheckoutLoading(isLoading) {
+    if (!confirmCheckoutSubmitBtn) return;
+    confirmCheckoutSubmitBtn.disabled = isLoading;
+    confirmCheckoutSubmitBtn.textContent = isLoading ? '주문 처리 중...' : '주문하기';
+  }
+
+  function submitOrderRequest() {
+    if (!orderSummaryPanel) return;
+    if (confirmCheckoutSubmitBtn && confirmCheckoutSubmitBtn.disabled) return;
+    setSubmitLoading(true);
+    setConfirmCheckoutLoading(true);
+    requestJson('/api/orders/', {
+      method: 'POST',
+      body: JSON.stringify({
+        recipient_name: orderSummaryPanel.dataset.recipientName || '',
+        recipient_phone: orderSummaryPanel.dataset.recipientPhone || '',
+        postal_code: orderSummaryPanel.dataset.postalCode || '',
+        delivery_address_main: orderSummaryPanel.dataset.deliveryAddressMain || '',
+        delivery_address_detail: orderSummaryPanel.dataset.deliveryAddressDetail || '',
+        delivery_address: orderSummaryPanel.dataset.deliveryAddress || '',
+        delivery_message: getDeliveryMessageValue(),
+        payment_method: orderSummaryPanel.dataset.paymentMethod || '',
+        coupon_id: selectedCouponId || 'none',
+        mileage_amount: selectedMileageValue || 0,
+      }),
+    }).then(function (data) {
+      var orderId = data && data.order && data.order.order_id;
+      if (!orderId) {
+        throw new Error('주문 완료 정보를 확인하지 못했습니다.');
+      }
+      window.closeCheckoutConfirmModal();
+      window.location.href = '/orders/complete/' + orderId + '/?entry=cart';
+    }).catch(function (error) {
+      showCheckoutToast(error.message || '주문을 완료하지 못했습니다.');
+      setSubmitLoading(false);
+      setConfirmCheckoutLoading(false);
+    });
+  }
+
+  document.addEventListener('click', function (event) {
+    if (!profileMenu || !profileMenuWrapper) return;
+    if (profileMenuWrapper.contains(event.target)) return;
+    profileMenu.classList.remove('is-open');
+  });
+
+  if (openDiscountModalBtn) {
+    openDiscountModalBtn.addEventListener('click', window.openDiscountModal);
+  }
+
+  if (openDeliverySheetBtn) {
+    openDeliverySheetBtn.addEventListener('click', window.openDeliverySheet);
+  }
+
+  if (openPaymentSheetBtn) {
+    openPaymentSheetBtn.addEventListener('click', window.openPaymentSheet);
+  }
+
+  if (saveDeliverySheetBtn) {
+    saveDeliverySheetBtn.addEventListener('click', function () {
+      if (!orderSummaryPanel) return;
+      var recipientName = deliverySheetRecipientInput ? (deliverySheetRecipientInput.value || '').trim() : '';
+      var recipientPhone = deliverySheetPhoneInput ? formatPhoneNumber(deliverySheetPhoneInput.value || '') : '';
+      var postalCode = deliverySheetPostalCodeInput ? (deliverySheetPostalCodeInput.value || '').trim() : '';
+      var baseAddress = deliverySheetBaseAddressInput ? (deliverySheetBaseAddressInput.value || '').trim() : '';
+      var detailAddress = deliverySheetDetailAddressInput ? (deliverySheetDetailAddressInput.value || '').trim() : '';
+
+      if (!validatePhoneNumber(recipientPhone)) {
+        syncDeliveryPhoneState();
+        showCheckoutToast('연락처 형식을 확인해 주세요');
+        return;
+      }
+
+      orderSummaryPanel.dataset.recipientName = recipientName;
+      orderSummaryPanel.dataset.recipientPhone = recipientPhone;
+      orderSummaryPanel.dataset.postalCode = postalCode;
+      orderSummaryPanel.dataset.deliveryAddressMain = baseAddress;
+      orderSummaryPanel.dataset.deliveryAddressDetail = detailAddress;
+      orderSummaryPanel.dataset.deliveryAddress = [baseAddress, detailAddress].filter(Boolean).join(' | ');
+      syncSummaryFields();
+      closeDeliverySheet();
+      showCheckoutToast('배송 정보를 반영했어요');
+    });
+  }
+
+  if (deliverySheetPhoneInput) {
+    deliverySheetPhoneInput.addEventListener('input', function () {
+      deliverySheetPhoneInput.value = extractPhoneDigits(deliverySheetPhoneInput.value || '');
+      deliverySheetPhoneInput.classList.remove('is-invalid');
+    });
+    deliverySheetPhoneInput.addEventListener('blur', function () {
+      deliverySheetPhoneInput.value = formatPhoneNumber(deliverySheetPhoneInput.value || '');
+      syncDeliveryPhoneState();
+    });
+  }
+
+  if (paymentOptions.length) {
+    paymentOptions.forEach(function (option) {
+      option.addEventListener('click', function () {
+        selectedPaymentMethod = option.getAttribute('data-payment-option') || '';
+        syncPaymentOptions();
+      });
+    });
+  }
+
+  if (savePaymentSheetBtn) {
+    savePaymentSheetBtn.addEventListener('click', function () {
+      if (!orderSummaryPanel || !selectedPaymentMethod) return;
+      if (selectedPaymentMethod === '신용/체크카드' && initialCardPaymentSummary) {
+        orderSummaryPanel.dataset.paymentMethod = initialCardPaymentSummary;
+      } else {
+        orderSummaryPanel.dataset.paymentMethod = selectedPaymentMethod;
+      }
+      syncSummaryFields();
+      closePaymentSheet();
+      showCheckoutToast('결제 수단을 반영했어요');
+    });
+  }
+
+  if (discountTabCoupon) {
+    discountTabCoupon.addEventListener('click', function () {
+      setDiscountTab('coupon');
+    });
+  }
+
+  if (discountTabMileage) {
+    discountTabMileage.addEventListener('click', function () {
+      setDiscountTab('mileage');
+    });
+  }
+
+  couponOptions.forEach(function (option) {
+    option.addEventListener('click', function () {
+      selectedCouponId = option.getAttribute('data-coupon-id') || 'none';
+      selectedCouponLabel = option.getAttribute('data-coupon-label') || '적용된 쿠폰 없음';
+      selectedCouponDiscount = Number(option.getAttribute('data-coupon-discount') || '0');
+      highlightSelectedCoupon();
+      updateDiscountPreview();
+    });
+  });
+
+  if (useAllMileageBtn) {
+    useAllMileageBtn.addEventListener('click', function () {
+      selectedMileageValue = 3200;
+      if (mileageInput) mileageInput.value = '3200';
+      updateDiscountPreview();
+    });
+  }
+
+  if (mileageInput) {
+    mileageInput.addEventListener('input', function () {
+      var nextValue = Number(mileageInput.value || '0');
+      nextValue = Math.max(0, Math.min(3200, nextValue));
+      if (nextValue !== Number(mileageInput.value || '0')) {
+        mileageInput.value = String(nextValue);
+      }
+      selectedMileageValue = nextValue;
+      updateDiscountPreview();
+    });
+  }
+
+  if (applyDiscountBtn) {
+    applyDiscountBtn.addEventListener('click', function () {
+      if (mileageInput) {
+        selectedMileageValue = Math.max(0, Math.min(3200, Number(mileageInput.value || '0')));
+        mileageInput.value = String(selectedMileageValue);
+      }
+      updateDiscountSummaryTexts();
+      updateCheckoutSummary();
+      window.closeDiscountModal();
+    });
+  }
+
+  if (deliveryMessageTrigger) {
+    deliveryMessageTrigger.addEventListener('click', function () {
+      if (!deliveryMessageOptionPanel) return;
+      var isHidden = deliveryMessageOptionPanel.classList.contains('hidden');
+      if (isHidden) {
+        openDeliveryMessageDropdown();
+      } else {
+        closeDeliveryMessageDropdown();
+      }
+    });
+  }
+
+  if (deliveryMessageOptions.length) {
+    deliveryMessageOptions.forEach(function (option) {
+      option.addEventListener('click', function () {
+        var value = option.getAttribute('data-delivery-option') || '직접 입력';
+        if (deliveryMessageSelect) {
+          deliveryMessageSelect.value = value;
+        }
+        syncDeliveryMessageField();
+        closeDeliveryMessageDropdown();
+      });
+    });
+  }
+
+  document.addEventListener('click', function (event) {
+    if (!deliveryMessageDropdown || !deliveryMessageOptionPanel) return;
+    if (!deliveryMessageDropdown.contains(event.target)) {
+      closeDeliveryMessageDropdown();
+    }
+  });
+
+  if (deliveryMessageSelect) {
+    deliveryMessageSelect.addEventListener('change', syncDeliveryMessageField);
+  }
+
+  if (submitOrderBtn) {
+    submitOrderBtn.addEventListener('click', function () {
+      var validation = validateCheckoutState();
+      if (!validation.valid) {
+        syncCheckoutNotice();
+        showCheckoutToast(validation.message);
+        return;
+      }
+      updateConfirmSummary();
+      if (checkoutConfirmModal) {
+        checkoutConfirmModal.classList.add('is-open');
+      }
+    });
+  }
+
+  if (confirmCheckoutSubmitBtn) {
+    confirmCheckoutSubmitBtn.addEventListener('click', submitOrderRequest);
+  }
+
+  initDeliveryMessageField();
+  if (deliverySheetPhoneInput) {
+    deliverySheetPhoneInput.value = formatPhoneNumber(deliverySheetPhoneInput.value || '');
+  }
+  syncDeliveryPhoneState();
+  syncSummaryFields();
+  updateDiscountSummaryTexts();
+  updateCheckoutSummary();
+  syncCheckoutNotice();
+})();
+</script>
+{% endblock %}

--- a/services/django/templates/orders/complete.html
+++ b/services/django/templates/orders/complete.html
@@ -3,154 +3,346 @@
 
 {% block head %}
 <style>
-  .order-complete-shell {
-    background:
-      radial-gradient(circle at top left, rgba(125, 211, 252, 0.2), transparent 28%),
-      radial-gradient(circle at top right, rgba(196, 181, 253, 0.16), transparent 24%),
-      linear-gradient(180deg, #f8fbff 0%, #f7fafc 100%);
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
   }
 
-  .order-complete-items {
-    max-height: min(560px, calc(100vh - 280px));
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #completeHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #completeHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #completeHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #completeViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
     overflow-y: auto;
-    scrollbar-gutter: stable;
-    padding-right: 4px;
+    padding: 24px 16px 32px;
   }
 
-  @media (max-width: 1023px) {
-    .order-complete-sticky {
-      position: static;
-    }
+  .complete-items {
+    display: grid;
+    gap: 12px;
+  }
 
-    .order-complete-items {
-      max-height: none;
-      overflow: visible;
-      padding-right: 0;
+  html,
+  body,
+  body.bg-white {
+    background: #f8f9fb !important;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
     }
   }
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="order-complete-shell min-h-screen">
-  <div class="mx-auto max-w-[1120px] px-4 py-8 md:px-6">
-    <div class="flex items-center justify-start">
-      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
-        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-      </a>
-    </div>
-
-    <div class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_360px]">
-      <section class="overflow-hidden rounded-[32px] border border-[#dbe7f5] bg-white shadow-[0_14px_40px_rgba(45,55,72,0.08)]">
-        <div class="border-b border-[#edf2f7] bg-[linear-gradient(140deg,#ebf8ff_0%,#eff6ff_48%,#ffffff_100%)] px-6 py-7 md:px-8 md:py-8">
-          <div class="flex items-center gap-4">
-            <div class="inline-flex h-[58px] w-[58px] shrink-0 items-center justify-center rounded-full bg-[#2b6cb0] text-[28px] text-white shadow-[0_10px_24px_rgba(43,108,176,0.24)]">
-              <span class="relative top-[-1px]">✓</span>
-            </div>
-            <p class="text-[30px] font-bold tracking-[-0.03em] text-[#1f2937]">주문이 정상적으로 접수되었어요</p>
+<div id="pageGate" class="min-h-screen bg-[#f8f9fb]">
+  <div class="app-shell">
+    <header id="completeHeader">
+      <div id="completeHeaderInner">
+        <div></div>
+        <a id="completeHeaderLogo" href="/chat/" aria-label="메인으로 이동">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div id="profileMenuWrapper">
+          <button type="button" onclick="toggleProfileMenu()" class="inline-flex h-10 w-10 items-center justify-center rounded-full border border-[#e2e8f0] bg-white text-[#4a5568] transition-colors hover:border-[#cbd5e0] hover:text-[#2d3748]" aria-label="프로필 메뉴">
+            <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="M12 12a4 4 0 1 0-4-4 4 4 0 0 0 4 4Z"></path>
+              <path d="M5 20a7 7 0 0 1 14 0"></path>
+            </svg>
+          </button>
+          <div id="profileMenu">
+            <a href="/profile/" class="flex h-[44px] items-center px-4 text-[14px] font-semibold text-[#2d3748] transition-colors hover:bg-[#f8fbff]">내 정보</a>
+            <a href="/pets/" class="flex h-[44px] items-center px-4 text-[14px] font-semibold text-[#2d3748] transition-colors hover:bg-[#f8fbff]">반려동물 정보</a>
+            <form method="post" action="/logout/" class="border-t border-[#edf2f7]">
+              {% csrf_token %}
+              <button type="submit" class="flex h-[44px] w-full items-center px-4 text-left text-[14px] font-semibold text-[#e53e3e] transition-colors hover:bg-[#fff5f5]">로그아웃</button>
+            </form>
           </div>
         </div>
+      </div>
+    </header>
 
-        <div class="px-6 py-6 md:px-8 md:py-7">
-          <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
-            <p class="mb-3 text-[12px] font-semibold text-[#90a4b8]">총 {{ order_completion.item_count }}개 상품</p>
-            <div class="order-complete-items space-y-3">
-              {% for item in order_completion.items %}
-              <div class="flex items-center gap-3 rounded-[18px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-3">
-                <div class="flex h-[54px] w-[54px] shrink-0 items-center justify-center overflow-hidden rounded-[16px] bg-[#f1f5f9]">
-                  {% if item.thumbnail_url %}
-                  <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
-                  {% else %}
-                  <span class="text-[18px] font-bold text-[#90a4b8]">?</span>
-                  {% endif %}
-                </div>
-                <div class="min-w-0 flex-1">
-                  <p class="truncate text-[12px] font-semibold text-[#90a4b8]">{{ item.brand }}</p>
-                  <p class="truncate text-[14px] font-bold text-[#2d3748]">{{ item.name }}</p>
-                </div>
-                <div class="shrink-0 text-right">
-                  <p class="text-[12px] font-semibold text-[#7aa6e9]">x {{ item.quantity }}</p>
-                  <p class="mt-1 text-[13px] font-bold text-[#2d3748]">{{ item.line_total }}</p>
-                </div>
-              </div>
-              {% endfor %}
-            </div>
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.2"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.2"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.2"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.2"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="19" r="1.6"></circle>
+            <circle cx="17" cy="19" r="1.6"></circle>
+            <path d="M5 5h2l1.4 8.2a1 1 0 0 0 1 .8h7.9a1 1 0 0 0 1-.8L20 8H8.2"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link is-active" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <div id="completeViewport">
+      <div class="pl-3">
+        <div class="text-[18px] font-bold text-[#2d3748]">주문 완료</div>
+      </div>
+      <div class="mt-3 h-px w-full bg-[#e2e8f0]"></div>
+
+      <section class="mt-6 rounded-[24px] border border-[#dbe7f5] bg-white px-5 py-5">
+        <div class="flex items-center gap-3">
+          <div class="inline-flex h-[42px] w-[42px] shrink-0 items-center justify-center rounded-full bg-[#2b6cb0] text-[20px] font-bold text-white">✓</div>
+          <div>
+            <p class="text-[18px] font-bold text-[#2d3748]">주문이 정상적으로 접수되었어요</p>
+            <p class="mt-1 text-[13px] text-[#718096]">주문번호 {{ order_completion.order_id }}</p>
           </div>
+        </div>
+      </section>
 
-          <div class="mt-6 grid gap-4 lg:grid-cols-2">
-            <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
-              <p class="text-[18px] font-bold tracking-[-0.02em] text-[#2563eb]">배송 정보</p>
-              <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
-                <div>
-                  <p class="font-semibold text-[#90a4b8]">주문번호</p>
-                  <p class="mt-1 break-all font-semibold text-[#2d3748]">{{ order_completion.order_id }}</p>
-                </div>
-                <div>
-                  <p class="font-semibold text-[#90a4b8]">수령인 / 연락처</p>
-                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.recipient_name }} / {{ order_completion.recipient_phone }}</p>
-                </div>
-                <div>
-                  <p class="font-semibold text-[#90a4b8]">상세 배송지</p>
-                  <p class="mt-1 font-semibold leading-[1.7] text-[#2d3748]">
-                    {{ order_completion.delivery_base_address }}
-                    {% if order_completion.delivery_detail_address %}
-                    <br>{{ order_completion.delivery_detail_address }}
-                    {% endif %}
-                  </p>
-                </div>
-                <div>
-                  <p class="font-semibold text-[#90a4b8]">배송 메시지</p>
-                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.delivery_message }}</p>
-                </div>
-              </div>
+      <section class="mt-4 rounded-[24px] border border-[#dbe7f5] bg-white px-5 py-5">
+        <div class="flex items-center justify-between gap-3">
+          <p class="text-[14px] font-bold text-[#2d3748]">주문 상품</p>
+          <p class="text-[12px] font-semibold text-[#718096]">총 {{ order_completion.item_count }}개</p>
+        </div>
+        <div class="complete-items mt-4">
+          {% for item in order_completion.items %}
+          <article class="flex items-center gap-3 rounded-[18px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-3">
+            <div class="flex h-[54px] w-[54px] shrink-0 items-center justify-center overflow-hidden rounded-[16px] bg-[#f1f5f9]">
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+              {% else %}
+              <span class="text-[18px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
             </div>
+            <div class="min-w-0 flex-1">
+              <p class="line-clamp-2 text-[14px] font-bold leading-[1.45] text-[#2d3748]">{{ item.name }}</p>
+            </div>
+            <div class="shrink-0 text-right">
+              <p class="text-[12px] font-semibold text-[#718096]">x {{ item.quantity }}</p>
+              <p class="mt-1 text-[13px] font-bold text-[#2d3748]">{{ item.line_total }}</p>
+            </div>
+          </article>
+          {% endfor %}
+        </div>
+      </section>
 
-            <div class="rounded-[24px] border border-[#e2e8f0] bg-white px-5 py-5">
-              <p class="text-[18px] font-bold tracking-[-0.02em] text-[#2563eb]">결제 요약</p>
-              <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
-                <div>
-                  <p class="font-semibold text-[#90a4b8]">결제 수단</p>
-                  <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.payment_method }}</p>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>상품 금액</span>
-                  <span class="font-semibold text-[#2d3748]">{{ order_completion.product_total }}</span>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>쿠폰 할인</span>
-                  <span class="font-semibold text-[#2563eb]">- {{ order_completion.coupon_discount }}</span>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>마일리지</span>
-                  <span class="font-semibold text-[#2563eb]">- {{ order_completion.mileage_discount }}</span>
-                </div>
-                <div class="flex items-center justify-between">
-                  <span>배송비</span>
-                  <span class="font-semibold text-[#2d3748]">{{ order_completion.shipping_fee }}</span>
-                </div>
-                <div class="border-t border-[#edf2f7] pt-3">
-                  <div class="flex items-center justify-between">
-                    <span class="text-[14px] font-semibold text-[#4a5568]">최종 결제 금액</span>
-                    <span class="text-[20px] font-bold text-[#2563eb]">{{ order_completion.total_price }}</span>
-                  </div>
-                </div>
-              </div>
+      <section class="mt-4 rounded-[24px] border border-[#dbe7f5] bg-white px-5 py-5">
+        <p class="text-[14px] font-bold text-[#2d3748]">배송 정보</p>
+        <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+          <div>
+            <p class="font-semibold text-[#90a4b8]">수령인 / 연락처</p>
+            <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.recipient_name }} / {{ order_completion.recipient_phone }}</p>
+          </div>
+          <div>
+            <p class="font-semibold text-[#90a4b8]">배송지</p>
+            <p class="mt-1 font-semibold leading-[1.7] text-[#2d3748]">
+              {{ order_completion.delivery_base_address }}
+              {% if order_completion.delivery_detail_address %}
+              <br>{{ order_completion.delivery_detail_address }}
+              {% endif %}
+            </p>
+          </div>
+          <div>
+            <p class="font-semibold text-[#90a4b8]">배송 메시지</p>
+            <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.delivery_message }}</p>
+          </div>
+        </div>
+      </section>
+
+      <section class="mt-4 rounded-[24px] border border-[#dbe7f5] bg-white px-5 py-5">
+        <p class="text-[14px] font-bold text-[#2d3748]">결제 요약</p>
+        <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
+          <div>
+            <p class="font-semibold text-[#90a4b8]">결제 수단</p>
+            <p class="mt-1 font-semibold text-[#2d3748]">{{ order_completion.payment_method }}</p>
+          </div>
+          <div class="flex items-center justify-between">
+            <span>상품 금액</span>
+            <span class="font-semibold text-[#2d3748]">{{ order_completion.product_total }}</span>
+          </div>
+          <div class="flex items-center justify-between">
+            <span>쿠폰 할인</span>
+            <span class="font-semibold text-[#2563eb]">- {{ order_completion.coupon_discount }}</span>
+          </div>
+          <div class="flex items-center justify-between">
+            <span>마일리지</span>
+            <span class="font-semibold text-[#2563eb]">- {{ order_completion.mileage_discount }}</span>
+          </div>
+          <div class="flex items-center justify-between">
+            <span>배송비</span>
+            <span class="font-semibold text-[#2d3748]">{{ order_completion.shipping_fee }}</span>
+          </div>
+          <div class="border-t border-[#edf2f7] pt-3">
+            <div class="flex items-center justify-between">
+              <span class="font-semibold text-[#4a5568]">최종 결제 금액</span>
+              <span class="text-[18px] font-bold text-[#2563eb]">{{ order_completion.total_price }}</span>
             </div>
           </div>
         </div>
       </section>
 
-      <aside class="order-complete-sticky self-start rounded-[28px] border border-[#dbe7f5] bg-white p-6 shadow-[0_12px_32px_rgba(45,55,72,0.06)] lg:sticky lg:top-8">
-        <div class="space-y-3">
-          <a href="/orders/" class="inline-flex h-[48px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[14px] font-semibold text-white">
-            주문 내역 보러가기
-          </a>
-          <a href="/chat/" class="inline-flex h-[48px] w-full items-center justify-center rounded-[16px] border border-[#dbe7f5] bg-[#f8fbff] text-[14px] font-semibold text-[#2d3748]">
-            메인 채팅으로 돌아가기
-          </a>
-        </div>
-      </aside>
+      <div class="mt-6 grid gap-3 md:grid-cols-2">
+        <a href="/orders/" class="inline-flex h-[48px] items-center justify-center rounded-[16px] bg-[#2d3748] text-[14px] font-semibold text-white">
+          주문 내역 보러가기
+        </a>
+        <a href="/chat/" class="inline-flex h-[48px] items-center justify-center rounded-[16px] border border-[#dbe7f5] bg-[#f8fbff] text-[14px] font-semibold text-[#2d3748]">
+          메인 채팅으로 돌아가기
+        </a>
+      </div>
     </div>
   </div>
 </div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
+
+  document.addEventListener('click', function (event) {
+    if (!profileMenu || !profileMenuWrapper) return;
+    if (profileMenuWrapper.contains(event.target)) return;
+    profileMenu.classList.remove('is-open');
+  });
+})();
+</script>
 {% endblock %}

--- a/services/django/templates/orders/list.html
+++ b/services/django/templates/orders/list.html
@@ -3,6 +3,139 @@
 
 {% block head %}
 <style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #ordersHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #ordersHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #ordersHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #ordersViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 24px 16px 28px;
+  }
+
   .order-detail-modal {
     display: none;
   }
@@ -36,6 +169,128 @@
     background: #2d3748;
     border-color: #2d3748;
     color: #fff;
+  }
+
+  .order-toolbar-select.hidden-native {
+    position: absolute;
+    opacity: 0;
+    pointer-events: none;
+    width: 0;
+    height: 0;
+  }
+
+  .order-toolbar-dropdown {
+    position: relative;
+    width: 148px;
+  }
+
+  .order-toolbar-trigger {
+    display: flex;
+    width: 100%;
+    height: 34px;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border: 1px solid #dbe7f5;
+    border-radius: 9999px;
+    background: #fff;
+    padding: 0 14px;
+    color: #4a5568;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .order-toolbar-control {
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    width: 100%;
+    max-width: 148px;
+    border-radius: 14px;
+    background: #f8fbff;
+    padding: 8px 0;
+  }
+
+  @media (min-width: 768px) {
+    .order-toolbar-control {
+      width: auto;
+      max-width: none;
+      border-radius: 0;
+      background: transparent;
+      padding: 0;
+    }
+  }
+
+  .order-toolbar-trigger-text {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .order-toolbar-trigger-caret {
+    width: 8px;
+    height: 8px;
+    flex: 0 0 8px;
+    border-right: 1.5px solid #90a4b8;
+    border-bottom: 1.5px solid #90a4b8;
+    transform: rotate(45deg) translateY(-1px);
+    transition: transform 160ms ease;
+  }
+
+  .order-toolbar-dropdown.is-open .order-toolbar-trigger-caret {
+    transform: rotate(-135deg) translateY(-1px);
+  }
+
+  .order-toolbar-option-panel {
+    position: absolute;
+    top: calc(100% + 8px);
+    left: 0;
+    right: 0;
+    z-index: 25;
+    overflow: hidden;
+    border: 1px solid #dbe7f5;
+    border-radius: 16px;
+    background: #fff;
+    box-shadow: 0 14px 30px rgba(45, 55, 72, 0.12);
+  }
+
+  .order-toolbar-option-panel.hidden {
+    display: none;
+  }
+
+  .order-toolbar-option {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    padding: 12px 14px;
+    color: #4a5568;
+    font-size: 12px;
+    font-weight: 600;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .order-toolbar-option + .order-toolbar-option {
+    border-top: 1px solid #edf2f7;
+  }
+
+  .order-toolbar-option:hover {
+    background: #f8fbff;
+  }
+
+  .order-toolbar-option.is-active {
+    background: #f8fbff;
+    color: #2d3748;
+  }
+
+  .order-toolbar-option-check {
+    opacity: 0;
+    color: #2d3748;
+  }
+
+  .order-toolbar-option.is-active .order-toolbar-option-check {
+    opacity: 1;
   }
 
   .order-detail-dialog {
@@ -73,10 +328,72 @@
     box-shadow: 0 6px 18px rgba(45, 55, 72, 0.04);
   }
 
+  html,
+  body,
+  body.bg-white {
+    background: #f8f9fb !important;
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+
+    .order-detail-dialog {
+      width: 100%;
+      max-width: 100%;
+      padding: 18px 16px;
+    }
+
+    .order-detail-body {
+      min-width: 0;
+    }
+
+    .order-detail-left {
+      min-width: 0;
+    }
+
+    .order-detail-body > aside {
+      min-width: 0;
+    }
+
+    #orderDetailAddress,
+    #orderDetailMessage {
+      max-width: 100%;
+      min-width: 0;
+      overflow-wrap: anywhere;
+      word-break: break-word;
+    }
+  }
+
   @media (max-width: 1023px) {
     .order-detail-dialog {
       max-height: calc(100vh - 20px);
       padding: 20px 18px;
+      overflow-y: auto;
+    }
+
+    .order-detail-body {
+      display: block;
+      min-height: auto;
+      overflow: visible;
+    }
+
+    .order-detail-left {
+      display: block;
+      min-height: auto;
+    }
+
+    .order-detail-items-scroll {
+      max-height: 220px;
+      overflow-y: auto;
+      margin-top: 16px;
+      padding-right: 4px;
+    }
+
+    .order-detail-body > aside {
+      display: block;
+      margin-top: 16px;
     }
 
     .order-empty-state {
@@ -84,44 +401,134 @@
       min-height: 300px;
     }
   }
+
 </style>
 {% endblock %}
 
 {% block content %}
-<div class="min-h-screen bg-[#f7fafc]">
-  <div class="mx-auto max-w-[1180px] px-4 py-8 md:px-6">
-    <div class="flex items-center justify-start">
-      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
-        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-      </a>
-    </div>
-
-    <div class="mt-8 flex items-center justify-start">
-      <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
-        <a href="/orders/" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">
-          주문 내역
+<div id="pageGate" class="min-h-screen bg-[#f7fafc]">
+  <div class="app-shell">
+    <header id="ordersHeader">
+      <div id="ordersHeaderInner">
+        <div></div>
+        <a href="/chat/" id="ordersHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link is-active" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
         </a>
       </div>
     </div>
-
-    <div class="mt-6 flex flex-col gap-3 rounded-[24px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)] md:flex-row md:items-center md:justify-between">
-      <div class="flex flex-wrap gap-2">
-        {% for option in order_filter_options %}
-        <a href="/orders/{% if option.query %}?{{ option.query }}{% endif %}"
-           class="order-toolbar-chip inline-flex h-[34px] items-center justify-center rounded-full border border-[#dbe7f5] px-4 text-[13px] font-semibold {% if option.is_active %}is-active{% else %}bg-[#f8fbff] text-[#4a5568]{% endif %}">
-          {{ option.label }}
-        </a>
-        {% endfor %}
+    <div id="ordersViewport">
+    <div class="mb-0 pl-2">
+      <h1 class="text-[24px] font-bold leading-[1.25] text-[#2d3748]">주문 내역</h1>
+      <div class="mt-3 h-px w-full bg-[#e8eef6]"></div>
+    </div>
+    <div class="mt-3 flex items-center justify-end gap-2 px-1 md:gap-5">
+      <div class="order-toolbar-control">
+        <div id="orderFilterDropdown" class="order-toolbar-dropdown">
+          <button type="button" id="orderFilterTrigger" class="order-toolbar-trigger" aria-haspopup="listbox" aria-expanded="false">
+            <span id="orderFilterTriggerText" class="order-toolbar-trigger-text"></span>
+            <span class="order-toolbar-trigger-caret" aria-hidden="true"></span>
+          </button>
+          <div id="orderFilterOptionPanel" class="order-toolbar-option-panel hidden" role="listbox">
+            {% for option in order_filter_options %}
+            <button type="button"
+                    class="order-toolbar-option {% if option.is_active %}is-active{% endif %}"
+                    data-order-filter-option
+                    data-value="/orders/{% if option.query %}?{{ option.query }}{% endif %}"
+                    data-label="{{ option.label }}">
+              <span>{{ option.label }}</span>
+              <span class="order-toolbar-option-check">✓</span>
+            </button>
+            {% endfor %}
+          </div>
+          <select id="orderFilterSelect" class="order-toolbar-select hidden-native">
+            {% for option in order_filter_options %}
+            <option value="/orders/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>
+              {{ option.label }}
+            </option>
+            {% endfor %}
+          </select>
+        </div>
       </div>
-      <div class="flex items-center gap-2 self-end md:self-auto">
-        <span class="text-[12px] font-semibold text-[#90a4b8]">정렬</span>
-        <div class="inline-flex rounded-full border border-[#dbe7f5] bg-[#f8fbff] p-[3px]">
-          {% for option in order_ordering_options %}
-          <a href="/orders/{% if option.query %}?{{ option.query }}{% endif %}"
-             class="order-toolbar-chip inline-flex h-[30px] min-w-[78px] items-center justify-center rounded-full px-3 text-[12px] font-semibold {% if option.is_active %}is-active{% else %}text-[#4a5568]{% endif %}">
-            {{ option.label }}
-          </a>
-          {% endfor %}
+      <div class="order-toolbar-control">
+        <div id="orderSortDropdown" class="order-toolbar-dropdown">
+          <button type="button" id="orderSortTrigger" class="order-toolbar-trigger" aria-haspopup="listbox" aria-expanded="false">
+            <span id="orderSortTriggerText" class="order-toolbar-trigger-text"></span>
+            <span class="order-toolbar-trigger-caret" aria-hidden="true"></span>
+          </button>
+          <div id="orderSortOptionPanel" class="order-toolbar-option-panel hidden" role="listbox">
+            {% for option in order_ordering_options %}
+            <button type="button"
+                    class="order-toolbar-option {% if option.is_active %}is-active{% endif %}"
+                    data-order-sort-option
+                    data-value="/orders/{% if option.query %}?{{ option.query }}{% endif %}"
+                    data-label="{{ option.label }}">
+              <span>{{ option.label }}</span>
+              <span class="order-toolbar-option-check">✓</span>
+            </button>
+            {% endfor %}
+          </div>
+          <select id="orderSortSelect" class="order-toolbar-select hidden-native">
+            {% for option in order_ordering_options %}
+            <option value="/orders/{% if option.query %}?{{ option.query }}{% endif %}" {% if option.is_active %}selected{% endif %}>
+              {{ option.label }}
+            </option>
+            {% endfor %}
+          </select>
         </div>
       </div>
     </div>
@@ -133,21 +540,20 @@
     {% endif %}
 
     {% if order_groups %}
-    <div class="order-card-grid mt-8 grid items-start gap-5 lg:grid-cols-2">
+    <div class="order-card-grid mt-3 grid items-start gap-5 lg:grid-cols-2">
       {% for order in order_groups %}
-      <section class="overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
+      <section class="overflow-hidden rounded-[22px] border border-[#e2e8f0] bg-white">
         <div class="px-5 py-5">
-          <div class="flex flex-col gap-4">
+          <div class="flex flex-col gap-3">
             <div class="min-w-0">
               <div class="flex items-start justify-between gap-4">
                 <div class="min-w-0">
                   <div class="flex flex-wrap items-center gap-2">
-                    <p class="text-[18px] font-bold text-[#2d3748]">{{ order.created_at }}</p>
-                    <span class="inline-flex rounded-full px-3 py-1 text-[12px] font-bold {{ order.status_class }}">
+                    <p class="text-[17px] font-bold text-[#2d3748]">{{ order.created_at }}</p>
+                    <span class="inline-flex rounded-full px-2.5 py-1 text-[11px] font-bold {{ order.status_class }}">
                       {{ order.status }}
                     </span>
                   </div>
-                  <p class="mt-2 text-[14px] font-semibold text-[#2d3748]">주문번호 {{ order.order_id }}</p>
                 </div>
                 <div class="flex shrink-0 items-center gap-2">
                   {% if order.can_reorder %}
@@ -158,14 +564,14 @@
                   </button>
                   {% endif %}
                   <button type="button"
-                          class="inline-flex h-[32px] items-center justify-center rounded-[10px] bg-[#edf2f7] px-3 text-[12px] font-semibold text-[#2d3748]"
+                          class="inline-flex h-[32px] items-center justify-center rounded-[10px] border border-[#e2e8f0] bg-[#f8fbff] px-3 text-[12px] font-semibold text-[#2d3748]"
                           data-order-open="{{ forloop.counter0 }}">
                     상세 보기
                   </button>
                 </div>
               </div>
 
-              <div class="mt-4 min-w-0 rounded-[20px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-3.5">
+              <div class="mt-3 min-w-0 rounded-[18px] border border-[#edf2f7] bg-[#fbfdff] px-4 py-3">
                 <div class="min-w-0">
                   {% for item in order.items|slice:":2" %}
                   <div class="{% if not forloop.first %}mt-1.5{% endif %} flex min-w-0 items-center gap-2">
@@ -180,12 +586,12 @@
               </div>
             </div>
 
-            <div class="rounded-[20px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-4">
+            <div class="rounded-[18px] border border-[#e2e8f0] bg-[#f8fbff] px-4 py-3.5">
               <div class="flex h-[20px] items-center justify-between gap-3">
-                <p class="text-[13px] font-semibold leading-none text-[#90a4b8]">결제 금액</p>
-                <span class="text-[13px] font-semibold leading-none text-[#90a4b8]">총 {{ order.item_count }} 개</span>
+                <p class="text-[12px] font-semibold leading-none text-[#90a4b8]">결제 금액</p>
+                <span class="text-[12px] font-semibold leading-none text-[#90a4b8]">총 {{ order.item_count }}개</span>
               </div>
-              <p class="mt-2 text-[22px] font-bold text-[#2d3748]">{{ order.total_price }}</p>
+              <p class="mt-1.5 text-[21px] font-bold text-[#2d3748]">{{ order.total_price }}</p>
             </div>
           </div>
         </div>
@@ -226,6 +632,7 @@
       </div>
     </div>
     {% endif %}
+    </div>
   </div>
 </div>
 
@@ -235,10 +642,10 @@
 </div>
 
 <div id="orderDetailModal" class="order-detail-modal fixed inset-0 z-50 items-center justify-center bg-[rgba(15,23,42,0.46)] px-4" onclick="closeOrderDetailModal(event)">
-  <div class="order-detail-dialog w-full max-w-[760px] rounded-[24px] bg-white px-6 py-6 shadow-[0_20px_60px_rgba(15,23,42,0.24)]">
+  <div class="order-detail-dialog w-full max-w-[760px] rounded-[22px] bg-white px-6 py-6 shadow-[0_18px_48px_rgba(15,23,42,0.2)]">
     <div class="flex items-start justify-between gap-4">
       <div>
-        <p id="orderDetailTitle" class="text-[24px] font-bold text-[#2d3748]"></p>
+        <p id="orderDetailTitle" class="text-[22px] font-bold text-[#2d3748]"></p>
       </div>
       <button type="button"
               class="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]"
@@ -246,49 +653,48 @@
               onclick="closeOrderDetailModal()">×</button>
     </div>
 
-    <div class="order-detail-body mt-5 grid gap-5 lg:grid-cols-[minmax(0,1fr)_260px]">
+    <div class="order-detail-body mt-4 grid gap-4 lg:grid-cols-[minmax(0,1fr)_248px]">
       <div class="order-detail-left min-h-0">
-        <div class="rounded-[20px] border border-[#dbe7f5] bg-[#f8fbff] px-5 py-5">
+        <div class="rounded-[18px] border border-[#e2e8f0] bg-[#f8fbff] px-5 py-4">
           <div class="flex flex-wrap items-center gap-2">
-            <p id="orderDetailDate" class="text-[18px] font-bold text-[#2d3748]"></p>
-            <span id="orderDetailStatus" class="inline-flex rounded-full px-3 py-1 text-[12px] font-bold"></span>
+            <p id="orderDetailDate" class="text-[17px] font-bold text-[#2d3748]"></p>
+            <span id="orderDetailStatus" class="inline-flex rounded-full px-2.5 py-1 text-[11px] font-bold"></span>
           </div>
-          <div class="mt-4 grid gap-3 text-[14px] text-[#4a5568]">
+          <div class="mt-4 grid gap-3 text-[13px] text-[#4a5568]">
             <div class="flex items-start justify-between gap-3">
-              <span class="text-[#90a4b8]">주문번호</span>
+              <span class="shrink-0 whitespace-nowrap text-[#90a4b8]">주문번호</span>
               <span id="orderDetailOrderId" class="font-semibold text-[#2d3748]"></span>
             </div>
             <div class="flex items-start justify-between gap-3">
-              <span class="text-[#90a4b8]">수령인</span>
+              <span class="shrink-0 whitespace-nowrap text-[#90a4b8]">수령인</span>
               <span id="orderDetailRecipient" class="font-semibold text-[#2d3748]"></span>
             </div>
             <div class="flex items-start justify-between gap-3">
-              <span class="text-[#90a4b8]">연락처</span>
+              <span class="shrink-0 whitespace-nowrap text-[#90a4b8]">연락처</span>
               <span id="orderDetailPhone" class="font-semibold text-[#2d3748]"></span>
             </div>
             <div class="flex items-start justify-between gap-3">
-              <span class="text-[#90a4b8]">배송지</span>
+              <span class="shrink-0 whitespace-nowrap text-[#90a4b8]">배송지</span>
               <span id="orderDetailAddress" class="max-w-[380px] text-right leading-[1.6] text-[#2d3748]"></span>
             </div>
             <div class="flex items-start justify-between gap-3">
-              <span id="orderDetailMessageLabel" class="text-[#90a4b8]">배송 메모</span>
+              <span id="orderDetailMessageLabel" class="shrink-0 whitespace-nowrap text-[#90a4b8]">배송 메모</span>
               <span id="orderDetailMessage" class="max-w-[380px] text-right leading-[1.6] text-[#2d3748]"></span>
             </div>
             <div class="flex items-start justify-between gap-3">
-              <span class="text-[#90a4b8]">결제 수단</span>
+              <span class="shrink-0 whitespace-nowrap text-[#90a4b8]">결제 수단</span>
               <span id="orderDetailPayment" class="font-semibold text-[#2d3748]"></span>
             </div>
           </div>
         </div>
 
-        <div class="order-detail-items-scroll mt-5 space-y-3" id="orderDetailItems"></div>
+        <div class="order-detail-items-scroll mt-4 space-y-3" id="orderDetailItems"></div>
       </div>
 
-      <aside class="rounded-[20px] border border-[#dbe7f5] bg-white px-5 py-5">
-        <p class="text-[13px] font-semibold text-[#90a4b8]">결제 요약</p>
-        <p id="orderDetailTotal" class="mt-3 text-[24px] font-bold text-[#2d3748]"></p>
-        <p id="orderDetailHint" class="mt-3 whitespace-pre-line text-[13px] leading-[1.6] text-[#718096]"></p>
-        <div class="mt-5 space-y-3 text-[13px] text-[#4a5568]">
+      <aside class="rounded-[18px] border border-[#e2e8f0] bg-white px-5 py-4">
+        <p class="text-[12px] font-semibold text-[#90a4b8]">결제 요약</p>
+        <p id="orderDetailTotal" class="mt-2.5 text-[23px] font-bold text-[#2d3748]"></p>
+        <div class="mt-4 space-y-3 text-[12px] text-[#4a5568]">
           <div class="flex items-center justify-between">
             <span>상품 수</span>
             <span id="orderDetailCount" class="font-semibold text-[#2d3748]"></span>
@@ -300,8 +706,8 @@
         </div>
         <button type="button"
                 id="orderDetailReorderButton"
-                class="mt-6 inline-flex h-[44px] w-full items-center justify-center rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] text-[14px] font-semibold text-[#2d3748]">
-          다시 주문하러 가기
+                class="mt-5 inline-flex h-[42px] w-full items-center justify-center rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] text-[14px] font-semibold text-[#2d3748]">
+          다시 담기
         </button>
       </aside>
     </div>
@@ -314,6 +720,8 @@
 {{ order_groups|json_script:"order-groups-data" }}
 <script>
 (function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
   var modal = document.getElementById('orderDetailModal');
   var orderDataScript = document.getElementById('order-groups-data');
   if (!modal || !orderDataScript) return;
@@ -335,9 +743,26 @@
   var detailCount = document.getElementById('orderDetailCount');
   var detailStatusText = document.getElementById('orderDetailStatusText');
   var detailReorderButton = document.getElementById('orderDetailReorderButton');
+  var orderFilterDropdown = document.getElementById('orderFilterDropdown');
+  var orderFilterTrigger = document.getElementById('orderFilterTrigger');
+  var orderFilterTriggerText = document.getElementById('orderFilterTriggerText');
+  var orderFilterOptionPanel = document.getElementById('orderFilterOptionPanel');
+  var orderFilterSelect = document.getElementById('orderFilterSelect');
+  var orderFilterOptions = Array.prototype.slice.call(document.querySelectorAll('[data-order-filter-option]'));
+  var orderSortDropdown = document.getElementById('orderSortDropdown');
+  var orderSortTrigger = document.getElementById('orderSortTrigger');
+  var orderSortTriggerText = document.getElementById('orderSortTriggerText');
+  var orderSortOptionPanel = document.getElementById('orderSortOptionPanel');
+  var orderSortSelect = document.getElementById('orderSortSelect');
+  var orderSortOptions = Array.prototype.slice.call(document.querySelectorAll('[data-order-sort-option]'));
   var activeOrderIndex = null;
   var feedbackToast = document.getElementById('orderFeedbackToast');
   var feedbackToastTimer = null;
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
 
   function getCsrfToken() {
     var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
@@ -367,6 +792,30 @@
       feedbackToast.classList.remove('is-open');
       feedbackToastTimer = null;
     }, 2600);
+  }
+
+  function syncToolbarDropdown(selectElement, triggerTextElement, options, dataAttribute) {
+    if (!selectElement || !triggerTextElement) return;
+    var selectedOption = selectElement.options[selectElement.selectedIndex];
+    triggerTextElement.textContent = selectedOption ? selectedOption.textContent.trim() : '';
+    options.forEach(function (option) {
+      var isActive = option.getAttribute(dataAttribute) === selectElement.value;
+      option.classList.toggle('is-active', isActive);
+    });
+  }
+
+  function openToolbarDropdown(dropdown, trigger, panel) {
+    if (!dropdown || !trigger || !panel) return;
+    panel.classList.remove('hidden');
+    dropdown.classList.add('is-open');
+    trigger.setAttribute('aria-expanded', 'true');
+  }
+
+  function closeToolbarDropdown(dropdown, trigger, panel) {
+    if (!dropdown || !trigger || !panel) return;
+    panel.classList.add('hidden');
+    dropdown.classList.remove('is-open');
+    trigger.setAttribute('aria-expanded', 'false');
   }
 
   function resetReorderButtons() {
@@ -505,6 +954,67 @@
       reorderOrder(activeOrderIndex, detailReorderButton);
     });
   }
+
+  document.addEventListener('click', function (event) {
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+    if (orderFilterDropdown && !orderFilterDropdown.contains(event.target)) {
+      closeToolbarDropdown(orderFilterDropdown, orderFilterTrigger, orderFilterOptionPanel);
+    }
+    if (orderSortDropdown && !orderSortDropdown.contains(event.target)) {
+      closeToolbarDropdown(orderSortDropdown, orderSortTrigger, orderSortOptionPanel);
+    }
+  });
+
+  syncToolbarDropdown(orderFilterSelect, orderFilterTriggerText, orderFilterOptions, 'data-value');
+  syncToolbarDropdown(orderSortSelect, orderSortTriggerText, orderSortOptions, 'data-value');
+
+  if (orderFilterTrigger) {
+    orderFilterTrigger.addEventListener('click', function () {
+      if (!orderFilterOptionPanel) return;
+      var isHidden = orderFilterOptionPanel.classList.contains('hidden');
+      closeToolbarDropdown(orderSortDropdown, orderSortTrigger, orderSortOptionPanel);
+      if (isHidden) {
+        openToolbarDropdown(orderFilterDropdown, orderFilterTrigger, orderFilterOptionPanel);
+      } else {
+        closeToolbarDropdown(orderFilterDropdown, orderFilterTrigger, orderFilterOptionPanel);
+      }
+    });
+  }
+
+  if (orderSortTrigger) {
+    orderSortTrigger.addEventListener('click', function () {
+      if (!orderSortOptionPanel) return;
+      var isHidden = orderSortOptionPanel.classList.contains('hidden');
+      closeToolbarDropdown(orderFilterDropdown, orderFilterTrigger, orderFilterOptionPanel);
+      if (isHidden) {
+        openToolbarDropdown(orderSortDropdown, orderSortTrigger, orderSortOptionPanel);
+      } else {
+        closeToolbarDropdown(orderSortDropdown, orderSortTrigger, orderSortOptionPanel);
+      }
+    });
+  }
+
+  orderFilterOptions.forEach(function (option) {
+    option.addEventListener('click', function () {
+      var value = option.getAttribute('data-value') || '';
+      if (!value) return;
+      if (orderFilterSelect) orderFilterSelect.value = value;
+      syncToolbarDropdown(orderFilterSelect, orderFilterTriggerText, orderFilterOptions, 'data-value');
+      window.location.href = value;
+    });
+  });
+
+  orderSortOptions.forEach(function (option) {
+    option.addEventListener('click', function () {
+      var value = option.getAttribute('data-value') || '';
+      if (!value) return;
+      if (orderSortSelect) orderSortSelect.value = value;
+      syncToolbarDropdown(orderSortSelect, orderSortTriggerText, orderSortOptions, 'data-value');
+      window.location.href = value;
+    });
+  });
 
   window.addEventListener('pageshow', function () {
     resetReorderButtons();

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -1,16 +1,145 @@
 {% extends "base.html" %}
-{% block title %}장바구니 — TailTalk{% endblock %}
+{% block title %}{% if active_tab == 'wishlist' %}관심 상품{% else %}장바구니{% endif %} — TailTalk{% endblock %}
 
 {% block head %}
 <style>
-  html {
-    scrollbar-gutter: stable;
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #productsHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #productsHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #productsHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #productsViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 24px 16px 146px;
   }
 
   html,
   body,
   body.bg-white {
-    background: #f7fafc !important;
+    background: #f8f9fb !important;
   }
 
   .product-tab-panel {
@@ -51,12 +180,41 @@
   }
 
   .product-list-viewport {
-    scrollbar-gutter: stable;
+    background: transparent;
+  }
+
+  .cart-item-card {
+    border: 0 !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    box-shadow: none !important;
+    padding: 0 0 16px !important;
+  }
+
+  #cartListViewport > .cart-item-card:not(:last-child) {
+    border-bottom: 1px solid #cfd8e3 !important;
+    margin-bottom: 18px;
+    padding-bottom: 18px !important;
+  }
+
+  #wishlistListViewport {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    align-items: start;
+    gap: 20px;
+  }
+
+  @media (min-width: 1024px) {
+    #wishlistListViewport {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
   }
 
   .product-fixed-viewport {
     min-height: 0 !important;
-    overflow-y: auto;
+    overflow: visible !important;
+    height: auto !important;
+    max-height: none !important;
   }
 
   .product-empty-compact {
@@ -156,7 +314,15 @@
     color: #4a5568;
   }
 
+  .wishlist-heart:hover {
+    color: #2d3748;
+  }
+
   .wishlist-heart.is-active {
+    color: #e53e3e;
+  }
+
+  .wishlist-heart.is-active:hover {
     color: #e53e3e;
   }
 
@@ -168,14 +334,183 @@
     display: block;
   }
 
-  .product-card-brand {
+  .catalog-card {
+    display: flex;
+    position: relative;
+    flex-direction: column;
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  }
+
+  .catalog-card:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 28px rgba(45, 55, 72, 0.08);
+    border-color: #cbd5e0;
+  }
+
+  @media (hover: none) and (pointer: coarse) {
+    .catalog-card:hover {
+      transform: none;
+      box-shadow: 0 8px 24px rgba(45, 55, 72, 0.04);
+      border-color: #e2e8f0;
+    }
+  }
+
+  .catalog-thumb {
+    aspect-ratio: 1 / 1;
+  }
+
+  .catalog-card-body {
+    display: flex;
+    min-height: 0;
+    flex: 1 1 auto;
+    flex-direction: column;
+  }
+
+  .catalog-card-title {
+    display: -webkit-box;
     overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+    min-height: calc(1em * 1.45 * 2);
+    font-size: 17px;
+    font-weight: 700;
+    line-height: 1.45;
+    color: #2d3748;
+  }
+
+  .catalog-card-meta {
+    margin-top: auto;
+    padding-top: 12px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 12px;
+  }
+
+  .catalog-card-price {
+    font-size: 20px;
+    font-weight: 700;
+    color: #2d3748;
+  }
+
+  .catalog-card-review {
+    margin-top: 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
     font-size: 12px;
+    color: #a0aec0;
+  }
+
+  .catalog-card-action {
+    display: inline-flex;
+    height: 38px;
+    width: 38px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    background: #2d3748;
+    font-size: 24px;
     font-weight: 600;
-    line-height: 1.25;
-    color: #90a4b8;
+    line-height: 1;
+    color: #fff;
+  }
+
+  .catalog-card-wishlist {
+    position: absolute;
+    right: 12px;
+    bottom: 12px;
+    z-index: 1;
+    display: inline-flex;
+    height: 28px;
+    width: 28px;
+    flex-shrink: 0;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1px solid rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.95);
+    line-height: 1;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(4px);
+    transition: color 160ms ease;
+  }
+
+  .catalog-card-select {
+    position: absolute;
+    top: 14px;
+    left: 12px;
+    z-index: 3;
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  }
+
+  .catalog-card-select:checked {
+    box-shadow: 0 8px 20px rgba(15, 23, 42, 0.12);
+  }
+
+  .cart-item-select {
+    appearance: none;
+    -webkit-appearance: none;
+    position: relative;
+    display: inline-flex;
+    height: 18px;
+    width: 18px;
+    flex: 0 0 auto;
+    align-items: center;
+    justify-content: center;
+    border-radius: 9999px;
+    border: 1.5px solid #cbd5e0;
+    background: #fff;
+    transition: border-color 160ms ease, background-color 160ms ease, box-shadow 160ms ease;
+    cursor: pointer;
+  }
+
+  .cart-item-select:checked {
+    border-color: #2d3748;
+    background: #2d3748;
+    box-shadow: 0 0 0 3px rgba(45, 55, 72, 0.08);
+  }
+
+  .cart-item-select::after {
+    content: '';
+    width: 8px;
+    height: 5px;
+    border-left: 1.8px solid transparent;
+    border-bottom: 1.8px solid transparent;
+    transform: translateY(-1px) rotate(-45deg);
+  }
+
+  .cart-item-select:checked::after {
+    border-left-color: #fff;
+    border-bottom-color: #fff;
+  }
+
+  #cartSelectionBar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: 14px 8px;
+    border-bottom: 1px solid #e8eef6;
+    margin-bottom: 14px;
+  }
+
+  #cartSelectionDeleteButton {
+    color: #e53e3e;
+    font-size: 13px;
+    font-weight: 600;
+    transition: color 160ms ease, opacity 160ms ease;
+  }
+
+  #cartSelectionDeleteButton:hover {
+    color: #c53030;
+  }
+
+  #cartSelectionDeleteButton.is-disabled {
+    color: #cbd5e0;
+    opacity: 0.65;
+    pointer-events: none;
   }
 
   .product-card-name {
@@ -252,43 +587,267 @@
     background-repeat: no-repeat;
     background-size: 12px 12px;
   }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+
+    .cart-item-card {
+      padding: 14px 12px 12px !important;
+      border-radius: 0 !important;
+    }
+
+    .cart-item-actions {
+      top: 19px !important;
+      right: 12px !important;
+      gap: 6px !important;
+    }
+
+    .cart-item-main {
+      gap: 10px !important;
+      align-items: flex-start !important;
+    }
+
+    .cart-item-media {
+      height: 56px !important;
+      width: 56px !important;
+      border-radius: 14px !important;
+    }
+
+    .cart-item-copy {
+      padding-right: 28px !important;
+    }
+
+    .cart-item-head {
+      align-items: flex-start !important;
+      gap: 8px !important;
+    }
+
+    [data-cart-name],
+    .product-card-name {
+      display: -webkit-box !important;
+      -webkit-box-orient: vertical !important;
+      -webkit-line-clamp: 2 !important;
+      overflow: hidden !important;
+      white-space: normal !important;
+      font-size: 15px !important;
+      line-height: 1.35 !important;
+    }
+
+    .cart-item-meta {
+      margin-top: 6px !important;
+      gap: 6px !important;
+      font-size: 11px !important;
+      line-height: 1.3 !important;
+    }
+
+    .cart-item-footer {
+      margin-top: 10px !important;
+      padding-top: 10px !important;
+      gap: 8px !important;
+      flex-wrap: nowrap !important;
+    }
+
+    .cart-item-stepper {
+      min-width: 0 !important;
+      flex: 0 0 auto !important;
+    }
+
+    .cart-item-total {
+      min-width: 0 !important;
+      flex: 0 0 auto !important;
+      width: 76px !important;
+      height: 28px !important;
+      text-align: right !important;
+    }
+
+    .cart-item-total [data-cart-line-total],
+    .product-card-price {
+      font-size: 16px !important;
+      line-height: 28px !important;
+    }
+
+    .catalog-card-title {
+      font-size: 15px !important;
+      line-height: 1.35 !important;
+    }
+
+    .catalog-card-meta {
+      margin-top: 10px !important;
+      gap: 8px !important;
+    }
+
+    .catalog-card-price,
+    .catalog-card-review {
+      font-size: 16px !important;
+      line-height: 1.25 !important;
+    }
+
+    .catalog-card-review {
+      margin-top: 2px !important;
+      font-size: 11px !important;
+    }
+
+    .catalog-card-action {
+      height: 34px !important;
+      width: 34px !important;
+      font-size: 22px !important;
+    }
+
+    .catalog-card-wishlist {
+      right: 10px !important;
+      bottom: 10px !important;
+      height: 26px !important;
+      width: 26px !important;
+    }
+
+    .catalog-card-select {
+      top: 12px !important;
+      left: 10px !important;
+    }
+
+    #wishlistListViewport {
+      gap: 12px;
+    }
+
+    #cartSelectionBar {
+      padding: 12px 4px;
+      margin-bottom: 12px;
+    }
+  }
+
+  #cartBottomBar {
+    position: absolute;
+    inset: auto 0 0 0;
+    z-index: 36;
+    border-top: 1px solid #e2e8f0;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(16px);
+    box-shadow: 0 -10px 30px rgba(15, 23, 42, 0.08);
+  }
+
+  #cartBottomBarSummary {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    padding: 11px 16px 10px;
+    border-bottom: 1px solid #edf2f7;
+  }
+
+  #cartBottomBarCheckoutButton {
+    display: inline-flex;
+    width: 100%;
+    height: 52px;
+    align-items: center;
+    justify-content: center;
+    border-radius: 0;
+    background: #2d3748;
+    color: #fff;
+    font-size: 14px;
+    font-weight: 700;
+  }
+
+  #cartBottomBarCheckoutButton.is-disabled {
+    background: #a0aec0;
+    color: rgba(255, 255, 255, 0.96);
+    pointer-events: none;
+  }
 </style>
 {% endblock %}
 
 {% block content %}
-<div id="productsPageShell" class="min-h-screen bg-[#f7fafc]">
-  <div id="productsPageInner" class="mx-auto max-w-[1180px] px-4 py-8 md:px-6">
-    <div class="flex items-center justify-start">
-      <a href="/chat/" class="text-[26px] font-bold leading-none text-[#2d3748]" aria-label="메인으로 이동">
-        <span class="text-[#3182ce]">Tail</span><span>Talk</span>
-      </a>
-    </div>
-
-    <div class="product-tabs-row mt-8 flex items-center justify-start">
-      <div class="inline-flex rounded-full border border-[#dbe7f5] bg-white p-[4px] shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
-        <button type="button" id="productsTabCart" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold transition-colors {% if active_tab == 'wishlist' %}text-[#718096] hover:text-[#2d3748]{% else %}bg-[#2d3748] text-white{% endif %}">
-          <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
-            <span class="inline-flex h-[18px] items-center leading-none">장바구니</span>
-            <span id="productsTabCartCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full px-1.5 text-[11px] font-bold leading-none {% if active_tab == 'wishlist' %}bg-[#edf2f7] text-[#4a5568]{% else %}bg-white/18 text-white{% endif %} {% if item_count == 0 %}hidden{% endif %}">
-              <span class="inline-flex h-[18px] items-center">{{ item_count }}</span>
-            </span>
-          </span>
-        </button>
-        <button type="button" id="productsTabWishlist" class="inline-flex h-[38px] min-w-[124px] items-center justify-center rounded-full px-4 text-[13px] font-semibold transition-colors {% if active_tab == 'wishlist' %}bg-[#2d3748] text-white{% else %}text-[#718096] hover:text-[#2d3748]{% endif %}">
-          <span class="inline-flex h-[18px] items-center justify-center gap-3.5">
-            <span class="inline-flex h-[18px] items-center leading-none">관심 상품</span>
-            <span id="productsTabWishlistCount" class="inline-flex h-[18px] min-w-[20px] items-center justify-center rounded-full px-1.5 text-[11px] font-bold leading-none {% if active_tab == 'wishlist' %}bg-white/18 text-white{% else %}bg-[#edf2f7] text-[#4a5568]{% endif %} {% if wishlist_count == 0 %}hidden{% endif %}">
-              <span class="inline-flex h-[18px] items-center">{{ wishlist_count }}</span>
-            </span>
-          </span>
-        </button>
+<div id="pageGate" class="min-h-screen bg-[#f7fafc]">
+  <div id="productsPageShell" class="app-shell" data-active-tab="{{ active_tab }}">
+    <header id="productsHeader">
+      <div id="productsHeaderInner">
+        <div></div>
+        <a href="/chat/" id="productsHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/"
+                 class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/"
+                 class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/"
+                 class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link {% if active_tab != 'wishlist' %}is-active{% endif %} {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if active_tab == 'wishlist' %}is-active{% endif %} {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9.5h10"></path>
+            <path d="M7 14.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
       </div>
     </div>
-
-    <div id="productsLayoutGrid" class="mt-8 grid gap-6 lg:grid-cols-[minmax(0,1fr)_470px]">
-      <section id="productsMainSection" class="min-h-[720px]">
-        <div id="productsPanelCart" class="product-tab-panel {% if active_tab != 'wishlist' %}is-active{% endif %} min-h-[720px]">
-        <div id="cartEmptyState" class="product-empty-state-compact {% if item_count != 0 %}hidden{% endif %} max-w-[650px] rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+    <div id="productsViewport">
+    <div id="productsPageInner">
+    <div id="productsLayoutGrid" class="grid gap-6">
+      <section id="productsMainSection">
+        <div class="mb-0 pl-2">
+          <h1 id="productsPageTitle" class="text-[24px] font-bold leading-[1.25] text-[#2d3748]">{% if active_tab == 'wishlist' %}관심 상품{% else %}장바구니{% endif %}</h1>
+          <div class="mt-3 h-px w-full bg-[#e8eef6]"></div>
+        </div>
+        <div id="cartSelectionBar">
+          <label class="inline-flex items-center gap-2.5 text-[14px] font-semibold text-[#2d3748]">
+            <input type="checkbox"
+                   id="cartSelectAllCheckbox"
+                   class="cart-item-select"
+                   aria-label="장바구니 전체 선택">
+            <span>전체선택</span>
+          </label>
+          <button type="button"
+                  id="cartSelectionDeleteButton"
+                  class="is-disabled"
+                  onclick="removeSelectedCartItems()">
+            선택삭제
+          </button>
+        </div>
+        <div id="productsPanelCart" class="product-tab-panel {% if active_tab != 'wishlist' %}is-active{% endif %}">
+        <div id="cartEmptyState" class="product-empty-state-compact {% if item_count != 0 %}hidden{% endif %} rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
           <div class="product-empty-icon text-[28px] text-[#7aa6e9]">🛒</div>
           <p class="product-empty-title mt-[10px] text-[18px] font-bold text-[#2d3748]">장바구니가 비어 있어요</p>
           <p class="product-empty-copy mt-[6px] text-[14px] leading-[1.6] text-[#718096]">추천 상품 카드에서 +를 눌러<br>장바구니에 상품을 담아보세요</p>
@@ -296,13 +855,12 @@
             채팅으로 돌아가기
           </a>
         </div>
-        <div id="cartListViewport" class="product-list-viewport product-fixed-viewport {% if item_count == 0 %}hidden{% endif %} min-h-[720px] max-w-[650px] space-y-3 lg:pr-2">
+        <div id="cartListViewport" class="product-list-viewport product-fixed-viewport {% if item_count == 0 %}hidden{% endif %}">
         {% for item in cart_items %}
-        <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
+        <article class="cart-item-card relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
                  data-cart-item
                  data-goods-id="{{ item.goods_id }}"
                  data-unit-price="{{ item.price }}"
-                 data-brand="{{ item.brand }}"
                  data-name="{{ item.name }}"
                  data-price-label="{{ item.price_label }}"
                  data-rating="{{ item.rating|default:'-' }}"
@@ -310,9 +868,118 @@
                  data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
                  data-product-url="{{ item.product_url|default:'' }}"
                  data-note="{{ item.note }}">
-          <div class="absolute right-4 top-4 flex items-center gap-2">
+          <div class="cart-item-actions absolute right-4 top-[22px] flex items-center gap-2">
             <button type="button"
-                    class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]"
+                    class="inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[14px] font-bold uppercase text-[#a0aec0] transition-colors hover:text-[#e53e3e]"
+                    aria-label="상품 삭제"
+                    onclick="removeCartItem(this)">X</button>
+          </div>
+          <div class="cart-item-main flex items-start gap-3">
+            {% if item.product_url %}
+            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="cart-item-media relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+              {% else %}
+              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
+            </a>
+            {% else %}
+            <div class="cart-item-media flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]" data-cart-thumbnail-link>
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
+              {% else %}
+              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
+            </div>
+            {% endif %}
+            <div class="cart-item-copy min-w-0 flex-1 pr-14">
+              {% if item.product_url %}
+              <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">{{ item.name }}</a>
+              {% else %}
+              <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]" data-cart-name>{{ item.name }}</p>
+              {% endif %}
+              <div class="cart-item-meta mt-2 flex items-center gap-2 text-[11px]" data-cart-review-row>
+                <span class="font-bold text-[#d69e2e]" data-cart-rating>★ {{ item.rating|default:"-" }}</span>
+                <span class="text-[#a0aec0]" data-cart-review-count>({{ item.review_count }})</span>
+              </div>
+            </div>
+          </div>
+          <div class="cart-item-footer mt-2.5 flex items-center justify-between gap-2.5 border-t border-[#edf2f7] pt-2.5">
+            <div class="flex items-center gap-2.5">
+              <input type="checkbox"
+                     class="cart-item-select"
+                     data-cart-select-checkbox
+                     aria-label="구매할 상품 선택"
+                     checked>
+              <button type="button"
+                      class="wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}inline-flex h-[30px] w-[30px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white leading-none text-[#4a5568] transition-colors"
+                      aria-label="관심 상품 상태 변경"
+                      onclick="toggleWishlistHeart(this)">
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                  <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                </svg>
+                <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                  <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+                </svg>
+              </button>
+            </div>
+            <div class="ml-auto flex items-center gap-2.5">
+            <div class="cart-item-stepper inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">
+              <button type="button"
+                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
+                      onclick="adjustCartQuantity(this, -1)">−</button>
+              <span class="inline-flex min-w-[28px] items-center justify-center px-1" data-cart-quantity>{{ item.quantity }}</span>
+              <button type="button"
+                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
+                      onclick="adjustCartQuantity(this, 1)">+</button>
+            </div>
+            <div class="cart-item-total flex min-w-[96px] items-center justify-end text-right">
+              <p class="leading-none text-[17px] font-bold text-[#2d3748]" data-cart-line-total>{{ item.line_total_label }}</p>
+            </div>
+            </div>
+          </div>
+        </article>
+        {% endfor %}
+        </div>
+        </div>
+
+        <div id="productsPanelWishlist" class="product-tab-panel {% if active_tab == 'wishlist' %}is-active{% endif %}">
+        <div id="wishlistEmptyState" class="product-empty-state-compact hidden rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
+          <div class="product-empty-icon text-[28px] text-[#e97b7b]">♡</div>
+          <p class="product-empty-title mt-[10px] text-[18px] font-bold text-[#2d3748]">관심 상품이 아직 없어요</p>
+          <p class="product-empty-copy mt-[6px] text-[14px] leading-[1.6] text-[#718096]">추천 상품 카드에서 하트를 눌러<br>나중에 볼 상품을 모아보세요</p>
+          <a href="/chat/" class="product-empty-cta mt-6 inline-flex h-[42px] items-center justify-center rounded-full bg-[#2d3748] px-5 text-[13px] font-semibold text-white">
+            채팅으로 돌아가기
+          </a>
+        </div>
+        <div id="wishlistListViewport" class="product-list-viewport product-fixed-viewport">
+        {% for item in wishlist_items %}
+        <article class="wishlist-item-card catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]"
+                 data-wishlist-item
+                 data-goods-id="{{ item.goods_id }}"
+                 data-name="{{ item.name }}"
+                 data-price-label="{{ item.price_label }}"
+                 data-rating="{{ item.rating|default:'-' }}"
+                 data-review-count="{{ item.review_count }}"
+                 data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
+                 data-product-url="{{ item.product_url|default:'' }}"
+                 data-note="{{ item.note }}">
+          {% if item.product_url %}
+          <div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">
+          <input type="checkbox"
+                 class="cart-item-select catalog-card-select"
+                 data-wishlist-select-checkbox
+                 aria-label="관심 상품 선택"
+                 >
+            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="absolute inset-0 block">
+              {% if item.thumbnail_url %}
+              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+              {% else %}
+              <span class="flex h-full w-full items-center justify-center text-[32px] font-bold text-[#90a4b8]">?</span>
+              {% endif %}
+            </a>
+            <button type="button"
+                    class="catalog-card-wishlist wishlist-heart is-active"
                     aria-label="관심 상품 상태 변경"
                     onclick="toggleWishlistHeart(this)">
               <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -322,134 +989,53 @@
                 <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
               </svg>
             </button>
+          </div>
+          {% else %}
+          <div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">
+            <input type="checkbox"
+                   class="cart-item-select catalog-card-select"
+                   data-wishlist-select-checkbox
+                   aria-label="관심 상품 선택"
+                   >
+            {% if item.thumbnail_url %}
+            <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+            {% else %}
+            <span class="flex h-full w-full items-center justify-center text-[32px] font-bold text-[#90a4b8]">?</span>
+            {% endif %}
             <button type="button"
-                    class="inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[14px] font-bold uppercase text-[#a0aec0] transition-colors hover:text-[#e53e3e]"
-                    aria-label="상품 삭제"
-                    onclick="removeCartItem(this)">X</button>
+                    class="catalog-card-wishlist wishlist-heart is-active"
+                    aria-label="관심 상품 상태 변경"
+                    onclick="toggleWishlistHeart(this)">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+              </svg>
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+              </svg>
+            </button>
           </div>
-          <div class="flex items-start gap-3">
+          {% endif %}
+          <div class="catalog-card-body p-4">
             {% if item.product_url %}
-            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">
-              {% if item.thumbnail_url %}
-              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
-              {% else %}
-              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
-              {% endif %}
-            </a>
+            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="catalog-card-title hover:text-[#3182ce]">{{ item.name }}</a>
             {% else %}
-            <div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]" data-cart-thumbnail-link>
-              {% if item.thumbnail_url %}
-              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
-              {% else %}
-              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
-              {% endif %}
-            </div>
+            <p class="catalog-card-title">{{ item.name }}</p>
             {% endif %}
-            <div class="min-w-0 flex-1 pr-14">
-              <div class="flex items-center justify-between gap-3">
-                <p class="truncate text-[12px] font-semibold text-[#90a4b8]" data-cart-brand>{{ item.brand }}</p>
-                <span class="shrink-0 text-[12px] text-[#90a4b8]" data-cart-unit-price>개당 {{ item.price_label }}</span>
+            <div class="catalog-card-meta">
+              <div>
+                <p class="catalog-card-price">₩ {{ item.price_label|cut:"원" }}</p>
+                <p class="catalog-card-review">
+                  <span class="text-[#f6ad55]">★</span>
+                  <span>{{ item.rating|default:"-" }}</span>
+                  <span>({{ item.review_count }})</span>
+                </p>
               </div>
-              {% if item.product_url %}
-              <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">{{ item.name }}</a>
-              {% else %}
-              <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]" data-cart-name>{{ item.name }}</p>
-              {% endif %}
-              <div class="mt-2 flex items-center gap-2 text-[11px]" data-cart-review-row>
-                <span class="font-bold text-[#d69e2e]" data-cart-rating>★ {{ item.rating|default:"-" }}</span>
-                <span class="text-[#a0aec0]" data-cart-review-count>리뷰 {{ item.review_count }}</span>
-              </div>
-            </div>
-          </div>
-          <div class="mt-2.5 flex items-center justify-end gap-2.5 border-t border-[#edf2f7] pt-2.5">
-            <div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">
               <button type="button"
-                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
-                      onclick="adjustCartQuantity(this, -1)">−</button>
-              <span class="inline-flex min-w-[28px] items-center justify-center px-1" data-cart-quantity>{{ item.quantity }}</span>
-              <button type="button"
-                      class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]"
-                      onclick="adjustCartQuantity(this, 1)">+</button>
-            </div>
-            <div class="min-w-[96px] text-right">
-              <p class="text-[17px] font-bold text-[#2d3748]" data-cart-line-total>{{ item.line_total_label }}</p>
-            </div>
-          </div>
-        </article>
-        {% endfor %}
-        </div>
-        </div>
-
-        <div id="productsPanelWishlist" class="product-tab-panel {% if active_tab == 'wishlist' %}is-active{% endif %} min-h-[720px]">
-        <div id="wishlistEmptyState" class="product-empty-state-compact hidden max-w-[650px] rounded-[20px] border border-dashed border-[#dbe7f5] bg-white px-6 py-9 text-center shadow-[0_6px_18px_rgba(45,55,72,0.04)]">
-          <div class="product-empty-icon text-[28px] text-[#e97b7b]">♡</div>
-          <p class="product-empty-title mt-[10px] text-[18px] font-bold text-[#2d3748]">관심 상품이 아직 없어요</p>
-          <p class="product-empty-copy mt-[6px] text-[14px] leading-[1.6] text-[#718096]">추천 상품 카드에서 하트를 눌러<br>나중에 볼 상품을 모아보세요</p>
-          <a href="/chat/" class="product-empty-cta mt-6 inline-flex h-[42px] items-center justify-center rounded-full bg-[#2d3748] px-5 text-[13px] font-semibold text-white">
-            채팅으로 돌아가기
-          </a>
-        </div>
-        <div id="wishlistListViewport" class="product-list-viewport product-fixed-viewport min-h-[720px] max-w-[650px] space-y-3 lg:pr-2">
-        {% for item in wishlist_items %}
-        <article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"
-                 data-wishlist-item
-                 data-goods-id="{{ item.goods_id }}"
-                 data-brand="{{ item.brand }}"
-                 data-name="{{ item.name }}"
-                 data-price-label="{{ item.price_label }}"
-                 data-rating="{{ item.rating|default:'-' }}"
-                 data-review-count="{{ item.review_count }}"
-                 data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
-                 data-product-url="{{ item.product_url|default:'' }}"
-                 data-note="{{ item.note }}">
-          <div class="flex items-center gap-3">
-            {% if item.product_url %}
-            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]">
-              {% if item.thumbnail_url %}
-              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
-              {% else %}
-              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
-              {% endif %}
-            </a>
-            {% else %}
-            <div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">
-              {% if item.thumbnail_url %}
-              <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
-              {% else %}
-              <span class="text-[20px] font-bold text-[#90a4b8]">?</span>
-              {% endif %}
-            </div>
-            {% endif %}
-            <div class="min-w-0 flex-1">
-              <p class="product-card-brand">{{ item.brand }}</p>
-              {% if item.product_url %}
-              <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="product-card-name mt-1 block transition-colors hover:text-[#3182ce]">{{ item.name }}</a>
-              {% else %}
-              <p class="product-card-name mt-1">{{ item.name }}</p>
-              {% endif %}
-              <p class="product-card-price">{{ item.price_label }}</p>
-              <div class="product-card-review-row">
-                <div class="product-card-review-meta">
-                  <span class="font-bold text-[#d69e2e]">★ {{ item.rating|default:"-" }}</span>
-                  <span class="product-card-review-count">리뷰 {{ item.review_count }}</span>
-                </div>
-                <div class="product-card-actions">
-                  <button type="button"
-                          class="wishlist-heart is-active inline-flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]"
-                          aria-label="관심 상품 상태 변경"
-                          onclick="toggleWishlistHeart(this)">
-                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true">
-                      <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
-                    </svg>
-                    <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
-                      <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
-                    </svg>
-                  </button>
-                  <button type="button" class="inline-flex h-[28px] items-center justify-center rounded-full bg-[#2d3748] px-3 text-[12px] font-semibold text-white" onclick="addWishlistToCart(this)">
-                    담기
-                  </button>
-                </div>
-              </div>
+                      class="catalog-card-action"
+                      aria-label="장바구니에 상품 추가"
+                      onclick="addWishlistToCart(this)">
+                <span class="relative top-[-2px]">+</span>
+              </button>
             </div>
           </div>
         </article>
@@ -458,159 +1044,22 @@
         </div>
       </section>
 
-      <aside id="cartPromoPanel" class="{% if item_count == 0 %}flex{% else %}hidden{% endif %} self-start flex-col rounded-[24px] border border-[#dbe7f5] bg-white p-4 shadow-[0_10px_28px_rgba(45,55,72,0.05)]{% if item_count == 0 %} product-promo-compact{% endif %}">
-        <div class="product-promo-list space-y-3">
-          <a href="/chat/" class="product-promo-hero group relative block overflow-hidden rounded-[20px] px-5 py-4 text-white shadow-[0_10px_24px_rgba(45,55,72,0.10)]" style="background: linear-gradient(135deg, #2563eb 0%, #3b82f6 100%);">
-            <div class="pr-[82px]">
-              <p class="text-[11px] font-bold uppercase tracking-[0.08em] text-white/70">추천</p>
-              <p class="product-promo-hero-title mt-2 text-[17px] font-bold leading-[1.3]">상담 후 바로 담는 맞춤 추천</p>
-              <p class="product-promo-hero-copy mt-2 text-[12px] leading-[1.5] text-white/80">채팅에서 추천받고 바로 담아보세요.</p>
-            </div>
-            <div class="absolute right-5 top-4 text-[34px] leading-none">🛍️</div>
-          </a>
+    </div>
+    </div>
+    </div>
+  </div>
 
-          <div class="product-promo-grid grid gap-3">
-            <div class="product-promo-card rounded-[18px] border border-[#dbe7f5] bg-[#f8fbff] px-5 py-4">
-              <div class="flex items-start justify-between gap-4">
-                <div class="pr-[10px]">
-                  <p class="text-[11px] font-bold uppercase tracking-[0.08em] text-[#7aa6e9]">혜택</p>
-                  <p class="product-promo-card-title mt-2 text-[16px] font-bold text-[#2d3748]">사료/간식 인기 상품 모아보기</p>
-                  <p class="product-promo-card-copy mt-2 text-[12px] leading-[1.6] text-[#718096]">많이 담긴 카테고리부터 둘러보세요.</p>
-                </div>
-                <div class="text-[28px] leading-none">🥣</div>
-              </div>
-            </div>
-
-            <div class="product-promo-card rounded-[18px] border border-[#dbe7f5] bg-[#fff7ed] px-5 py-4">
-              <div class="flex items-start justify-between gap-4">
-                <div class="pr-[10px]">
-                  <p class="text-[11px] font-bold uppercase tracking-[0.08em] text-[#f59e0b]">인기</p>
-                  <p class="product-promo-card-title mt-2 text-[16px] font-bold text-[#2d3748]">관심 상품에서 다시 담아보세요</p>
-                  <p class="product-promo-card-copy mt-2 text-[12px] leading-[1.6] text-[#718096]">모아둔 상품을 다시 꺼내 담아보세요.</p>
-                </div>
-                <div class="text-[28px] leading-none">💛</div>
-              </div>
-            </div>
-          </div>
-        </div>
-      </aside>
-
-      <aside id="orderSummaryPanel"
-             data-recipient-name="{{ recipient_name }}"
-             data-recipient-phone="{{ recipient_phone }}"
-             data-postal-code="{{ delivery_postal_code|default:'' }}"
-             data-delivery-address-main="{{ delivery_base_address }}"
-             data-delivery-address-detail="{{ delivery_detail_address }}"
-             data-delivery-address="{{ delivery_base_address }} | {{ delivery_detail_address }}"
-             data-payment-method="{{ payment_method }}"
-             class="{% if item_count == 0 %}hidden{% else %}flex{% endif %} min-h-[720px] flex-col rounded-[24px] border border-[#dbe7f5] bg-white p-6 shadow-[0_10px_28px_rgba(45,55,72,0.05)] lg:sticky lg:top-8">
-        <h2 class="text-[22px] font-bold text-[#2d3748]">주문 정보</h2>
-
-        <div id="checkoutStatusNotice" class="mt-4 hidden rounded-[18px] border border-[#fed7d7] bg-[#fff5f5] px-4 py-4">
-          <p id="checkoutStatusTitle" class="text-[13px] font-semibold text-[#c53030]">주문 전에 확인이 필요해요</p>
-          <p id="checkoutStatusBody" class="mt-1 text-[13px] leading-[1.6] text-[#9b2c2c]">배송지와 결제 수단을 먼저 확인해 주세요.</p>
-          <a href="/profile/" class="mt-3 inline-flex h-[34px] items-center justify-center rounded-full bg-white px-4 text-[12px] font-semibold text-[#c53030]">
-            프로필 보완하기
-          </a>
-        </div>
-
-        <div class="mt-5 grid gap-3 md:grid-cols-2">
-          <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-            <div class="flex items-start justify-between gap-4">
-              <div class="min-w-0 flex-1">
-                <p class="text-[13px] font-semibold text-[#2563eb]">배송 정보</p>
-                <p id="checkoutRecipientName" class="mt-2 text-[13px] font-semibold text-[#4a5568]">{{ recipient_name }}</p>
-                <p id="checkoutDeliveryBaseAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_base_address }}</p>
-                <p id="checkoutDeliveryDetailAddress" class="mt-1 text-[13px] leading-[1.6] text-[#718096]">{{ delivery_detail_address }}</p>
-                <p id="checkoutRecipientPhone" class="mt-1 text-[13px] text-[#718096]">{{ recipient_phone }}</p>
-              </div>
-              <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
-            </div>
-          </div>
-          <div class="rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-            <div class="flex items-start justify-between gap-4">
-              <div class="min-w-0 flex-1">
-                <p class="text-[13px] font-semibold text-[#2563eb]">결제 수단</p>
-                <p id="checkoutPaymentMethod" class="mt-2 text-[13px] leading-[1.6] text-[#718096]">{{ payment_method }}</p>
-              </div>
-              <a href="/profile/" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">수정</a>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-          <div class="flex items-start justify-between gap-4">
-            <div class="min-w-0 flex-1">
-              <p class="text-[13px] font-semibold text-[#2563eb]">배송 메시지</p>
-              <div class="mt-3 rounded-[16px] border border-[#dbe7f5] bg-[#f8fbff] px-4">
-                <select id="deliveryMessageSelect"
-                        class="h-[44px] w-full bg-transparent pr-8 text-[13px] font-medium text-[#4a5568] outline-none">
-                  <option value="직접 입력">직접 입력</option>
-                  <option value="문 앞에 놓아주세요">문 앞에 놓아주세요</option>
-                  <option value="배송 전에 미리 연락해 주세요">배송 전에 미리 연락해 주세요</option>
-                  <option value="부재 시 경비실에 맡겨 주세요">부재 시 경비실에 맡겨 주세요</option>
-                  <option value="부재 시 전화 또는 문자 남겨 주세요">부재 시 전화 또는 문자 남겨 주세요</option>
-                  <option value="배송 시 벨은 누르지 말아 주세요">배송 시 벨은 누르지 말아 주세요</option>
-                  <option value="도착 후 문 앞 사진을 남겨 주세요">도착 후 문 앞 사진을 남겨 주세요</option>
-                </select>
-              </div>
-              <div id="deliveryMessageCustomField" class="mt-2 rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] px-4">
-                <input id="deliveryMessageInput"
-                       type="text"
-                       maxlength="100"
-                       value="{{ delivery_message }}"
-                       placeholder="직접 입력"
-                       class="h-[40px] w-full bg-transparent text-[13px] font-medium text-[#4a5568] outline-none placeholder:text-[#a0aec0]" />
-              </div>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-4 rounded-[18px] border border-[#e2e8f0] bg-white px-4 py-4">
-          <div class="flex items-start justify-between gap-4">
-            <p class="text-[13px] font-semibold text-[#2563eb]">할인 혜택</p>
-            <button type="button" id="openDiscountModalBtn" class="mt-0.5 shrink-0 text-[12px] font-semibold text-[#3182ce]">적용</button>
-          </div>
-          <div class="mt-3 grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)]">
-            <div class="min-w-0">
-              <p class="text-[12px] font-semibold text-[#2d3748]">쿠폰</p>
-              <p id="couponSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ coupon_summary }}</p>
-            </div>
-            <div class="min-w-0 md:pl-4">
-              <p class="text-[12px] font-semibold text-[#2d3748]">마일리지</p>
-              <p id="mileageSummaryText" class="mt-1 truncate text-[13px] text-[#4a5568]">{{ mileage_summary }}</p>
-            </div>
-          </div>
-        </div>
-
-        <div class="mt-5 rounded-[18px] bg-[#f8fbff] px-4 py-4">
-          <p class="text-[13px] font-semibold text-[#2563eb]">결제 금액</p>
-          <div class="mt-4 space-y-3 text-[13px] text-[#4a5568]">
-            <div class="flex items-center justify-between">
-              <span>상품 금액</span>
-              <span class="font-semibold text-[#2d3748]" id="productTotalAmount">{{ product_total }}</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>할인 적용</span>
-              <span class="font-semibold text-[#2563eb]" id="discountTotalAmount">- {{ discount_total }}</span>
-            </div>
-            <div class="flex items-center justify-between">
-              <span>배송비</span>
-              <span class="font-semibold text-[#2d3748]" id="shippingFeeAmount">{{ shipping_fee }}</span>
-            </div>
-          </div>
-          <div id="finalTotalDivider" class="mt-4 border-t border-[#dbe7f5] pt-4">
-            <div class="flex items-center justify-between">
-              <span class="text-[14px] font-semibold text-[#4a5568]">최종 결제 금액</span>
-              <span class="text-[24px] font-bold text-[#2563eb]" id="finalTotalAmount">{{ final_total }}</span>
-            </div>
-          </div>
-        </div>
-
-        <button type="button" id="submitOrderBtn" class="mt-auto inline-flex h-[52px] w-full items-center justify-center rounded-[16px] bg-[#2d3748] text-[15px] font-bold text-white shadow-[0_10px_24px_rgba(45,55,72,0.18)]">
-          주문하기
-        </button>
-      </aside>
+  <div id="cartBottomBar"
+       class="{% if active_tab == 'wishlist' or item_count == 0 %}hidden{% else %}block{% endif %}">
+    <div class="mx-auto w-full max-w-[960px]">
+      <div id="cartBottomBarSummary">
+        <p class="text-[12px] font-semibold text-[#90a4b8]">총 결제 금액</p>
+        <p id="cartBottomBarTotal" class="text-[18px] font-bold leading-none text-[#2d3748]">{{ final_total }}</p>
+      </div>
+      <a href="/checkout/"
+         id="cartBottomBarCheckoutButton">
+        총 <span id="cartBottomBarCount" class="mx-1">{{ item_count }}</span>개 상품 구매하기
+      </a>
     </div>
   </div>
 </div>
@@ -619,127 +1068,29 @@
      class="product-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
   오류가 발생했습니다.
 </div>
-
-<div id="checkoutConfirmModal" class="checkout-confirm-modal fixed inset-0 z-[60] items-center justify-center bg-black/10 px-4"
-     onclick="closeCheckoutConfirmModal(event)">
-  <div class="w-full max-w-[420px] rounded-[20px] border border-[#dbe7f5] bg-white px-8 pb-7 pt-8 shadow-[0_14px_36px_rgba(45,55,72,0.10)]"
-       onclick="event.stopPropagation()">
-    <div class="mx-auto flex h-[81px] w-[81px] items-center justify-center rounded-full border-[4px] border-[#3182ce]">
-      <span class="relative top-[-1px] text-[44px] font-bold leading-none text-[#3182ce]">?</span>
-    </div>
-    <p class="mt-6 text-center text-[19px] font-bold leading-none text-[#2d3748]">주문을 진행할까요?</p>
-    <p class="mt-4 text-center text-[14px] leading-[1.6] text-[#718096]">
-      배송 정보와 결제 금액을 확인한 뒤<br>주문이 접수됩니다.
-    </p>
-    <div class="mt-6 rounded-[14px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-3">
-      <div class="flex items-center justify-between gap-3 text-[13px]">
-        <span class="font-semibold text-[#90a4b8]">최종 결제 금액</span>
-        <span id="checkoutConfirmAmount" class="font-bold text-[#2563eb]">0원</span>
-      </div>
-      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
-        <span class="font-semibold text-[#90a4b8]">수령인</span>
-        <span id="checkoutConfirmRecipient" class="text-right font-semibold text-[#2d3748]"></span>
-      </div>
-      <div class="mt-2 flex items-center justify-between gap-3 text-[13px]">
-        <span class="font-semibold text-[#90a4b8]">연락처</span>
-        <span id="checkoutConfirmPhone" class="text-right font-semibold text-[#2d3748]"></span>
-      </div>
-      <div class="mt-2 flex items-start justify-between gap-3 text-[13px]">
-        <span class="shrink-0 font-semibold text-[#90a4b8]">배송지</span>
-        <span id="checkoutConfirmAddress" class="text-right font-semibold leading-[1.6] text-[#2d3748]"></span>
-      </div>
-    </div>
-    <div class="mt-6 flex h-[42px] items-center justify-between gap-3">
-      <button type="button" onclick="closeCheckoutConfirmModal()"
-              class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#edf2f7] text-[14px] font-bold text-[#4a5568]">
-        취소
-      </button>
-      <button type="button" id="confirmCheckoutSubmitBtn"
-              class="flex h-full flex-1 items-center justify-center rounded-[8px] bg-[#3182ce] text-[14px] font-bold text-white">
-        주문하기
-      </button>
-    </div>
-  </div>
-</div>
-
-<div id="discountBenefitModal" class="discount-modal fixed inset-0 z-50 items-center justify-center bg-[rgba(15,23,42,0.46)] px-4" onclick="closeDiscountModal(event)">
-  <div class="w-full max-w-[520px] rounded-[24px] bg-white px-6 py-6 shadow-[0_20px_60px_rgba(15,23,42,0.24)]">
-    <div class="flex items-start justify-between gap-4">
-      <div>
-        <p class="text-[22px] font-bold text-[#2d3748]">할인 혜택 적용</p>
-        <p class="mt-1 text-[13px] text-[#718096]">쿠폰과 마일리지를 선택하면 주문 정보에 바로 반영됩니다.</p>
-      </div>
-      <button type="button" class="inline-flex h-[28px] w-[28px] items-center justify-center rounded-full text-[16px] font-bold text-[#a0aec0] transition-colors hover:bg-[#f8fbff] hover:text-[#2d3748]" onclick="closeDiscountModal()" aria-label="할인 혜택 모달 닫기">X</button>
-    </div>
-
-    <div class="mt-5 inline-flex rounded-full border border-[#dbe7f5] bg-[#f8fbff] p-[4px]">
-      <button type="button" id="discountTabCoupon" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full bg-[#2d3748] px-4 text-[13px] font-semibold text-white">쿠폰</button>
-      <button type="button" id="discountTabMileage" class="inline-flex h-[36px] min-w-[92px] items-center justify-center rounded-full px-4 text-[13px] font-semibold text-[#718096] transition-colors hover:text-[#2d3748]">마일리지</button>
-    </div>
-
-    <div id="discountPanelCoupon" class="mt-5 space-y-3">
-      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="none" data-coupon-label="적용된 쿠폰 없음" data-coupon-discount="0">
-        <div>
-          <p class="text-[14px] font-semibold text-[#2d3748]">쿠폰 적용 안 함</p>
-          <p class="mt-1 text-[12px] text-[#718096]">할인을 적용하지 않고 현재 금액으로 주문합니다.</p>
-        </div>
-        <span class="text-[13px] font-semibold text-[#718096]">0원</span>
-      </button>
-      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="new-member" data-coupon-label="신규회원 3,000원 할인" data-coupon-discount="3000">
-        <div>
-          <p class="text-[14px] font-semibold text-[#2d3748]">신규회원 3,000원 할인</p>
-          <p class="mt-1 text-[12px] text-[#718096]">30,000원 이상 결제 시 사용 가능</p>
-        </div>
-        <span class="text-[13px] font-semibold text-[#2563eb]">-3,000원</span>
-      </button>
-      <button type="button" class="discount-coupon-option flex w-full items-start justify-between rounded-[18px] border border-[#dbe7f5] bg-white px-4 py-4 text-left transition-colors hover:border-[#90cdf4]" data-coupon-id="pet-care" data-coupon-label="펫케어 5,000원 할인" data-coupon-discount="5000">
-        <div>
-          <p class="text-[14px] font-semibold text-[#2d3748]">펫케어 5,000원 할인</p>
-          <p class="mt-1 text-[12px] text-[#718096]">60,000원 이상 결제 시 사용 가능</p>
-        </div>
-        <span class="text-[13px] font-semibold text-[#2563eb]">-5,000원</span>
-      </button>
-    </div>
-
-    <div id="discountPanelMileage" class="mt-5 hidden">
-      <div class="rounded-[18px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-4">
-        <div class="flex items-center justify-between gap-4">
-          <div>
-            <p class="text-[14px] font-semibold text-[#2d3748]">사용 가능한 마일리지</p>
-            <p class="mt-1 text-[12px] text-[#718096]">보유 마일리지 3,200원</p>
-          </div>
-          <button type="button" id="useAllMileageBtn" class="shrink-0 text-[12px] font-semibold text-[#3182ce]">전액 사용</button>
-        </div>
-        <label class="mt-4 block">
-          <span class="text-[12px] font-semibold text-[#2d3748]">사용할 마일리지</span>
-          <div class="mt-2 flex items-center rounded-[14px] border border-[#dbe7f5] bg-white px-4">
-            <input id="mileageInput" type="number" min="0" max="3200" step="100" value="0" class="h-[48px] w-full bg-transparent text-[15px] font-semibold text-[#2d3748] outline-none" />
-            <span class="shrink-0 text-[13px] font-semibold text-[#718096]">원</span>
-          </div>
-        </label>
-      </div>
-    </div>
-
-    <div class="mt-6 flex items-center justify-between gap-4 rounded-[18px] bg-[#f8fbff] px-4 py-4">
-      <div>
-        <p class="text-[12px] font-semibold text-[#718096]">예상 할인 금액</p>
-        <p id="discountModalPreviewAmount" class="mt-1 text-[22px] font-bold text-[#2563eb]">- 0원</p>
-      </div>
-      <button type="button" id="applyDiscountBtn" class="inline-flex h-[46px] items-center justify-center rounded-[14px] bg-[#2d3748] px-5 text-[14px] font-semibold text-white">적용하기</button>
-    </div>
-  </div>
-</div>
 {% endblock %}
 
 {% block scripts %}
 <script>
 (function () {
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
   var cartTab = document.getElementById('productsTabCart');
   var wishlistTab = document.getElementById('productsTabWishlist');
   var productsPageShell = document.getElementById('productsPageShell');
   var productsPageInner = document.getElementById('productsPageInner');
   var productsLayoutGrid = document.getElementById('productsLayoutGrid');
   var productsMainSection = document.getElementById('productsMainSection');
+  var productsPageTitle = document.getElementById('productsPageTitle');
+  var headerCartNavLink = document.querySelector('.header-subnav-link[href="/products/"]');
+  var headerWishlistNavLink = document.querySelector('.header-subnav-link[href="/wishlist/"]');
+  var cartBottomBar = document.getElementById('cartBottomBar');
+  var cartBottomBarTotal = document.getElementById('cartBottomBarTotal');
+  var cartBottomBarCount = document.getElementById('cartBottomBarCount');
+  var cartBottomBarCheckoutButton = document.getElementById('cartBottomBarCheckoutButton');
+  var cartSelectionBar = document.getElementById('cartSelectionBar');
+  var cartSelectAllCheckbox = document.getElementById('cartSelectAllCheckbox');
+  var cartSelectionDeleteButton = document.getElementById('cartSelectionDeleteButton');
   var cartPanel = document.getElementById('productsPanelCart');
   var wishlistPanel = document.getElementById('productsPanelWishlist');
   var cartEmptyState = document.getElementById('cartEmptyState');
@@ -791,7 +1142,12 @@
   var discountMode = 'coupon';
   var viewportSyncFrame = null;
   var productToastTimer = null;
-  if (!cartTab || !wishlistTab || !cartPanel || !wishlistPanel) return;
+  if (!cartPanel || !wishlistPanel) return;
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
 
   function formatPrice(value) {
     return new Intl.NumberFormat('ko-KR').format(value) + '원';
@@ -829,6 +1185,24 @@
         }
         return data;
       });
+    });
+  }
+
+  function refreshMemberNavIndicators() {
+    return Promise.all([
+      requestJson('/api/orders/cart/'),
+      requestJson('/api/orders/wishlist/'),
+    ]).then(function (results) {
+      var cartData = results[0] || {};
+      var wishlistData = results[1] || {};
+      if (headerCartNavLink) {
+        headerCartNavLink.classList.toggle('has-indicator', !!(cartData.items && cartData.items.length));
+      }
+      if (headerWishlistNavLink) {
+        headerWishlistNavLink.classList.toggle('has-indicator', !!(wishlistData.items && wishlistData.items.length));
+      }
+    }).catch(function () {
+      return null;
     });
   }
 
@@ -952,7 +1326,7 @@
       window.closeCheckoutConfirmModal();
       window.location.href = '/orders/complete/' + orderId + '/?entry=cart';
     }).catch(function (error) {
-      showProductToast(error.message || '주문을 완료하지 못했습니다.');
+      showProductToast(error.message || '주문을 완료하지 못했어요');
       setOrderSubmitLoading(false);
       setConfirmCheckoutLoading(false);
     });
@@ -967,8 +1341,52 @@
     return digits || '0';
   }
 
+  function getSelectedCartItems() {
+    return Array.prototype.filter.call(document.querySelectorAll('[data-cart-item]'), function (item) {
+      var checkbox = item.querySelector('[data-cart-select-checkbox]');
+      return !!checkbox && checkbox.checked;
+    });
+  }
+
+  function getCurrentSelectionSelector() {
+    return cartPanel.classList.contains('is-active')
+      ? '[data-cart-select-checkbox]'
+      : '[data-wishlist-select-checkbox]';
+  }
+
+  function getCurrentSelectableItems() {
+    return Array.prototype.slice.call(
+      document.querySelectorAll(
+        cartPanel.classList.contains('is-active') ? '[data-cart-item]' : '[data-wishlist-item]'
+      )
+    );
+  }
+
+  function syncCartSelectionControls() {
+    var selector = getCurrentSelectionSelector();
+    var selectableItems = getCurrentSelectableItems();
+    var selectedItems = selectableItems.filter(function (item) {
+      var checkbox = item.querySelector(selector);
+      return !!checkbox && checkbox.checked;
+    });
+    var totalCount = selectableItems.length;
+    var selectedCount = selectedItems.length;
+
+    if (cartSelectAllCheckbox) {
+      cartSelectAllCheckbox.checked = totalCount > 0 && selectedCount === totalCount;
+      cartSelectAllCheckbox.indeterminate = selectedCount > 0 && selectedCount < totalCount;
+      cartSelectAllCheckbox.disabled = totalCount === 0;
+    }
+
+    if (cartSelectionDeleteButton) {
+      cartSelectionDeleteButton.classList.toggle('is-disabled', selectedCount === 0);
+      cartSelectionDeleteButton.setAttribute('aria-disabled', selectedCount === 0 ? 'true' : 'false');
+    }
+  }
+
   function updateCartSummary() {
-    var productTotal = 0;
+    var selectedProductTotal = 0;
+    var selectedQuantityTotal = 0;
     document.querySelectorAll('[data-cart-item]').forEach(function (item) {
       var unitPrice = Number(item.getAttribute('data-unit-price') || '0');
       var quantityNode = item.querySelector('[data-cart-quantity]');
@@ -978,22 +1396,42 @@
       if (lineNode) {
         lineNode.textContent = formatPrice(lineTotal);
       }
-      productTotal += lineTotal;
+      var checkbox = item.querySelector('[data-cart-select-checkbox]');
+      if (checkbox && checkbox.checked) {
+        selectedProductTotal += lineTotal;
+        selectedQuantityTotal += quantity;
+      }
     });
 
     var currentDiscountTotal = selectedCouponDiscount + selectedMileageValue;
-    var shippingFee = productTotal > 0 && productTotal < 30000 ? shippingFeeRaw : 0;
-    var finalTotal = Math.max(productTotal - currentDiscountTotal, 0) + shippingFee;
+    var shippingFee = selectedProductTotal > 0 && selectedProductTotal < 30000 ? shippingFeeRaw : 0;
+    var finalTotal = Math.max(selectedProductTotal - currentDiscountTotal, 0) + shippingFee;
 
     var productTotalNode = document.getElementById('productTotalAmount');
     var discountNode = document.getElementById('discountTotalAmount');
     var shippingNode = document.getElementById('shippingFeeAmount');
     var finalTotalNode = document.getElementById('finalTotalAmount');
+    if (cartBottomBarTotal) {
+      cartBottomBarTotal.textContent = formatPrice(finalTotal);
+    }
+    if (cartBottomBarCount) {
+      cartBottomBarCount.textContent = String(selectedQuantityTotal);
+    }
+    if (cartBottomBarCheckoutButton) {
+      var selectedGoodsIds = getSelectedCartItems().map(function (item) {
+        return item.getAttribute('data-goods-id') || '';
+      }).filter(Boolean);
+      var hasSelection = selectedGoodsIds.length > 0;
+      cartBottomBarCheckoutButton.classList.toggle('is-disabled', !hasSelection);
+      cartBottomBarCheckoutButton.setAttribute('aria-disabled', hasSelection ? 'false' : 'true');
+      cartBottomBarCheckoutButton.href = hasSelection ? '/checkout/?items=' + encodeURIComponent(selectedGoodsIds.join(',')) : '#';
+    }
 
-    if (productTotalNode) productTotalNode.textContent = formatPrice(productTotal);
+    if (productTotalNode) productTotalNode.textContent = formatPrice(selectedProductTotal);
     if (discountNode) discountNode.textContent = '- ' + formatPrice(currentDiscountTotal);
     if (shippingNode) shippingNode.textContent = shippingFee === 0 ? '무료' : formatPrice(shippingFee);
     if (finalTotalNode) finalTotalNode.textContent = formatPrice(finalTotal);
+    syncCartSelectionControls();
   }
 
   function updateCartQuantityBadge() {
@@ -1013,7 +1451,6 @@
       var quantityNode = item.querySelector('[data-cart-quantity]');
       items.push({
         goodsId: item.getAttribute('data-goods-id') || '',
-        brand: item.getAttribute('data-brand') || '',
         name: item.getAttribute('data-name') || '',
         price: Number(item.getAttribute('data-unit-price') || '0'),
         priceLabel: item.getAttribute('data-price-label') || formatPrice(Number(item.getAttribute('data-unit-price') || '0')),
@@ -1050,7 +1487,6 @@
     if (!item || !cartItem) return;
 
     item.setAttribute('data-unit-price', String(cartItem.price || 0));
-    item.setAttribute('data-brand', cartItem.brand || '');
     item.setAttribute('data-name', cartItem.name || '상품');
     item.setAttribute('data-price-label', cartItem.price_label || formatPrice(Number(cartItem.price || 0)));
     item.setAttribute('data-rating', cartItem.rating || '-');
@@ -1068,16 +1504,6 @@
       lineTotalNode.textContent = cartItem.line_total_label || formatPrice(Number(cartItem.line_total || 0));
     }
 
-    var brandNode = item.querySelector('[data-cart-brand]');
-    if (brandNode) {
-      brandNode.textContent = cartItem.brand || '';
-    }
-
-    var unitPriceNode = item.querySelector('[data-cart-unit-price]');
-    if (unitPriceNode) {
-      unitPriceNode.textContent = '개당 ' + (cartItem.price_label || formatPrice(Number(cartItem.price || 0)));
-    }
-
     var nameNode = item.querySelector('[data-cart-name]');
     if (nameNode) {
       var nextNameMarkup = cartNameMarkup(cartItem.product_url || '', cartItem.name || '상품');
@@ -1086,21 +1512,13 @@
       nameNode.replaceWith(nameTemplate.content.firstElementChild);
     }
 
-    var thumbnailNode = item.querySelector('[data-cart-thumbnail-link]');
-    if (thumbnailNode) {
-      var nextThumbnailMarkup = cartThumbnailMarkup(cartItem.product_url || '', cartItem.thumbnail_url || '', cartItem.name || '상품');
-      var thumbnailTemplate = document.createElement('template');
-      thumbnailTemplate.innerHTML = nextThumbnailMarkup.trim();
-      thumbnailNode.replaceWith(thumbnailTemplate.content.firstElementChild);
-    }
-
     var ratingNode = item.querySelector('[data-cart-rating]');
     if (ratingNode) {
       ratingNode.textContent = '★ ' + (cartItem.rating || '-');
     }
     var reviewCountNode = item.querySelector('[data-cart-review-count]');
     if (reviewCountNode) {
-      reviewCountNode.textContent = '리뷰 ' + normalizeReviewCount(cartItem.review_count || '0');
+      reviewCountNode.textContent = '(' + normalizeReviewCount(cartItem.review_count || '0') + ')';
     }
   }
 
@@ -1131,6 +1549,23 @@
     if (wishlistCountBadge) {
       wishlistCountBadge.textContent = String(wishlistCount);
       wishlistCountBadge.classList.toggle('hidden', wishlistCount === 0);
+    }
+
+    if (headerCartNavLink) {
+      headerCartNavLink.classList.toggle('has-indicator', cartCount > 0);
+    }
+
+    if (cartBottomBar) {
+      cartBottomBar.classList.toggle('hidden', !cartActive || cartCount === 0);
+      cartBottomBar.classList.toggle('block', cartActive && cartCount > 0);
+    }
+
+    if (cartSelectionBar) {
+      cartSelectionBar.classList.toggle('hidden', !cartActive);
+    }
+
+    if (headerWishlistNavLink) {
+      headerWishlistNavLink.classList.toggle('has-indicator', wishlistCount > 0);
     }
 
     if (wishlistEmptyState) {
@@ -1169,6 +1604,7 @@
     }
 
     scheduleViewportSync();
+    syncCartSelectionControls();
   }
 
   function escapeHtml(value) {
@@ -1235,30 +1671,11 @@
   }
 
   function syncProductViewportHeights() {
-    if (!cartListViewport || !wishlistListViewport || !finalTotalDivider || !orderSummaryPanel) return;
-
+    if (!cartListViewport || !wishlistListViewport) return;
     cartListViewport.style.removeProperty('height');
     cartListViewport.style.removeProperty('max-height');
     wishlistListViewport.style.removeProperty('height');
     wishlistListViewport.style.removeProperty('max-height');
-
-    if (orderSummaryPanel.classList.contains('hidden')) return;
-
-    var dividerTop = finalTotalDivider.getBoundingClientRect().top;
-    var cartTop = cartListViewport.getBoundingClientRect().top;
-    var wishlistTop = wishlistListViewport.getBoundingClientRect().top;
-    var cartHeight = Math.floor(dividerTop - cartTop);
-    var wishlistHeight = Math.floor(dividerTop - wishlistTop);
-
-    if (cartHeight > 0) {
-      cartListViewport.style.setProperty('height', cartHeight + 'px');
-      cartListViewport.style.setProperty('max-height', cartHeight + 'px');
-    }
-
-    if (wishlistHeight > 0) {
-      wishlistListViewport.style.setProperty('height', wishlistHeight + 'px');
-      wishlistListViewport.style.setProperty('max-height', wishlistHeight + 'px');
-    }
   }
 
   function scheduleViewportSync() {
@@ -1322,11 +1739,10 @@
     var nameHtml = cartNameMarkup(data.productUrl || '', data.name || '상품');
 
     return [
-      '<article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"',
+      '<article class="cart-item-card relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]"',
       ' data-cart-item',
       ' data-goods-id="' + escapeHtml(data.goodsId) + '"',
       ' data-unit-price="' + escapeHtml(data.price) + '"',
-      ' data-brand="' + escapeHtml(data.brand) + '"',
       ' data-name="' + escapeHtml(data.name) + '"',
       ' data-price-label="' + escapeHtml(data.priceLabel) + '"',
       ' data-rating="' + escapeHtml(data.rating) + '"',
@@ -1334,31 +1750,32 @@
       ' data-thumbnail-url="' + escapeHtml(data.thumbnailUrl) + '"',
       ' data-product-url="' + productUrl + '"',
       ' data-note="' + escapeHtml(data.note) + '">',
-      '<div class="absolute right-4 top-4 flex items-center gap-2">',
-      '<button type="button" class="wishlist-heart ' + (data.isWishlisted ? 'is-active ' : '') + 'inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)">',
-      '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
-      '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>',
-      '</button>',
+      '<div class="cart-item-actions absolute right-4 top-[22px] flex items-center gap-2">',
       '<button type="button" class="inline-flex h-[18px] w-[18px] items-center justify-center leading-none text-[14px] font-bold uppercase text-[#a0aec0] transition-colors hover:text-[#e53e3e]" aria-label="상품 삭제" onclick="removeCartItem(this)">X</button>',
       '</div>',
-      '<div class="flex items-start gap-3">',
+      '<div class="cart-item-main flex items-start gap-3">',
       thumbnailHtml,
-      '<div class="min-w-0 flex-1 pr-14">',
-      '<div class="flex items-center justify-between gap-3">',
-      '<p class="truncate text-[12px] font-semibold text-[#90a4b8]" data-cart-brand>' + escapeHtml(data.brand) + '</p>',
-      '<span class="shrink-0 text-[12px] text-[#90a4b8]" data-cart-unit-price>개당 ' + escapeHtml(data.priceLabel) + '</span>',
-      '</div>',
+      '<div class="cart-item-copy min-w-0 flex-1 pr-14">',
       nameHtml,
-      '<div class="mt-2 flex items-center gap-2 text-[11px]" data-cart-review-row><span class="font-bold text-[#d69e2e]" data-cart-rating>★ ' + escapeHtml(data.rating) + '</span><span class="text-[#a0aec0]" data-cart-review-count>리뷰 ' + escapeHtml(data.reviewCount) + '</span></div>',
+      '<div class="cart-item-meta mt-2 flex items-center gap-2 text-[11px]" data-cart-review-row><span class="font-bold text-[#d69e2e]" data-cart-rating>★ ' + escapeHtml(data.rating) + '</span><span class="text-[#a0aec0]" data-cart-review-count>(' + escapeHtml(data.reviewCount) + ')</span></div>',
       '</div>',
       '</div>',
-      '<div class="mt-2.5 flex items-center justify-end gap-2.5 border-t border-[#edf2f7] pt-2.5">',
-      '<div class="inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">',
+      '<div class="cart-item-footer mt-2.5 flex items-center justify-between gap-2.5 border-t border-[#edf2f7] pt-2.5">',
+      '<div class="flex items-center gap-2.5">',
+      '<input type="checkbox" class="cart-item-select" data-cart-select-checkbox aria-label="구매할 상품 선택" checked>',
+      '<button type="button" class="wishlist-heart ' + (data.isWishlisted ? 'is-active ' : '') + 'inline-flex h-[30px] w-[30px] items-center justify-center rounded-full border border-[#dbe7f5] bg-white leading-none text-[#4a5568] transition-colors" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)">',
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
+      '<svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>',
+      '</button>',
+      '</div>',
+      '<div class="ml-auto flex items-center gap-2.5">',
+      '<div class="cart-item-stepper inline-flex items-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] px-[3px] py-[2px] text-[12px] font-semibold text-[#2d3748]">',
       '<button type="button" class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]" onclick="adjustCartQuantity(this, -1)">−</button>',
       '<span class="inline-flex min-w-[28px] items-center justify-center px-1" data-cart-quantity>' + escapeHtml(data.quantity) + '</span>',
       '<button type="button" class="flex h-[22px] w-[22px] items-center justify-center rounded-full bg-white text-[13px]" onclick="adjustCartQuantity(this, 1)">+</button>',
       '</div>',
-      '<div class="min-w-[96px] text-right"><p class="text-[17px] font-bold text-[#2d3748]" data-cart-line-total>' + escapeHtml(formatPrice(Number(data.price || 0) * Number(data.quantity || 1))) + '</p></div>',
+      '<div class="cart-item-total flex min-w-[96px] items-center justify-end text-right"><p class="leading-none text-[17px] font-bold text-[#2d3748]" data-cart-line-total>' + escapeHtml(formatPrice(Number(data.price || 0) * Number(data.quantity || 1))) + '</p></div>',
+      '</div>',
       '</div>',
       '</article>'
     ].join('');
@@ -1367,19 +1784,21 @@
   function wishlistItemMarkup(data) {
     var thumbnail = data.thumbnailUrl
       ? '<img src="' + escapeHtml(data.thumbnailUrl) + '" alt="' + escapeHtml(data.name) + '" class="h-full w-full object-cover" />'
-      : '<span class="text-[20px] font-bold text-[#90a4b8]">?</span>';
+      : '<span class="flex h-full w-full items-center justify-center text-[32px] font-bold text-[#90a4b8]">?</span>';
     var productUrl = escapeHtml(data.productUrl || '');
-    var thumbnailHtml = productUrl
-      ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]">' + thumbnail + '</a>'
-      : '<div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]">' + thumbnail + '</div>';
+    var checkboxHtml = '<input type="checkbox" class="cart-item-select catalog-card-select" data-wishlist-select-checkbox aria-label="관심 상품 선택">';
+    var thumbnailHtml = (
+      productUrl
+        ? '<div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">' + checkboxHtml + '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="absolute inset-0 block">' + thumbnail + '</a><button type="button" class="catalog-card-wishlist wishlist-heart is-active" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg></button></div>'
+        : '<div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">' + checkboxHtml + thumbnail + '<button type="button" class="catalog-card-wishlist wishlist-heart is-active" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg></button></div>'
+    );
     var nameHtml = productUrl
-      ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="product-card-name mt-1 block transition-colors hover:text-[#3182ce]">' + escapeHtml(data.name) + '</a>'
-      : '<p class="product-card-name mt-1">' + escapeHtml(data.name) + '</p>';
+      ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="catalog-card-title hover:text-[#3182ce]">' + escapeHtml(data.name) + '</a>'
+      : '<p class="catalog-card-title">' + escapeHtml(data.name) + '</p>';
 
     return [
-      '<article class="relative rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-4 shadow-[0_6px_18px_rgba(45,55,72,0.04)]" data-wishlist-item',
+      '<article class="wishlist-item-card catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]" data-wishlist-item',
       ' data-goods-id="' + escapeHtml(data.goodsId) + '"',
-      ' data-brand="' + escapeHtml(data.brand) + '"',
       ' data-name="' + escapeHtml(data.name) + '"',
       ' data-price="' + escapeHtml(data.price) + '"',
       ' data-price-label="' + escapeHtml(data.priceLabel) + '"',
@@ -1388,21 +1807,12 @@
       ' data-thumbnail-url="' + escapeHtml(data.thumbnailUrl) + '"',
       ' data-product-url="' + productUrl + '"',
       ' data-note="' + escapeHtml(data.note) + '">',
-      '<div class="flex items-center gap-3">',
       thumbnailHtml,
-      '<div class="min-w-0 flex-1">',
-      '<p class="product-card-brand">' + escapeHtml(data.brand) + '</p>',
+      '<div class="catalog-card-body p-4">',
       nameHtml,
-      '<p class="product-card-price">' + escapeHtml(data.priceLabel) + '</p>',
-      '<div class="product-card-review-row">',
-      '<div class="product-card-review-meta"><span class="font-bold text-[#d69e2e]">★ ' + escapeHtml(data.rating) + '</span><span class="product-card-review-count">리뷰 ' + escapeHtml(data.reviewCount) + '</span></div>',
-      '<div class="product-card-actions">',
-      '<button type="button" class="wishlist-heart is-active inline-flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none text-[#4a5568] transition-colors hover:text-[#e53e3e]" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)">',
-      '<svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>',
-      '<svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>',
-      '</button>',
-      '<button type="button" class="inline-flex h-[28px] items-center justify-center rounded-full bg-[#2d3748] px-3 text-[12px] font-semibold text-white" onclick="addWishlistToCart(this)">담기</button>',
-      '</div>',
+      '<div class="catalog-card-meta">',
+      '<div><p class="catalog-card-price">₩ ' + escapeHtml(String(data.priceLabel).replace(/원/g, "")) + '</p><p class="catalog-card-review"><span class="text-[#f6ad55]">★</span><span>' + escapeHtml(data.rating) + '</span><span>(' + escapeHtml(data.reviewCount) + ')</span></p></div>',
+      '<button type="button" class="catalog-card-action" aria-label="장바구니에 상품 추가" onclick="addWishlistToCart(this)"><span class="relative top-[-2px]">+</span></button>',
       '</div>',
       '</div>',
       '</article>'
@@ -1412,7 +1822,6 @@
   function getCartItemData(item) {
     return {
       goodsId: item.getAttribute('data-goods-id') || '',
-      brand: item.getAttribute('data-brand') || '',
       name: item.getAttribute('data-name') || '',
       price: Number(item.getAttribute('data-unit-price') || '0'),
       priceLabel: item.getAttribute('data-price-label') || '',
@@ -1426,18 +1835,25 @@
 
   function setActiveTab(tab) {
     var cartActive = tab === 'cart';
+    if (productsPageTitle) {
+      productsPageTitle.textContent = cartActive ? '장바구니' : '관심 상품';
+    }
     cartPanel.classList.toggle('is-active', cartActive);
     wishlistPanel.classList.toggle('is-active', !cartActive);
 
-    cartTab.classList.toggle('bg-[#2d3748]', cartActive);
-    cartTab.classList.toggle('text-white', cartActive);
-    cartTab.classList.toggle('text-[#718096]', !cartActive);
-    cartTab.classList.toggle('hover:text-[#2d3748]', !cartActive);
+    if (cartTab) {
+      cartTab.classList.toggle('bg-[#2d3748]', cartActive);
+      cartTab.classList.toggle('text-white', cartActive);
+      cartTab.classList.toggle('text-[#718096]', !cartActive);
+      cartTab.classList.toggle('hover:text-[#2d3748]', !cartActive);
+    }
 
-    wishlistTab.classList.toggle('bg-[#2d3748]', !cartActive);
-    wishlistTab.classList.toggle('text-white', !cartActive);
-    wishlistTab.classList.toggle('text-[#718096]', cartActive);
-    wishlistTab.classList.toggle('hover:text-[#2d3748]', cartActive);
+    if (wishlistTab) {
+      wishlistTab.classList.toggle('bg-[#2d3748]', !cartActive);
+      wishlistTab.classList.toggle('text-white', !cartActive);
+      wishlistTab.classList.toggle('text-[#718096]', cartActive);
+      wishlistTab.classList.toggle('hover:text-[#2d3748]', cartActive);
+    }
 
     if (cartCountBadge) {
       cartCountBadge.classList.toggle('bg-white/18', cartActive);
@@ -1458,13 +1874,11 @@
   }
 
   function applyInitialProductsTab() {
-    try {
-      var params = new URLSearchParams(window.location.search || '');
-      if (params.get('tab') === 'wishlist') {
-        setActiveTab('wishlist');
-        return;
-      }
-    } catch (error) {}
+    var initialTab = '{{ active_tab|escapejs }}';
+    if (initialTab === 'wishlist') {
+      setActiveTab('wishlist');
+      return;
+    }
     setActiveTab('cart');
   }
 
@@ -1474,7 +1888,6 @@
     items.forEach(function (item) {
       wishlistListViewport.insertAdjacentHTML('beforeend', wishlistItemMarkup({
         goodsId: item.product_id || item.goodsId,
-        brand: item.brand || '',
         name: item.name || '상품',
         price: Number(item.price || 0),
         priceLabel: item.price_label || item.priceLabel || formatPrice(Number(item.price || 0)),
@@ -1507,7 +1920,6 @@
       (cartData.items || []).forEach(function (item) {
         cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup({
           goodsId: item.product_id,
-          brand: item.brand || '',
           name: item.name || '상품',
           price: Number(item.price || 0),
           priceLabel: item.price_label || formatPrice(Number(item.price || 0)),
@@ -1537,7 +1949,7 @@
         window.scrollTo(0, preservedWindowScrollY);
       });
     }).catch(function (error) {
-      showProductToast(error.message || '장바구니 정보를 불러오지 못했습니다.');
+      showProductToast(error.message || '장바구니 정보를 불러오지 못했어요');
     });
   }
 
@@ -1549,17 +1961,23 @@
     if (cartItem) {
       var goodsId = cartItem.getAttribute('data-goods-id');
       if (!goodsId) {
-        showProductToast('상품 식별 정보를 찾을 수 없습니다.');
+        showProductToast('상품 식별 정보를 찾을 수 없습니다');
         return;
       }
       var nextActive = !button.classList.contains('is-active');
+      button.disabled = true;
       requestJson('/api/orders/wishlist/', {
         method: nextActive ? 'POST' : 'DELETE',
         body: JSON.stringify({ product_id: goodsId }),
       }).then(function () {
-        return refreshProductsData();
+        button.classList.toggle('is-active', nextActive);
+        updateTabCounts();
+        refreshMemberNavIndicators();
+        showProductToast(nextActive ? '관심상품에 담았어요' : '관심상품에서 뺐어요');
       }).catch(function (error) {
-        showProductToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+        showProductToast(error.message || '관심상품을 변경하지 못했어요');
+      }).finally(function () {
+        button.disabled = false;
       });
       return;
     }
@@ -1567,27 +1985,38 @@
     if (wishlistItem) {
       var goodsId = wishlistItem.getAttribute('data-goods-id');
       if (!goodsId) {
-        showProductToast('상품 식별 정보를 찾을 수 없습니다.');
+        showProductToast('상품 식별 정보를 찾을 수 없습니다');
         return;
       }
+      button.disabled = true;
       requestJson('/api/orders/wishlist/', {
         method: 'DELETE',
         body: JSON.stringify({ product_id: goodsId }),
       }).then(function () {
-        return refreshProductsData();
+        wishlistItem.remove();
+        updateTabCounts();
+        refreshMemberNavIndicators();
+        scheduleViewportSync();
+        showProductToast('관심상품에서 뺐어요');
       }).catch(function (error) {
-        showProductToast(error.message || '관심 상품 상태를 변경하지 못했습니다.');
+        showProductToast(error.message || '관심상품을 변경하지 못했어요');
+      }).finally(function () {
+        button.disabled = false;
       });
     }
   };
 
-  cartTab.addEventListener('click', function () {
-    setActiveTab('cart');
-  });
+  if (cartTab) {
+    cartTab.addEventListener('click', function () {
+      setActiveTab('cart');
+    });
+  }
 
-  wishlistTab.addEventListener('click', function () {
-    setActiveTab('wishlist');
-  });
+  if (wishlistTab) {
+    wishlistTab.addEventListener('click', function () {
+      setActiveTab('wishlist');
+    });
+  }
 
   window.adjustCartQuantity = function (button, delta) {
     var item = button.closest('[data-cart-item]');
@@ -1608,7 +2037,7 @@
       updateCartSummary();
       updateCartQuantityBadge();
     }).catch(function (error) {
-      showProductToast(error.message || '장바구니 수량을 변경하지 못했습니다.');
+      showProductToast(error.message || '장바구니 수량을 변경하지 못했어요');
     });
   };
 
@@ -1621,7 +2050,40 @@
     }).then(function () {
       return refreshProductsData();
     }).catch(function (error) {
-      showProductToast(error.message || '장바구니 상품을 삭제하지 못했습니다.');
+      showProductToast(error.message || '장바구니 상품을 삭제하지 못했어요');
+    });
+  };
+
+  window.removeSelectedCartItems = function () {
+    var cartActive = cartPanel.classList.contains('is-active');
+    var selector = getCurrentSelectionSelector();
+    var selectedItems = getCurrentSelectableItems().filter(function (item) {
+      var checkbox = item.querySelector(selector);
+      return !!checkbox && checkbox.checked;
+    });
+    if (!selectedItems.length) {
+      showProductToast('삭제할 상품을 먼저 선택해 주세요');
+      return;
+    }
+
+    if (cartSelectionDeleteButton) {
+      cartSelectionDeleteButton.classList.add('is-disabled');
+      cartSelectionDeleteButton.setAttribute('aria-disabled', 'true');
+    }
+
+    Promise.all(selectedItems.map(function (item) {
+      return requestJson(cartActive ? '/api/orders/cart/' : '/api/orders/wishlist/', {
+        method: 'DELETE',
+        body: JSON.stringify({ product_id: item.getAttribute('data-goods-id') }),
+      });
+    })).then(function () {
+      return refreshProductsData();
+    }).then(function () {
+      showProductToast('선택한 상품을 삭제했어요');
+    }).catch(function (error) {
+      showProductToast(error.message || '선택한 상품을 삭제하지 못했어요');
+    }).finally(function () {
+      syncCartSelectionControls();
     });
   };
 
@@ -1637,7 +2099,7 @@
     }).then(function () {
       return refreshProductsData();
     }).catch(function (error) {
-      showProductToast(error.message || '장바구니에 상품을 담지 못했습니다.');
+      showProductToast(error.message || '장바구니에 담지 못했어요');
     });
   };
 
@@ -1711,7 +2173,7 @@
       var validation = validateCheckoutState();
       syncCheckoutNotice();
       if (!validation.valid) {
-        showProductToast(validation.message || '주문 전에 필수 정보를 먼저 확인해 주세요.');
+        showProductToast(validation.message || '주문 전에 필수 정보를 먼저 확인해 주세요');
         return;
       }
       updateCheckoutConfirmSummary();
@@ -1725,6 +2187,28 @@
     confirmCheckoutSubmitBtn.addEventListener('click', submitOrderRequest);
   }
 
+  document.addEventListener('click', function (event) {
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+  });
+
+  document.addEventListener('change', function (event) {
+    if (event.target && (event.target.matches('[data-cart-select-checkbox]') || event.target.matches('[data-wishlist-select-checkbox]'))) {
+      updateCartSummary();
+    }
+  });
+
+  if (cartSelectAllCheckbox) {
+    cartSelectAllCheckbox.addEventListener('change', function () {
+      var shouldCheck = !!cartSelectAllCheckbox.checked;
+      document.querySelectorAll(getCurrentSelectionSelector()).forEach(function (checkbox) {
+        checkbox.checked = shouldCheck;
+      });
+      updateCartSummary();
+    });
+  }
+
   var cartListViewport = document.getElementById('cartListViewport');
 
   function renderCartFromState(items) {
@@ -1735,7 +2219,6 @@
       if (!goodsId) return;
       cartListViewport.insertAdjacentHTML('beforeend', cartItemMarkup({
         goodsId: goodsId,
-        brand: item.brand || '',
         name: item.name || '상품',
         price: Number(item.price || 0),
         priceLabel: item.price_label || item.priceLabel || formatPrice(Number(item.price || 0)),
@@ -1759,7 +2242,9 @@
   syncCheckoutSummaryPreview();
   syncCheckoutNotice();
   applyInitialProductsTab();
-  refreshProductsData();
+  updateCartSummary();
+  updateTabCounts();
+  scheduleViewportSync();
   window.addEventListener('resize', scheduleViewportSync);
 })();
 </script>

--- a/services/django/templates/users/login.html
+++ b/services/django/templates/users/login.html
@@ -5,23 +5,25 @@
 {% block content %}
 <div class="auth-legacy-shell min-h-screen bg-[#f7fafc]">
   <div class="relative h-screen w-full overflow-hidden bg-[#f7fafc] flex items-center justify-center auth-legacy-scale">
-    <div class="relative h-[244px] w-[400px] max-w-[calc(100vw-32px)] overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white shadow-[0_16px_40px_rgba(45,55,72,0.08)] auth-legacy-card" id="authLegacyCard" data-ready="true">
+    <div class="relative flex h-[244px] w-[400px] max-w-[calc(100vw-32px)] flex-col items-center overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white px-[32px] pt-[32px] shadow-[0_16px_40px_rgba(45,55,72,0.08)] auth-legacy-card" id="authLegacyCard" data-ready="true">
       <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(247,250,252,0.98)_100%)]"></div>
 
       <a
         href="/"
-        class="absolute left-[151px] top-[33px] h-[31px] w-[98px] text-center text-[26px] font-bold leading-none text-[#2d3748]"
+        class="relative z-[1] h-[31px] text-center text-[26px] font-bold leading-none text-[#2d3748]"
       >
         <span class="text-[#3182ce]">Tail</span><span>Talk</span>
       </a>
 
-      <div class="absolute left-[40px] top-[84px] h-px w-[60px] bg-[#dbe7f5]"></div>
-      <div class="auth-legacy-divider-label absolute left-[156px] top-[74px] h-[20px] w-[88px]">
-        <p class="auth-legacy-divider-text">간편 로그인</p>
+      <div class="relative z-[1] mt-[18px] flex w-full items-center gap-[16px]">
+        <div class="h-px flex-1 bg-[#dbe7f5]"></div>
+        <div class="auth-legacy-divider-label h-[20px] shrink-0">
+          <p class="auth-legacy-divider-text">간편 로그인</p>
+        </div>
+        <div class="h-px flex-1 bg-[#dbe7f5]"></div>
       </div>
-      <div class="absolute left-[300px] top-[84px] h-px w-[60px] bg-[#dbe7f5]"></div>
 
-      <div class="absolute left-[106px] top-[114px] flex h-[48px] w-[188px] items-center justify-between">
+      <div class="relative z-[1] mt-[20px] flex h-[48px] w-[188px] items-center justify-between">
         <a href="/auth/kakao/start/?remember=on" data-social-link aria-label="카카오 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#FEE500]">
           <svg viewBox="0 0 40 40" class="relative left-[0.5px] block h-[30px] w-[30px]" aria-hidden="true">
             <path fill="#191919" d="M20 8.2c-6.6 0-12 4.25-12 9.5 0 3.39 2.2 6.37 5.52 8.06l-1.4 5.1c-.07.28.23.5.48.36l5.98-3.95c.47.05.94.08 1.42.08 6.63 0 12-4.25 12-9.5s-5.37-9.55-12-9.55Z"/>
@@ -43,7 +45,7 @@
       </div>
       <button
         type="button"
-        class="auth-legacy-remember absolute left-[140px] top-[186px] h-[26px] w-[148px]"
+        class="auth-legacy-remember relative z-[1] mt-[24px] h-[26px] w-[148px] translate-x-[24px]"
         id="rememberToggle"
         aria-pressed="true"
       >
@@ -52,7 +54,7 @@
             <path d="M1 4L3.5 6.5L9 1"></path>
           </svg>
         </span>
-        <span class="auth-legacy-remember-text">로그인 상태 유지</span>
+        <span class="auth-legacy-remember-text">로그인 유지</span>
       </button>
     </div>
   </div>

--- a/services/django/templates/users/signup.html
+++ b/services/django/templates/users/signup.html
@@ -5,23 +5,25 @@
 {% block content %}
 <div class="auth-legacy-shell min-h-screen bg-[#f7fafc]">
   <div class="relative h-screen w-full overflow-hidden bg-[#f7fafc] flex items-center justify-center auth-legacy-scale">
-    <div class="relative h-[244px] w-[400px] max-w-[calc(100vw-32px)] overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white shadow-[0_16px_40px_rgba(45,55,72,0.08)] auth-legacy-card" id="authLegacyCard" data-ready="true">
+    <div class="relative flex h-[244px] w-[400px] max-w-[calc(100vw-32px)] flex-col items-center overflow-hidden rounded-[24px] border border-[#dbe7f5] bg-white px-[32px] pt-[32px] shadow-[0_16px_40px_rgba(45,55,72,0.08)] auth-legacy-card" id="authLegacyCard" data-ready="true">
       <div class="absolute inset-0 bg-[linear-gradient(180deg,rgba(255,255,255,0.96)_0%,rgba(247,250,252,0.98)_100%)]"></div>
 
       <a
         href="/"
-        class="absolute left-[151px] top-[33px] h-[31px] w-[98px] text-center text-[26px] font-bold leading-none text-[#2d3748]"
+        class="relative z-[1] h-[31px] text-center text-[26px] font-bold leading-none text-[#2d3748]"
       >
         <span class="text-[#3182ce]">Tail</span><span>Talk</span>
       </a>
 
-      <div class="absolute left-[40px] top-[84px] h-px w-[60px] bg-[#dbe7f5]"></div>
-      <div class="auth-legacy-divider-label absolute left-[156px] top-[74px] h-[20px] w-[88px]">
-        <p class="auth-legacy-divider-text">간편 로그인</p>
+      <div class="relative z-[1] mt-[18px] flex w-full items-center gap-[16px]">
+        <div class="h-px flex-1 bg-[#dbe7f5]"></div>
+        <div class="auth-legacy-divider-label h-[20px] shrink-0">
+          <p class="auth-legacy-divider-text">간편 로그인</p>
+        </div>
+        <div class="h-px flex-1 bg-[#dbe7f5]"></div>
       </div>
-      <div class="absolute left-[300px] top-[84px] h-px w-[60px] bg-[#dbe7f5]"></div>
 
-      <div class="absolute left-[106px] top-[114px] flex h-[48px] w-[188px] items-center justify-between">
+      <div class="relative z-[1] mt-[20px] flex h-[48px] w-[188px] items-center justify-between">
         <a href="/auth/kakao/start/?remember=on" data-social-link aria-label="카카오 로그인" class="flex h-[40px] w-[40px] items-center justify-center overflow-hidden rounded-full bg-[#FEE500]">
           <svg viewBox="0 0 40 40" class="relative left-[0.5px] block h-[30px] w-[30px]" aria-hidden="true">
             <path fill="#191919" d="M20 8.2c-6.6 0-12 4.25-12 9.5 0 3.39 2.2 6.37 5.52 8.06l-1.4 5.1c-.07.28.23.5.48.36l5.98-3.95c.47.05.94.08 1.42.08 6.63 0 12-4.25 12-9.5s-5.37-9.55-12-9.55Z"/>
@@ -43,7 +45,7 @@
       </div>
       <button
         type="button"
-        class="auth-legacy-remember absolute left-[140px] top-[186px] h-[26px] w-[148px]"
+        class="auth-legacy-remember relative z-[1] mt-[24px] h-[26px] w-[148px] translate-x-[24px]"
         id="rememberToggle"
         aria-pressed="true"
       >
@@ -52,7 +54,7 @@
             <path d="M1 4L3.5 6.5L9 1"></path>
           </svg>
         </span>
-        <span class="auth-legacy-remember-text">로그인 상태 유지</span>
+        <span class="auth-legacy-remember-text">로그인 유지</span>
       </button>
     </div>
   </div>


### PR DESCRIPTION
## 요약
구조 변경 머지를 유지한 상태에서 사용자 영역 모바일 UI와 주문 흐름 변경 사항을 새 구조에 맞게 재이식했습니다.

## 변경 사항
- orders refactor 구조에 맞춰 사용자 영역 주문/카탈로그 로직을 이식했습니다.
- 채팅, 상품 목록, 장바구니/관심상품, 주문내역, 로그인 화면의 사용자 영역 UI 변경을 새 구조에 맞게 반영했습니다.
- 주요 회원/비회원 페이지 렌더와 기본 라우팅 흐름을 검증했습니다.

## 관련 이슈
closes #318
ref #302

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 구조 변경 이후 orders/pages 기준 컨텍스트와 템플릿 이식이 의도대로 유지되는지 확인 부탁드립니다.
- 사용자 영역 공통 헤더와 주문 흐름 UI가 이전 작업 의도대로 복원됐는지 확인 부탁드립니다.