### PR TITLE
[frontend] 사용자 영역 UI 디테일 후속 조정 (#322)

### DIFF
--- a/services/django/chat/pages/context_builders.py
+++ b/services/django/chat/pages/context_builders.py
@@ -2,7 +2,7 @@ import json
 
 from django.db.models import Q
 
-from orders.models import Cart
+from orders.models import Cart, Wishlist
 from pets.future_profile import get_future_pet_profile_for_request
 from products.catalog_menu import build_catalog_menu_context
 from products.models import Product
@@ -89,6 +89,21 @@ def serialize_cart_product(item):
         "unit_price": price,
         "badge": "장바구니",
         "accent": "bg-[#e9d5ff] text-[#7c3aed]",
+    }
+
+
+def member_nav_indicator_state(user):
+    if not getattr(user, "is_authenticated", False):
+        return {
+            "member_nav_has_cart_items": False,
+            "member_nav_has_wishlist_items": False,
+        }
+
+    cart, _ = Cart.objects.get_or_create(user=user)
+    wishlist, _ = Wishlist.objects.get_or_create(user=user)
+    return {
+        "member_nav_has_cart_items": cart.items.exists(),
+        "member_nav_has_wishlist_items": wishlist.items.exists(),
     }
 
 
@@ -480,5 +495,6 @@ def build_chat_page_context(request):
         "promo_banners": promo_banners,
         "session_threads": session_threads,
         "catalog_menu_sections": build_catalog_menu_sections(),
+        **member_nav_indicator_state(request.user),
         **quick_order_profile,
     }

--- a/services/django/static/css/main.css
+++ b/services/django/static/css/main.css
@@ -43,6 +43,54 @@ body {
   *:hover::-webkit-scrollbar-thumb {
     background-color: rgba(100, 116, 139, 0.82);
   }
+
+  .app-scrollbar-auto-hide {
+    scrollbar-gutter: auto;
+    scrollbar-width: none;
+    scrollbar-color: transparent transparent;
+  }
+
+  .app-scrollbar-auto-hide::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+  }
+
+  .app-scrollbar-auto-hide::-webkit-scrollbar-thumb {
+    background-color: transparent;
+  }
+
+  .app-scrollbar-auto-hide:hover,
+  .app-scrollbar-auto-hide.is-scrolling {
+    scrollbar-width: thin;
+    scrollbar-color: rgba(148, 163, 184, 0.72) transparent;
+  }
+
+  .app-scrollbar-auto-hide:hover::-webkit-scrollbar,
+  .app-scrollbar-auto-hide.is-scrolling::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  .app-scrollbar-auto-hide:hover::-webkit-scrollbar-thumb,
+  .app-scrollbar-auto-hide.is-scrolling::-webkit-scrollbar-thumb {
+    background-color: rgba(148, 163, 184, 0.72);
+  }
+
+}
+
+.app-feedback-toast {
+  position: fixed;
+  left: 50%;
+  top: 88px;
+  z-index: 70;
+  transform: translate(-50%, 10px) scale(0.98);
+}
+
+@media (max-width: 767px) {
+  .app-feedback-toast {
+    top: 88px;
+    width: min(calc(100vw - 32px), 360px);
+  }
 }
 
 a,

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -553,19 +553,15 @@
   }
 
   #chatActionToast {
-    position: absolute;
-    left: 50%;
-    top: 50%;
     opacity: 0;
     visibility: hidden;
-    transform: translate(-50%, calc(-50% + 10px)) scale(0.98);
-    transition: opacity 180ms ease, transform 180ms ease;
+    transition: opacity 180ms ease, transform 180ms ease, visibility 180ms ease;
   }
 
   #chatActionToast.is-open {
     opacity: 1;
     visibility: visible;
