### PR TITLE
fix: 반려동물 품종 입력에서 괄호 포함 품종명 유지

### DIFF
--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -439,7 +439,7 @@
 
     function sanitizeBreedInput(value) {
       return (value || '')
-        .replace(/[^A-Za-z가-힣ㄱ-ㅎ\s]/g, '')
+        .replace(/[^A-Za-z가-힣ㄱ-ㅎ()\s]/g, '')
         .replace(/\s+/g, ' ')
         .replace(/^\s+/, '');
     }


### PR DESCRIPTION
## 관련 이슈
- closes #329

## 변경 내용
- 반려동물 품종 입력 정규식에서 괄호 ( ) 를 허용하도록 수정
- 괄호가 포함된 공식 품종명 선택 시 입력값이 변형되지 않도록 처리

## 영향 범위
- services/django/templates/pets/add_step2.html

## 확인 내용
- 치와와 (단모) 같은 품종명이 breed_meta 기준 공식 값으로 존재함을 확인
- 프론트 입력 정제 로직이 괄호를 제거하던 원인을 확인
- 서버의 resolve_breed() 검증 로직은 유지
