### PR TITLE
refactor(chat): 세션 메시지 요청을 message id 기반으로 단순화

### DIFF
--- a/services/django/chat/api/views.py
+++ b/services/django/chat/api/views.py
@@ -12,7 +12,7 @@ from ..models import ChatMessage, ChatSession
 from ..policies.chat_access_policy import require_authenticated
 from ..selectors.chat_selector import get_owned_session
 from ..selectors.pet_selector import get_owned_target_pet
-from ..services.chat_memory_service import build_memory_payload, get_or_create_session_memory
+from ..services.chat_memory_service import get_or_create_session_memory
 from ..services.chat_session_service import (
     normalize_profile_context_type,
     touch_session,
@@ -194,7 +194,6 @@ def session_messages_proxy_view(
     chat_base_url_fn=chat_base_url,
     persist_streamed_response_fn=persist_streamed_response,
     touch_session_fn=touch_session,
-    build_memory_payload_fn=build_memory_payload,
 ):
     unauthorized = require_authenticated_fn(request)
     if unauthorized:
@@ -228,7 +227,6 @@ def session_messages_proxy_view(
 
     user_message = ChatMessage.objects.create(session=session, role="user", content=message)
     touch_session_fn(session)
-    memory_payload = build_memory_payload_fn(session, exclude_message_id=user_message.message_id)
 
     request_id = build_request_id(request)
     safe_payload = build_chat_payload_fn(
@@ -236,9 +234,7 @@ def session_messages_proxy_view(
         request.user.id,
         thread_id=session.session_id,
         target_pet_id=session.target_pet_id,
-        conversation_history=memory_payload["conversation_history"],
-        memory_summary=memory_payload["memory_summary"],
-        dialog_state=memory_payload["dialog_state"],
+        current_user_message_id=user_message.message_id,
     )
     return StreamingHttpResponse(
         persist_streamed_response_fn(

--- a/services/django/chat/api/views.py
+++ b/services/django/chat/api/views.py
@@ -12,6 +12,7 @@ from ..models import ChatMessage, ChatSession
 from ..policies.chat_access_policy import require_authenticated
 from ..selectors.chat_selector import get_owned_session
 from ..selectors.pet_selector import get_owned_target_pet
+from ..services.chat_memory_service import build_memory_payload, get_or_create_session_memory
 from ..services.chat_session_service import (
     normalize_profile_context_type,
     touch_session,
@@ -82,6 +83,7 @@ def sessions_proxy_view(
     serialize_session_groups_fn=serialize_session_groups,
     normalize_profile_context_type_fn=normalize_profile_context_type,
     get_owned_target_pet_fn=get_owned_target_pet,
+    get_or_create_session_memory_fn=get_or_create_session_memory,
 ):
     unauthorized = require_authenticated_fn(request)
     if unauthorized:
@@ -118,6 +120,7 @@ def sessions_proxy_view(
         profile_context_type=profile_context_type,
         title=title,
     )
+    get_or_create_session_memory_fn(session)
     return JsonResponse(serialize_session_fn(session), status=201)
 
 
@@ -191,6 +194,7 @@ def session_messages_proxy_view(
     chat_base_url_fn=chat_base_url,
     persist_streamed_response_fn=persist_streamed_response,
     touch_session_fn=touch_session,
+    build_memory_payload_fn=build_memory_payload,
 ):
     unauthorized = require_authenticated_fn(request)
     if unauthorized:
@@ -222,8 +226,9 @@ def session_messages_proxy_view(
     if not message:
         return build_proxy_error_response_fn("message is required.", status=400)
 
-    ChatMessage.objects.create(session=session, role="user", content=message)
+    user_message = ChatMessage.objects.create(session=session, role="user", content=message)
     touch_session_fn(session)
+    memory_payload = build_memory_payload_fn(session, exclude_message_id=user_message.message_id)
 
     request_id = build_request_id(request)
     safe_payload = build_chat_payload_fn(
@@ -231,6 +236,9 @@ def session_messages_proxy_view(
         request.user.id,
         thread_id=session.session_id,
         target_pet_id=session.target_pet_id,
+        conversation_history=memory_payload["conversation_history"],
+        memory_summary=memory_payload["memory_summary"],
+        dialog_state=memory_payload["dialog_state"],
     )
     return StreamingHttpResponse(
         persist_streamed_response_fn(

--- a/services/django/chat/clients/fastapi_chat_client.py
+++ b/services/django/chat/clients/fastapi_chat_client.py
@@ -65,6 +65,10 @@ def capture_sse_event(event_lines, capture):
         final_cards = payload.get("cards")
         if final_cards is not None:
             capture["product_cards"] = final_cards or []
+        memory_payload = payload.get("memory") or {}
+        capture["dialog_state"] = memory_payload.get("dialog_state")
+        capture["memory_summary"] = memory_payload.get("memory_summary")
+        capture["last_compacted_message_id"] = memory_payload.get("last_compacted_message_id")
         capture["completed"] = True
     elif event_type == "error":
         capture["error_message"] = payload.get("message") or "죄송합니다, 오류가 발생했습니다."

--- a/services/django/chat/dto/chat_payload.py
+++ b/services/django/chat/dto/chat_payload.py
@@ -3,18 +3,13 @@ def build_chat_payload(
     user_id,
     thread_id=None,
     target_pet_id=None,
-    conversation_history=None,
-    memory_summary=None,
-    dialog_state=None,
+    current_user_message_id=None,
 ):
-    safe_payload = {
-        "message": (payload.get("message") or "").strip(),
-        "pet_profile": payload.get("pet_profile"),
-        "health_concerns": payload.get("health_concerns") or [],
-        "allergies": payload.get("allergies") or [],
-        "food_preferences": payload.get("food_preferences") or [],
-        "user_id": str(user_id),
-    }
+    safe_payload = {"user_id": str(user_id)}
+    message = (payload.get("message") or "").strip()
+    if message and current_user_message_id is None:
+        safe_payload["message"] = message
+
     if thread_id:
         safe_payload["thread_id"] = str(thread_id)
     elif payload.get("thread_id"):
@@ -25,10 +20,18 @@ def build_chat_payload(
     resolved_target_pet_id = target_pet_id or payload.get("target_pet_id")
     if resolved_target_pet_id:
         safe_payload["target_pet_id"] = str(resolved_target_pet_id)
-    if conversation_history is not None:
-        safe_payload["conversation_history"] = conversation_history
-    if memory_summary is not None:
-        safe_payload["memory_summary"] = memory_summary
-    if dialog_state is not None:
-        safe_payload["dialog_state"] = dialog_state
+
+    if current_user_message_id is not None:
+        safe_payload["current_user_message_id"] = str(current_user_message_id)
+
+    for key in ("profile_context_type", "pet_profile"):
+        value = payload.get(key)
+        if value is not None:
+            safe_payload[key] = value
+
+    for key in ("health_concerns", "allergies", "food_preferences"):
+        values = payload.get(key) or []
+        if values:
+            safe_payload[key] = values
+
     return safe_payload

--- a/services/django/chat/dto/chat_payload.py
+++ b/services/django/chat/dto/chat_payload.py
@@ -1,4 +1,12 @@
-def build_chat_payload(payload, user_id, thread_id=None, target_pet_id=None):
+def build_chat_payload(
+    payload,
+    user_id,
+    thread_id=None,
+    target_pet_id=None,
+    conversation_history=None,
+    memory_summary=None,
+    dialog_state=None,
+):
     safe_payload = {
         "message": (payload.get("message") or "").strip(),
         "pet_profile": payload.get("pet_profile"),
@@ -17,4 +25,10 @@ def build_chat_payload(payload, user_id, thread_id=None, target_pet_id=None):
     resolved_target_pet_id = target_pet_id or payload.get("target_pet_id")
     if resolved_target_pet_id:
         safe_payload["target_pet_id"] = str(resolved_target_pet_id)
+    if conversation_history is not None:
+        safe_payload["conversation_history"] = conversation_history
+    if memory_summary is not None:
+        safe_payload["memory_summary"] = memory_summary
+    if dialog_state is not None:
+        safe_payload["dialog_state"] = dialog_state
     return safe_payload

--- a/services/django/chat/migrations/0004_chatsessionmemory.py
+++ b/services/django/chat/migrations/0004_chatsessionmemory.py
@@ -1,0 +1,34 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("chat", "0003_chatsession_profile_context_type"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="ChatSessionMemory",
+            fields=[
+                (
+                    "session",
+                    models.OneToOneField(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        primary_key=True,
+                        related_name="memory",
+                        serialize=False,
+                        to="chat.chatsession",
+                    ),
+                ),
+                ("summary_text", models.TextField(blank=True, default="")),
+                ("dialog_state", models.JSONField(blank=True, default=dict)),
+                ("last_compacted_message_id", models.UUIDField(blank=True, null=True)),
+                ("version", models.PositiveIntegerField(default=1)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                "db_table": "chat_session_memory",
+            },
+        ),
+    ]

--- a/services/django/chat/models.py
+++ b/services/django/chat/models.py
@@ -50,3 +50,15 @@ class ChatMessageRecommendation(models.Model):
     class Meta:
         db_table = "chat_message_recommendation"
         unique_together = [("message", "product")]
+
+
+class ChatSessionMemory(models.Model):
+    session = models.OneToOneField(ChatSession, on_delete=models.CASCADE, related_name="memory", primary_key=True)
+    summary_text = models.TextField(blank=True, default="")
+    dialog_state = models.JSONField(default=dict, blank=True)
+    last_compacted_message_id = models.UUIDField(null=True, blank=True)
+    version = models.PositiveIntegerField(default=1)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        db_table = "chat_session_memory"

--- a/services/django/chat/services/__init__.py
+++ b/services/django/chat/services/__init__.py
@@ -1,11 +1,16 @@
 from .chat_message_service import persist_recommended_products
+from .chat_memory_service import build_conversation_history, build_memory_payload, get_or_create_session_memory, update_session_memory
 from .chat_session_service import normalize_profile_context_type, touch_session, update_session_metadata
 from .chat_stream_service import persist_streamed_response
 
 __all__ = [
+    "build_conversation_history",
+    "build_memory_payload",
+    "get_or_create_session_memory",
     "normalize_profile_context_type",
     "persist_recommended_products",
     "persist_streamed_response",
     "touch_session",
+    "update_session_memory",
     "update_session_metadata",
 ]

--- a/services/django/chat/services/__init__.py
+++ b/services/django/chat/services/__init__.py
@@ -1,11 +1,9 @@
 from .chat_message_service import persist_recommended_products
-from .chat_memory_service import build_conversation_history, build_memory_payload, get_or_create_session_memory, update_session_memory
+from .chat_memory_service import get_or_create_session_memory, update_session_memory
 from .chat_session_service import normalize_profile_context_type, touch_session, update_session_metadata
 from .chat_stream_service import persist_streamed_response
 
 __all__ = [
-    "build_conversation_history",
-    "build_memory_payload",
     "get_or_create_session_memory",
     "normalize_profile_context_type",
     "persist_recommended_products",

--- a/services/django/chat/services/chat_memory_service.py
+++ b/services/django/chat/services/chat_memory_service.py
@@ -1,34 +1,9 @@
 from ..models import ChatSessionMemory
 
-HISTORY_WINDOW_MESSAGES = 12
-
 
 def get_or_create_session_memory(session):
     memory, _ = ChatSessionMemory.objects.get_or_create(session=session)
     return memory
-
-
-def build_conversation_history(session, *, limit=HISTORY_WINDOW_MESSAGES, exclude_message_id=None):
-    queryset = session.messages.order_by("-created_at")
-    if exclude_message_id is not None:
-        queryset = queryset.exclude(message_id=exclude_message_id)
-
-    messages = list(queryset[:limit])
-    messages.reverse()
-    return [{"role": message.role, "content": message.content} for message in messages]
-
-
-def build_memory_payload(session, *, limit=HISTORY_WINDOW_MESSAGES, exclude_message_id=None):
-    memory = get_or_create_session_memory(session)
-    return {
-        "conversation_history": build_conversation_history(
-            session,
-            limit=limit,
-            exclude_message_id=exclude_message_id,
-        ),
-        "memory_summary": memory.summary_text or "",
-        "dialog_state": memory.dialog_state or {},
-    }
 
 
 def update_session_memory(

--- a/services/django/chat/services/chat_memory_service.py
+++ b/services/django/chat/services/chat_memory_service.py
@@ -1,0 +1,57 @@
+from ..models import ChatSessionMemory
+
+HISTORY_WINDOW_MESSAGES = 12
+
+
+def get_or_create_session_memory(session):
+    memory, _ = ChatSessionMemory.objects.get_or_create(session=session)
+    return memory
+
+
+def build_conversation_history(session, *, limit=HISTORY_WINDOW_MESSAGES, exclude_message_id=None):
+    queryset = session.messages.order_by("-created_at")
+    if exclude_message_id is not None:
+        queryset = queryset.exclude(message_id=exclude_message_id)
+
+    messages = list(queryset[:limit])
+    messages.reverse()
+    return [{"role": message.role, "content": message.content} for message in messages]
+
+
+def build_memory_payload(session, *, limit=HISTORY_WINDOW_MESSAGES, exclude_message_id=None):
+    memory = get_or_create_session_memory(session)
+    return {
+        "conversation_history": build_conversation_history(
+            session,
+            limit=limit,
+            exclude_message_id=exclude_message_id,
+        ),
+        "memory_summary": memory.summary_text or "",
+        "dialog_state": memory.dialog_state or {},
+    }
+
+
+def update_session_memory(
+    session,
+    *,
+    dialog_state=None,
+    memory_summary=None,
+    last_compacted_message_id=None,
+):
+    memory = get_or_create_session_memory(session)
+    updated_fields = []
+
+    if dialog_state is not None and memory.dialog_state != dialog_state:
+        memory.dialog_state = dialog_state
+        updated_fields.append("dialog_state")
+    if memory_summary is not None and memory.summary_text != memory_summary:
+        memory.summary_text = memory_summary
+        updated_fields.append("summary_text")
+    if last_compacted_message_id is not None and memory.last_compacted_message_id != last_compacted_message_id:
+        memory.last_compacted_message_id = last_compacted_message_id
+        updated_fields.append("last_compacted_message_id")
+
+    if updated_fields:
+        memory.save(update_fields=updated_fields + ["updated_at"])
+
+    return memory

--- a/services/django/chat/services/chat_stream_service.py
+++ b/services/django/chat/services/chat_stream_service.py
@@ -1,5 +1,6 @@
 from ..clients.fastapi_chat_client import stream_fastapi_response
 from ..models import ChatMessage
+from .chat_memory_service import update_session_memory
 from .chat_message_service import persist_recommended_products
 from .chat_session_service import touch_session
 
@@ -11,6 +12,9 @@ def persist_streamed_response(session, url, payload, user_id, request_id=None):
         "error_message": None,
         "completed": False,
         "product_cards": [],
+        "dialog_state": None,
+        "memory_summary": None,
+        "last_compacted_message_id": None,
     }
 
     try:
@@ -28,4 +32,13 @@ def persist_streamed_response(session, url, payload, user_id, request_id=None):
         if content:
             assistant_message = ChatMessage.objects.create(session=session, role="assistant", content=content)
             persist_recommended_products(assistant_message, capture["product_cards"])
+            if not capture["error_message"] and (
+                capture["dialog_state"] is not None or capture["memory_summary"] is not None
+            ):
+                update_session_memory(
+                    session,
+                    dialog_state=capture["dialog_state"],
+                    memory_summary=capture["memory_summary"],
+                    last_compacted_message_id=capture["last_compacted_message_id"] or assistant_message.message_id,
+                )
             touch_session(session)

--- a/services/django/chat/services/chat_stream_service.py
+++ b/services/django/chat/services/chat_stream_service.py
@@ -39,6 +39,6 @@ def persist_streamed_response(session, url, payload, user_id, request_id=None):
                     session,
                     dialog_state=capture["dialog_state"],
                     memory_summary=capture["memory_summary"],
-                    last_compacted_message_id=capture["last_compacted_message_id"] or assistant_message.message_id,
+                    last_compacted_message_id=capture["last_compacted_message_id"],
                 )
             touch_session(session)

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 import json
+import json as json_module
 import uuid
 from unittest.mock import patch
 
@@ -241,11 +242,53 @@ class _FakeHttpxClient:
             "headers": headers,
             "json": json,
         }
+        final_payload = {
+            "type": "final",
+            "message": "hello",
+            "cards": [
+                {
+                    "goods_id": "TEST-PRODUCT-1",
+                    "product_name": "추천 상품",
+                    "brand_name": "브랜드",
+                    "price": 10000,
+                    "discount_price": 9000,
+                    "rating": 4.5,
+                    "reviews": 12,
+                    "thumbnail_url": "https://example.com/thumb.jpg",
+                    "product_url": "https://example.com/product",
+                }
+            ],
+            "meta": {"request_id": "req-test", "session_id": "session-test"},
+            "memory": {
+                "dialog_state": {
+                    "intents": ["recommend"],
+                    "filters": {"pet_type": "고양이", "category": "사료"},
+                    "domain_intent": None,
+                    "clarification_count": 1,
+                    "pending_pet_ids": [],
+                    "pending_categories": [],
+                    "target_pet_id": "pet-memory",
+                    "pet_profile": {"species": "cat"},
+                    "health_concerns": [],
+                    "allergies": [],
+                    "food_preferences": [],
+                    "is_pet_override": False,
+                    "pet_mismatch": False,
+                    "form_hint": None,
+                    "detected_aspect": None,
+                    "budget": None,
+                    "filter_relaxation_count": 0,
+                    "recommend_retry_pending": False,
+                },
+                "memory_summary": "업데이트된 요약",
+                "last_compacted_message_id": None,
+            },
+        }
         return _FakeStreamResponse(
             [
                 b'data: {"type":"token","content":"hel"}\n\n',
                 'data: {"type":"products","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}]}\n\n',
-                'data: {"type":"final","message":"hello","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}],"meta":{"request_id":"req-test","session_id":"session-test"},"memory":{"dialog_state":{"intents":["recommend"],"filters":{"pet_type":"고양이","category":"사료"},"domain_intent":null,"clarification_count":1,"pending_pet_ids":[],"pending_categories":[],"target_pet_id":"pet-memory","pet_profile":{"species":"cat"},"health_concerns":[],"allergies":[],"food_preferences":[],"is_pet_override":false,"pet_mismatch":false,"form_hint":null,"detected_aspect":null,"budget":null,"filter_relaxation_count":0,"recommend_retry_pending":false},"memory_summary":"업데이트된 요약","last_compacted_message_id":null}}\n\n',
+                f"data: {json_module.dumps(final_payload, ensure_ascii=False, separators=(',', ':'))}\n\n",
                 b'data: {"type":"done"}\n\n',
             ]
         )
@@ -426,8 +469,8 @@ class ChatProxyTests(TestCase):
                 "clarification_count": 1,
             },
         )
-        ChatMessage.objects.create(session=session, role="user", content="이전 질문")
-        ChatMessage.objects.create(session=session, role="assistant", content="이전 답변")
+        ChatMessage.objects.create(session=session, role="user", content="이전 대화 1")
+        ChatMessage.objects.create(session=session, role="assistant", content="이전 대화 2")
 
         response = self.client.post(
             f"/api/chat/sessions/{session.session_id}/messages/",
@@ -442,23 +485,16 @@ class ChatProxyTests(TestCase):
         self.assertIn('"type":"done"', payload)
         self.assertIn('"type":"final"', payload)
         self.assertEqual(_FakeHttpxClient.last_stream_request["url"], settings.FASTAPI_INTERNAL_CHAT_URL)
-        self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["message"], "hello")
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["thread_id"], str(session.session_id))
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["user_id"], str(self.user.id))
+        self.assertIn("current_user_message_id", _FakeHttpxClient.last_stream_request["json"])
+        self.assertNotIn("message", _FakeHttpxClient.last_stream_request["json"])
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["target_pet_id"], str(self.pet.pet_id))
         self.assertNotEqual(_FakeHttpxClient.last_stream_request["json"]["target_pet_id"], str(secondary_pet.pet_id))
-        self.assertEqual(
-            _FakeHttpxClient.last_stream_request["json"]["conversation_history"],
-            [
-                {"role": "user", "content": "이전 질문"},
-                {"role": "assistant", "content": "이전 답변"},
-            ],
-        )
-        self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["memory_summary"], "기존 요약")
-        self.assertEqual(
-            _FakeHttpxClient.last_stream_request["json"]["dialog_state"]["filters"],
-            {"pet_type": "고양이", "category": "사료"},
-        )
+        self.assertNotIn("conversation_history", _FakeHttpxClient.last_stream_request["json"])
+        self.assertNotIn("summary_candidates", _FakeHttpxClient.last_stream_request["json"])
+        self.assertNotIn("memory_summary", _FakeHttpxClient.last_stream_request["json"])
+        self.assertNotIn("dialog_state", _FakeHttpxClient.last_stream_request["json"])
         self.assertEqual(_FakeHttpxClient.last_stream_request["headers"]["X-Session-Id"], str(session.session_id))
         self.assertIn("X-Request-Id", _FakeHttpxClient.last_stream_request["headers"])
 
@@ -472,7 +508,7 @@ class ChatProxyTests(TestCase):
         self.assertEqual(memory.summary_text, "업데이트된 요약")
         self.assertEqual(memory.dialog_state["intents"], ["recommend"])
         self.assertEqual(memory.dialog_state["filters"], {"pet_type": "고양이", "category": "사료"})
-        self.assertEqual(memory.last_compacted_message_id, assistant_message.message_id)
+        self.assertIsNone(memory.last_compacted_message_id)
 
         list_response = self.client.get(
             f"/api/chat/sessions/{session.session_id}/messages/",

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -12,7 +12,7 @@ from rest_framework_simplejwt.tokens import AccessToken
 from rest_framework_simplejwt.tokens import RefreshToken
 
 from chat.api_views import sessions_proxy_view
-from chat.models import ChatMessage, ChatMessageRecommendation, ChatSession
+from chat.models import ChatMessage, ChatMessageRecommendation, ChatSession, ChatSessionMemory
 from chat.pages.views import ensure_chat_api_tokens
 from pets.models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 from products.models import Product
@@ -245,7 +245,7 @@ class _FakeHttpxClient:
             [
                 b'data: {"type":"token","content":"hel"}\n\n',
                 'data: {"type":"products","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}]}\n\n',
-                'data: {"type":"final","message":"hello","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}],"meta":{"request_id":"req-test","session_id":"session-test"}}\n\n',
+                'data: {"type":"final","message":"hello","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}],"meta":{"request_id":"req-test","session_id":"session-test"},"memory":{"dialog_state":{"intents":["recommend"],"filters":{"pet_type":"고양이","category":"사료"},"domain_intent":null,"clarification_count":1,"pending_pet_ids":[],"pending_categories":[],"target_pet_id":"pet-memory","pet_profile":{"species":"cat"},"health_concerns":[],"allergies":[],"food_preferences":[],"is_pet_override":false,"pet_mismatch":false,"form_hint":null,"detected_aspect":null,"budget":null,"filter_relaxation_count":0,"recommend_retry_pending":false},"memory_summary":"업데이트된 요약","last_compacted_message_id":null}}\n\n',
                 b'data: {"type":"done"}\n\n',
             ]
         )
@@ -375,6 +375,7 @@ class ChatProxyTests(TestCase):
         self.assertEqual(created_session.user_id, self.user.id)
         self.assertEqual(created_session.target_pet_id, self.pet.pet_id)
         self.assertEqual(created_session.profile_context_type, ChatSession.PROFILE_CONTEXT_PET)
+        self.assertTrue(ChatSessionMemory.objects.filter(session=created_session).exists())
 
         patch_response = self.client.patch(
             f"/api/chat/sessions/{existing_session.session_id}/",
@@ -416,6 +417,17 @@ class ChatProxyTests(TestCase):
             budget_range="10_15",
         )
         session = ChatSession.objects.create(user=self.user, target_pet=self.pet, title="추천 세션")
+        ChatSessionMemory.objects.create(
+            session=session,
+            summary_text="기존 요약",
+            dialog_state={
+                "intents": ["recommend"],
+                "filters": {"pet_type": "고양이", "category": "사료"},
+                "clarification_count": 1,
+            },
+        )
+        ChatMessage.objects.create(session=session, role="user", content="이전 질문")
+        ChatMessage.objects.create(session=session, role="assistant", content="이전 답변")
 
         response = self.client.post(
             f"/api/chat/sessions/{session.session_id}/messages/",
@@ -435,22 +447,39 @@ class ChatProxyTests(TestCase):
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["user_id"], str(self.user.id))
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["target_pet_id"], str(self.pet.pet_id))
         self.assertNotEqual(_FakeHttpxClient.last_stream_request["json"]["target_pet_id"], str(secondary_pet.pet_id))
+        self.assertEqual(
+            _FakeHttpxClient.last_stream_request["json"]["conversation_history"],
+            [
+                {"role": "user", "content": "이전 질문"},
+                {"role": "assistant", "content": "이전 답변"},
+            ],
+        )
+        self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["memory_summary"], "기존 요약")
+        self.assertEqual(
+            _FakeHttpxClient.last_stream_request["json"]["dialog_state"]["filters"],
+            {"pet_type": "고양이", "category": "사료"},
+        )
         self.assertEqual(_FakeHttpxClient.last_stream_request["headers"]["X-Session-Id"], str(session.session_id))
         self.assertIn("X-Request-Id", _FakeHttpxClient.last_stream_request["headers"])
 
         messages = list(session.messages.order_by("created_at").values_list("role", "content"))
-        self.assertEqual(messages, [("user", "hello"), ("assistant", "hello")])
-        assistant_message = session.messages.get(role="assistant")
+        self.assertEqual(messages[-2:], [("user", "hello"), ("assistant", "hello")])
+        assistant_message = session.messages.filter(role="assistant").order_by("-created_at").first()
         recommendation = ChatMessageRecommendation.objects.get(message=assistant_message)
         self.assertEqual(recommendation.product_id, self.product.goods_id)
         self.assertEqual(recommendation.rank_order, 0)
+        memory = ChatSessionMemory.objects.get(session=session)
+        self.assertEqual(memory.summary_text, "업데이트된 요약")
+        self.assertEqual(memory.dialog_state["intents"], ["recommend"])
+        self.assertEqual(memory.dialog_state["filters"], {"pet_type": "고양이", "category": "사료"})
+        self.assertEqual(memory.last_compacted_message_id, assistant_message.message_id)
 
         list_response = self.client.get(
             f"/api/chat/sessions/{session.session_id}/messages/",
             HTTP_AUTHORIZATION=f"Bearer {self.access_token}",
         )
         self.assertEqual(list_response.status_code, 200)
-        assistant_payload = list_response.json()["messages"][1]
+        assistant_payload = list_response.json()["messages"][-1]
         self.assertEqual(assistant_payload["recommended_products"][0]["goods_id"], self.product.goods_id)
 
     @patch("chat.api_views.httpx.Client", _ExplodingHttpxClient)


### PR DESCRIPTION
## 요약
Django가 대화 이력을 직접 조립해 FastAPI로 보내던 구조를 정리하고, 세션 메시지 저장 후 `current_user_message_id` 중심의 최소 payload만 전달하도록 변경했습니다. FastAPI 서브모듈 포인터는 세션 문맥 DB 직접 조회 리팩터링 커밋으로 갱신했습니다.

## 변경 사항
- Django 세션 메시지 API가 user message 저장 후 `current_user_message_id`와 최소 문맥만 FastAPI에 전달하도록 payload를 축소했습니다.
- `chat_memory_service`는 세션 메모리 저장 책임만 남기고, history/summary candidate 조립 책임은 FastAPI로 이동하도록 정리했습니다.
- `services/fastapi` 서브모듈 포인터를 AI PR 기준 커밋(`b29ff03`)으로 업데이트하고, Django 테스트를 DB 직접 조회 구조에 맞게 갱신했습니다.

## 관련 이슈
closes #326

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- Django에서 더 이상 history를 직접 만들지 않고 `current_user_message_id`만 넘기는 흐름이 프론트-세션 메시지 저장 시점과 잘 맞는지 확인 부탁드립니다.
- `services/fastapi` 서브모듈 포인터가 AI PR #40의 커밋 `b29ff03`를 정확히 가리키는지만 함께 봐주시면 됩니다.