-    transform: translate(-50%, -50%) scale(1);
+    transform: translate(-50%, 0) scale(1);
   }
 
   @keyframes recommendation-icon-twinkle {
@@ -758,7 +754,7 @@
             <span class="history-title absolute left-[6px] right-[72px] top-[12px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold leading-none text-[#2d3748]">
               {{ session.title|default:"새 대화" }}
             </span>
-            <span class="history-date absolute right-0 top-[12px] w-[66px] whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]">
+            <span class="history-date absolute right-[8px] top-[12px] w-[58px] whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]">
               {% if session.updated_at|date:"y/m/d" != "" %}{{ session.updated_at|date:"y/m/d" }}{% else %}{{ session.updated_at }}{% endif %}
             </span>
           </div>
@@ -1003,7 +999,7 @@
             <p class="text-[17px] font-bold text-[#2d3748]">추천 상품</p>
           </div>
           <div id="chatActionToast"
-               class="pointer-events-none z-[2] flex min-h-[34px] min-w-[140px] max-w-[220px] items-center justify-center rounded-full bg-[#1f2937] px-[14px] py-[8px] text-center text-[12px] font-semibold leading-[1.35] text-white shadow-[0_10px_24px_rgba(15,23,42,0.22)]">
+               class="app-feedback-toast pointer-events-none z-[72] flex min-h-[44px] min-w-[232px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold leading-[1.35] text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
             작업이 완료되었습니다
           </div>
           <button type="button" class="inline-flex h-[30px] w-[30px] items-center justify-center rounded-full bg-[#f8fafc] text-[18px] text-[#718096]" aria-label="추천 상품 닫기" onclick="closeRecommendationPanel()">
@@ -2173,7 +2169,7 @@
       wrapper.setAttribute('data-profile-context-type', state && state.profileContextType ? state.profileContextType : 'none');
       wrapper.innerHTML = ''
         + '<span class="history-title absolute left-[6px] right-[72px] top-[12px] overflow-hidden text-ellipsis whitespace-nowrap text-[12px] font-semibold leading-none text-[#2d3748]"></span>'
-        + '<span class="history-date absolute right-0 top-[12px] w-[66px] whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]"></span>';
+        + '<span class="history-date absolute right-[8px] top-[12px] w-[58px] whitespace-nowrap text-right text-[11px] leading-none tabular-nums text-[#a0aec0]"></span>';
 
       wrapper.querySelector('.history-title').textContent = title || '새 대화';
       var now = new Date();

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -457,6 +457,7 @@
     right: 12px;
     bottom: 64px;
     width: min(calc(100% - 24px), 392px);
+    max-width: calc(100% - 24px);
     max-height: min(68vh, 560px);
     overflow: hidden;
     border: 1px solid #dbe7f5;
@@ -494,12 +495,15 @@
 
   #catalogFilterPanel {
     position: absolute;
-    top: 0;
-    right: 0;
-    height: 100%;
+    top: 12px;
+    right: 12px;
+    bottom: 12px;
+    height: auto;
     width: min(calc(100% - 24px), 352px);
+    max-width: calc(100% - 24px);
     overflow-y: auto;
-    border-left: 1px solid #dbe7f5;
+    border: 1px solid #dbe7f5;
+    border-radius: 28px;
     background: rgba(255, 255, 255, 0.98);
     box-shadow: -18px 0 36px rgba(15, 23, 42, 0.12);
     transform: translateX(100%);
@@ -583,6 +587,23 @@
       height: 22px;
       width: 22px;
       font-size: 10px;
+    }
+  }
+
+  @media (max-width: 767px) {
+    #catalogSessionPanel {
+      right: 8px;
+      bottom: 56px;
+      width: min(calc(100% - 16px), 392px);
+      max-width: calc(100% - 16px);
+    }
+
+    #catalogFilterPanel {
+      top: 8px;
+      right: 8px;
+      bottom: 8px;
+      width: min(calc(100% - 16px), 352px);
+      max-width: calc(100% - 16px);
     }
   }
 
@@ -1026,7 +1047,10 @@
                           data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
                           aria-label="장바구니에 상품 추가"
                           onclick="addCatalogToCart(this)">
-                    <span class="relative top-[-2px]">+</span>
+                    <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                      <path d="M7 2.2V11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                      <path d="M2.2 7H11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
                   </button>
               </div>
             </div>
@@ -1137,7 +1161,7 @@
 </div>
 
 <div id="catalogFeedbackToast"
-     class="catalog-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+     class="app-feedback-toast catalog-feedback-toast pointer-events-none flex min-h-[44px] min-w-[232px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
   오류가 발생했습니다.
 </div>
 
@@ -1203,7 +1227,10 @@
                           data-in-cart="{% if item.is_in_cart %}1{% else %}0{% endif %}"
                           aria-label="장바구니에 상품 추가"
                           onclick="addCatalogToCart(this)">
-                    <span>+</span>
+                    <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true">
+                      <path d="M6 1.8V10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                      <path d="M1.8 6H10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    </svg>
                   </button>
                 </div>
               </div>
@@ -1748,7 +1775,7 @@
       + '            <svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>'
       + '          </button>'
       + '          <button type="button" class="inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full bg-[#2d3748] text-[16px] font-semibold leading-none text-white" data-product-id="' + productId + '" data-in-cart="0" aria-label="장바구니에 상품 추가" onclick="addCatalogToCart(this)">'
-      + '            <span>+</span>'
+      + '            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" aria-hidden="true"><path d="M6 1.8V10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M1.8 6H10.2" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>'
       + '          </button>'
       + '        </div>'
       + '      </div>'

--- a/services/django/templates/orders/checkout.html
+++ b/services/django/templates/orders/checkout.html
@@ -738,7 +738,7 @@
   </div>
 </div>
 
-<div id="checkoutFeedbackToast" class="checkout-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">오류가 발생했습니다.</div>
+<div id="checkoutFeedbackToast" class="app-feedback-toast checkout-feedback-toast pointer-events-none flex min-h-[44px] min-w-[232px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">오류가 발생했습니다.</div>
 
 <div id="deliveryInfoSheet" class="checkout-sheet fixed inset-0 z-[65] items-end bg-[rgba(15,23,42,0.38)] px-0 md:px-4" onclick="closeDeliverySheet(event)">
   <div class="checkout-sheet-panel px-5 pb-6 pt-5 md:px-6 md:pb-6 md:pt-6" onclick="event.stopPropagation()">

--- a/services/django/templates/orders/list.html
+++ b/services/django/templates/orders/list.html
@@ -637,7 +637,7 @@
 </div>
 
 <div id="orderFeedbackToast"
-     class="order-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+     class="app-feedback-toast order-feedback-toast pointer-events-none flex min-h-[44px] min-w-[232px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
   오류가 발생했습니다.
 </div>
 

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -1034,7 +1034,10 @@
                       class="catalog-card-action"
                       aria-label="장바구니에 상품 추가"
                       onclick="addWishlistToCart(this)">
-                <span class="relative top-[-2px]">+</span>
+                <svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                  <path d="M7 2.2V11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  <path d="M2.2 7H11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                </svg>
               </button>
             </div>
           </div>
@@ -1065,7 +1068,7 @@
 </div>
 
 <div id="productFeedbackToast"
-     class="product-feedback-toast pointer-events-none fixed left-1/2 top-[88px] z-[70] flex min-h-[44px] min-w-[232px] max-w-[360px] -translate-x-1/2 items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+     class="app-feedback-toast product-feedback-toast pointer-events-none flex min-h-[44px] min-w-[232px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
   오류가 발생했습니다.
 </div>
 {% endblock %}
@@ -1812,7 +1815,7 @@
       nameHtml,
       '<div class="catalog-card-meta">',
       '<div><p class="catalog-card-price">₩ ' + escapeHtml(String(data.priceLabel).replace(/원/g, "")) + '</p><p class="catalog-card-review"><span class="text-[#f6ad55]">★</span><span>' + escapeHtml(data.rating) + '</span><span>(' + escapeHtml(data.reviewCount) + ')</span></p></div>',
-      '<button type="button" class="catalog-card-action" aria-label="장바구니에 상품 추가" onclick="addWishlistToCart(this)"><span class="relative top-[-2px]">+</span></button>',
+      '<button type="button" class="catalog-card-action" aria-label="장바구니에 상품 추가" onclick="addWishlistToCart(this)"><svg width="14" height="14" viewBox="0 0 14 14" fill="none" aria-hidden="true"><path d="M7 2.2V11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M2.2 7H11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg></button>',
       '</div>',
       '</div>',
       '</article>'

--- a/services/django/templates/pets/add_future.html
+++ b/services/django/templates/pets/add_future.html
@@ -284,8 +284,8 @@
           </div>
         </div>
 
-        <div class="mt-[28px] flex flex-col-reverse gap-[10px] md:flex-row md:items-end md:gap-[14px]">
-          <a href="/pets/add/" class="flex h-[44px] w-full items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[128px]">
+        <div class="mt-[28px] flex items-center gap-[10px] md:gap-[14px]">
+          <a href="/pets/add/" class="flex h-[44px] w-[112px] shrink-0 items-center justify-center rounded-[10px] bg-[#edf2f7] text-[16px] font-bold leading-none text-[#4a5568] transition-colors hover:bg-[#e2e8f0] md:w-[128px]">
             이전으로
           </a>
           <button id="futureSubmitButton" type="submit" class="flex h-[44px] flex-1 items-center justify-center rounded-[10px] bg-[#cbd5e0] text-[16px] font-bold leading-none text-white transition-colors">


### PR DESCRIPTION
## 작업 내용
- 채팅 기록 리스트 스크롤/날짜 정렬 디테일 조정
- 메인 채팅 화면 장바구니 점 표시 로직 복구
- 예비 집사 입력 완료 화면 버튼 정렬 정리
- 상품 목록/관심 상품 카드의 장바구니 추가 버튼 중심 정렬 보정
- 토스트 메시지 위치를 화면 상단 중앙 기준으로 통일
- 상품 목록 우측 슬라이드 패널이 프레임 밖으로 벗어나지 않도록 보정

## 검증
- docker compose -f infra/docker-compose.yml exec -T django python manage.py check

## 연관 이슈
- closes #322