### PR TITLE
feat(data): 추천 상호작용 수집 경로 및 데이터 점검 기반 추가

### DIFF
--- a/docs/data/recommendation_data_audit_2026-04-06.md
+++ b/docs/data/recommendation_data_audit_2026-04-06.md
@@ -1,0 +1,235 @@
+# Recommendation Data Audit
+
+Date: 2026-04-06
+Issue: #325
+
+## Scope
+
+- Recommendation input columns currently used by the FastAPI recommendation flow
+- Product metadata completeness for ranking-related fields
+- Current `UserInteraction` logging coverage in Django
+
+## Files Checked
+
+- `services/django/orders/models.py`
+- `services/django/orders/api/core.py`
+- `services/fastapi/final_ai/infrastructure/repositories/product_repository.py`
+- `services/fastapi/final_ai/infrastructure/repositories/product_filters.py`
+- `services/fastapi/final_ai/application/recommendation/service.py`
+- `services/fastapi/final_ai/api/routers/recommend.py`
+- `services/fastapi/final_ai/api/routers/products.py`
+
+## Recommendation Columns In Use
+
+### Retrieval / filter
+
+- `goods_id`
+- `goods_name`
+- `pet_type`
+- `category`
+- `subcategory`
+- `price`
+- `embedding`
+- `search_vector`
+- `health_concern_tags`
+
+### Rerank
+
+- `popularity_score`
+- `sentiment_avg`
+- `repeat_rate`
+- `health_concern_tags`
+
+### Safety / post-filter
+
+- `main_ingredients`
+- `ingredient_text_ocr`
+
+### Response payload
+
+- `brand_name`
+- `discount_price`
+- `rating`
+- `review_count`
+- `thumbnail_url`
+- `product_url`
+- `soldout_yn`
+
+## Product Metadata Snapshot
+
+Source: local PostgreSQL `product` table
+
+- total products: `4902`
+- missing `goods_name`: `0`
+- missing `pet_type`: `0`
+- missing `category`: `0`
+- missing `subcategory`: `0`
+- missing `health_concern_tags`: `4308`
+- missing `main_ingredients`: `2483`
+- missing `ingredient_text_ocr`: `2483`
+- missing `popularity_score`: `261`
+- missing `sentiment_avg`: `3187`
+- missing `repeat_rate`: `2588`
+
+## Distribution Snapshot
+
+- distinct `pet_type`: `2`
+- distinct `category`: `7`
+- distinct `subcategory`: `76`
+- distinct `health_concern_tags`: `9`
+
+## Interaction Logging Status
+
+`UserInteraction` model supports:
+
+- `click`
+- `cart`
+- `purchase`
+- `reject`
+
+Current write path found:
+
+- `services/django/orders/api/core.py`
+  - only `purchase` is written in `create_order_from_cart()`
+
+Local DB snapshot:
+
+- `purchase`: `39` rows, total weight `55`
+- `click`: `0`
+- `cart`: `0`
+- `reject`: `0`
+
+## ETL / Data Source Notes
+
+Relevant generation paths found:
+
+- `scripts/gold/goods.py`
+  - joins OCR into `ingredient_text_ocr`
+  - joins health tag results into `health_concern_tags`
+  - joins parsed ingredients into `main_ingredients`
+  - calculates `popularity_score`
+  - calculates `sentiment_avg`
+  - calculates `repeat_rate`
+- `scripts/gold/health_tags.py`
+  - generates `health_concern_tags`
+- `scripts/gold/ingredients.py`
+  - generates `main_ingredients`
+- `scripts/ingest_postgres.py`
+  - writes these fields into PostgreSQL `product`
+
+Observed implication from code:
+
+- `sentiment_avg` and `repeat_rate` depend on review-side inputs in `scripts/gold/goods.py`
+- when review inputs are missing, these fields are intentionally left as `None`
+- `health_concern_tags` are only joined for OCR-target products
+- `ingredient_text_ocr` and `main_ingredients` are also tied to OCR / ingredient parsing availability
+
+## Current Risks
+
+1. Ranking features are sparse.
+   - `sentiment_avg`, `repeat_rate`, `health_concern_tags` have high null rates.
+
+2. Safety-related ingredient coverage is incomplete.
+   - `main_ingredients` and `ingredient_text_ocr` are missing for about half of products.
+
+3. Online feedback loop is effectively absent.
+   - recommendation can only rely on product metadata and purchase logs.
+   - click/cart/reject signal coverage is now possible but still sparse.
+
+## Event Hook Status
+
+Frontend recommendation panel actions found:
+
+- `services/django/templates/chat/index.html`
+  - `addRecommendedToCart(button)`
+  - `toggleRecommendedWishlist(button)`
+  - product thumbnail / name links open external `product_url`
+
+Backend event handling status:
+
+- recommendation card -> cart
+  - goes through `POST /api/orders/cart/`
+  - now can be extended by writing `UserInteraction(interaction_type="cart")` in cart API
+- recommendation card -> wishlist
+  - goes through `POST/DELETE /api/orders/wishlist/`
+  - wishlist is currently separate from `UserInteraction`
+- recommendation card click
+  - can be sent to `POST /api/orders/interactions/` with `interaction_type="click"`
+- recommendation reject / dislike
+  - can be sent to `POST /api/orders/interactions/` with `interaction_type="reject"`
+  - current UI can support lightweight dismiss-style feedback
+
+Practical implication:
+
+- low-risk extension points are cart add logging, recommendation click logging, and lightweight reject logging
+- next remaining work is aggregation / feature consumption on the recommendation side
+
+## Next Actions
+
+1. Verify how `popularity_score`, `sentiment_avg`, and `repeat_rate` are generated in ETL.
+2. Check whether `health_concern_tags` and `ingredient_text_ocr` can be backfilled from existing pipelines.
+3. Define minimal interaction logging scope for recommendation:
+   - cart add
+   - recommendation click
+   - recommendation reject
+4. Prepare a feature proposal for rerank input:
+   - recent click count
+   - recent cart count
+   - recent purchase count
+   - reject count
+   - category preference count
+
+## Candidate Behavior Features
+
+### Short-term feasible
+
+- `recent_purchase_count_by_goods_id`
+- `recent_purchase_count_by_category`
+- `recent_cart_count_by_goods_id`
+- `recent_cart_count_by_category`
+- `recent_click_count_by_goods_id`
+- `recent_click_count_by_category`
+
+Reason:
+
+- `purchase` is already stored
+- `cart` can be added on top of the existing cart API with low write-scope risk
+- recommendation card click can be logged through a dedicated interaction endpoint
+
+### Mid-term feasible
+
+- `recent_recommendation_panel_click_count`
+- `recent_reject_count_by_goods_id`
+- `recent_reject_count_by_category`
+
+Reason:
+
+- needs aggregation strategy on top of raw click/reject events
+
+### Long-term / optional
+
+- `reject_count_by_goods_id`
+- `reject_count_by_category`
+- `session_level_skip_rate`
+
+Reason:
+
+- reject UI and semantics are not implemented yet
+
+## Suggested Implementation Order
+
+1. backfill / verify metadata fields used by current rerank
+2. add `cart` interaction logging
+3. define recommendation click logging path
+4. add aggregate feature query layer for rerank experiments
+
+## Implementation Progress
+
+Completed in this branch:
+
+- `cart` interaction logging on `POST /api/orders/cart/`
+- `click` interaction logging endpoint via `POST /api/orders/interactions/`
+- lightweight `reject` logging path from recommendation cards
+- FastAPI repository layer for interaction aggregates:
+  - goods-level counts
+  - category-level counts

--- a/services/django/orders/api/__init__.py
+++ b/services/django/orders/api/__init__.py
@@ -1,9 +1,10 @@
 from .views_cart import CartView
-from .views_order import OrderDetailView, OrderListView, QuickPurchaseView
+from .views_order import InteractionView, OrderDetailView, OrderListView, QuickPurchaseView
 from .views_wishlist import WishlistView
 
 __all__ = [
     "CartView",
+    "InteractionView",
     "OrderDetailView",
     "OrderListView",
     "QuickPurchaseView",

--- a/services/django/orders/api/core.py
+++ b/services/django/orders/api/core.py
@@ -81,6 +81,29 @@ def _display_product_name(brand_name, goods_name):
     return (goods_name or "").strip()
 
 
+def create_user_interaction(*, user, product, interaction_type, weight=1, session_id=None):
+    return UserInteraction.objects.create(
+        user=user,
+        product=product,
+        session_id=session_id,
+        interaction_type=interaction_type,
+        weight=max(int(weight or 1), 1),
+    )
+
+
+def validate_interaction_type(interaction_type):
+    valid_types = {choice[0] for choice in UserInteraction.INTERACTION_CHOICES}
+    if interaction_type not in valid_types:
+        return error_response(
+            "invalid interaction_type.",
+            code="invalid_interaction_type",
+            status_code=status.HTTP_400_BAD_REQUEST,
+            field="interaction_type",
+            extra={"available_interaction_types": sorted(valid_types)},
+        )
+    return None
+
+
 def serialize_product_summary(product: Product) -> dict:
     price = product.price
     return {
@@ -759,6 +782,13 @@ class CartView(APIView):
             cart_item.quantity += quantity
             cart_item.save(update_fields=["quantity"])
 
+        create_user_interaction(
+            user=request.user,
+            product=product,
+            interaction_type="cart",
+            weight=quantity,
+        )
+
         return Response(
             {"cart_item": serialize_cart_item(cart_item)},
             status=status.HTTP_201_CREATED if created else status.HTTP_200_OK,
@@ -833,3 +863,41 @@ class WishlistView(APIView):
             return Response({"detail": "wishlist item not found."}, status=status.HTTP_404_NOT_FOUND)
 
         return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class InteractionView(APIView):
+    authentication_classes = [JWTAuthentication, SessionAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    @transaction.atomic
+    def post(self, request):
+        product, product_error_response = get_product_or_400(request.data.get("product_id"))
+        if product_error_response:
+            return product_error_response
+
+        interaction_type = (request.data.get("interaction_type") or "").strip()
+        interaction_type_error = validate_interaction_type(interaction_type)
+        if interaction_type_error:
+            return interaction_type_error
+
+        session_id = request.data.get("session_id")
+        weight = request.data.get("weight", 1)
+
+        interaction = create_user_interaction(
+            user=request.user,
+            product=product,
+            interaction_type=interaction_type,
+            weight=weight,
+            session_id=session_id,
+        )
+        return Response(
+            {
+                "interaction": {
+                    "id": str(interaction.id),
+                    "product_id": product.goods_id,
+                    "interaction_type": interaction.interaction_type,
+                    "weight": interaction.weight,
+                }
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/services/django/orders/api/views_order.py
+++ b/services/django/orders/api/views_order.py
@@ -1,6 +1,7 @@
-from .core import OrderDetailView, OrderListView, QuickPurchaseView
+from .core import InteractionView, OrderDetailView, OrderListView, QuickPurchaseView
 
 __all__ = [
+    "InteractionView",
     "OrderDetailView",
     "OrderListView",
     "QuickPurchaseView",

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -46,6 +46,8 @@ class CartApiTests(TestCase):
         self.assertEqual(response.data["cart_item"]["product_id"], self.product.goods_id)
         self.assertEqual(response.data["cart_item"]["quantity"], 2)
         self.assertTrue(CartItem.objects.filter(cart__user=self.user, product=self.product).exists())
+        interaction = UserInteraction.objects.get(user=self.user, product=self.product, interaction_type="cart")
+        self.assertEqual(interaction.weight, 2)
 
     def test_post_cart_existing_item_increments_quantity(self):
         self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
@@ -58,6 +60,9 @@ class CartApiTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data["cart_item"]["quantity"], 4)
+        interactions = UserInteraction.objects.filter(user=self.user, product=self.product, interaction_type="cart")
+        self.assertEqual(interactions.count(), 2)
+        self.assertEqual(list(interactions.order_by("created_at").values_list("weight", flat=True)), [1, 3])
 
     def test_patch_cart_updates_quantity(self):
         self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
@@ -130,6 +135,68 @@ class WishlistApiTests(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(WishlistItem.objects.filter(wishlist__user=self.user, product=self.product).exists())
+
+
+class InteractionApiTests(TestCase):
+    def setUp(self):
+        self.client = APIClient()
+        self.user = User.objects.create_user(email="interaction@example.com", password="Password123!")
+        self.client.force_authenticate(self.user)
+        self.product = Product.objects.create(
+            goods_id="GI2101",
+            goods_name="상호작용 테스트 상품",
+            brand_name="테스트 브랜드",
+            price=15000,
+            discount_price=12900,
+            thumbnail_url="https://example.com/interaction-thumb.png",
+            product_url="https://example.com/interaction-product",
+            crawled_at=timezone.now(),
+        )
+
+    def test_post_interaction_logs_click(self):
+        response = self.client.post(
+            "/api/orders/interactions/",
+            {
+                "product_id": self.product.goods_id,
+                "interaction_type": "click",
+                "weight": 1,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        interaction = UserInteraction.objects.get(user=self.user, product=self.product, interaction_type="click")
+        self.assertEqual(interaction.weight, 1)
+        self.assertEqual(response.data["interaction"]["product_id"], self.product.goods_id)
+        self.assertEqual(response.data["interaction"]["interaction_type"], "click")
+
+    def test_post_interaction_logs_reject(self):
+        response = self.client.post(
+            "/api/orders/interactions/",
+            {
+                "product_id": self.product.goods_id,
+                "interaction_type": "reject",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        interaction = UserInteraction.objects.get(user=self.user, product=self.product, interaction_type="reject")
+        self.assertEqual(interaction.weight, 1)
+
+    def test_post_interaction_rejects_unknown_type(self):
+        response = self.client.post(
+            "/api/orders/interactions/",
+            {
+                "product_id": self.product.goods_id,
+                "interaction_type": "unknown",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["code"], "invalid_interaction_type")
+        self.assertEqual(response.data["field"], "interaction_type")
 
 
 class OrderCreateApiTests(TestCase):

--- a/services/django/orders/urls.py
+++ b/services/django/orders/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .api import CartView, OrderDetailView, OrderListView, QuickPurchaseView, WishlistView
+from .api import CartView, InteractionView, OrderDetailView, OrderListView, QuickPurchaseView, WishlistView
 
 urlpatterns = [
     path("", OrderListView.as_view(), name="order-list"),
     path("quick-purchase/", QuickPurchaseView.as_view(), name="order-quick-purchase"),
+    path("interactions/", InteractionView.as_view(), name="order-interactions"),
     path("<uuid:order_id>/", OrderDetailView.as_view(), name="order-detail"),
     path("cart/", CartView.as_view(), name="order-cart"),
     path("wishlist/", WishlistView.as_view(), name="order-wishlist"),

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1141,6 +1141,35 @@
       });
     }
 
+    function logRecommendationInteraction(productId, interactionType, weight) {
+      if (!productId || !interactionType) return;
+      requestJson('/api/orders/interactions/', {
+        method: 'POST',
+        body: JSON.stringify({
+          product_id: productId,
+          interaction_type: interactionType,
+          session_id: activeSessionId || null,
+          weight: weight || 1,
+        }),
+      }).catch(function () {});
+    }
+
+    window.dismissRecommendationCard = function (button) {
+      if (!button) return;
+      var productId = button.getAttribute('data-product-id');
+      logRecommendationInteraction(productId, 'reject');
+      var card = button.closest('[data-recommendation-card]');
+      if (card) {
+        card.remove();
+      }
+      if (recommendationPanelBody && !recommendationPanelBody.querySelector('[data-recommendation-card]')) {
+        recommendationPanelBody.innerHTML = ''
+          + '<div class="rounded-[18px] border border-dashed border-[#d6e3f5] bg-white/88 px-5 py-7 text-center text-[14px] leading-6 text-[#718096]">'
+          + '이번 추천은 모두 닫았어요. 다시 대화를 이어가면 새 추천이 표시됩니다.'
+          + '</div>';
+      }
+    };
+
     function ensureSessionState(sessionId) {
       if (!sessionId) return null;
       if (!sessionState[sessionId]) {
@@ -1473,6 +1502,7 @@
     }
 
     function recommendationCardMarkup(item) {
+      var productId = escapeHtml(item.product_id || item.goods_id || '');
       var display = splitBrandAndName(item.brand_name || '', item.product_name || '추천 상품');
       var productUrl = escapeHtml(item.product_url || '');
       var brandName = escapeHtml(display.brand || '');
@@ -1482,7 +1512,7 @@
       var reviews = escapeHtml(normalizeReviewLabel(item.reviews));
       var rating = escapeHtml(item.rating || '4.7');
       var thumbnailHtml = productUrl
-        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="relative flex h-[68px] w-[68px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-br from-[#dbeafe] via-[#eff6ff] to-[#f8fafc] transition-transform hover:scale-[1.02]">'
+        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="relative flex h-[68px] w-[68px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-br from-[#dbeafe] via-[#eff6ff] to-[#f8fafc] transition-transform hover:scale-[1.02]" onclick="logRecommendationInteraction(\'' + productId + '\', \'click\')">'
           + '  <img src="' + thumbnailUrl + '" alt="" class="h-full w-full object-cover" onerror="this.style.display=\'none\'; this.parentNode.querySelector(&quot;.fallback-emoji&quot;).style.display = \'flex\';">'
           + '  <div class="fallback-emoji absolute inset-0 hidden items-center justify-center text-[26px]">🛍️</div>'
           + '</a>'
@@ -1491,11 +1521,11 @@
           + '  <div class="fallback-emoji absolute inset-0 hidden items-center justify-center text-[26px]">🛍️</div>'
           + '</div>';
       var nameHtml = productUrl
-        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="product-card-name block transition-colors hover:text-[#2b6cb0]">' + productName + '</a>'
+        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="product-card-name block transition-colors hover:text-[#2b6cb0]" onclick="logRecommendationInteraction(\'' + productId + '\', \'click\')">' + productName + '</a>'
         : '<div class="product-card-name">' + productName + '</div>';
 
       return ''
-        + '<article class="rounded-[20px] border border-[#dbe7f5] bg-white px-[14px] py-[13px] shadow-[0_8px_20px_rgba(45,55,72,0.05)]">'
+        + '<article class="rounded-[20px] border border-[#dbe7f5] bg-white px-[14px] py-[13px] shadow-[0_8px_20px_rgba(45,55,72,0.05)]" data-recommendation-card>'
         + '  <div class="flex items-center gap-[10px]">'
         +        thumbnailHtml
         + '    <div class="product-card-text-block min-w-0">'
@@ -1510,15 +1540,22 @@
         + '        <div class="flex items-center gap-[6px]">'
         + '          <button type="button"'
         + ' class="wishlist-heart inline-flex h-[28px] w-[28px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white leading-none transition-colors hover:border-[#f3c1c1] hover:text-[#e53e3e]"'
-        + ' data-product-id="' + escapeHtml(item.product_id || item.goods_id || '') + '"'
+        + ' data-product-id="' + productId + '"'
         + ' onclick="toggleRecommendedWishlist(this)"'
         + ' aria-label="관심 상품 추가">'
         + '  <svg width="14" height="14" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg>'
         + '  <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg>'
         + '</button>'
         + '<button type="button"'
+        + ' class="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#e2e8f0] bg-white text-[#94a3b8] transition-colors hover:border-[#cbd5e1] hover:text-[#64748b]"'
+        + ' data-product-id="' + productId + '"'
+        + ' onclick="dismissRecommendationCard(this)"'
+        + ' aria-label="이 추천 숨기기">'
+        + '  <span class="relative top-[-1px] text-[16px] leading-none">×</span>'
+        + '</button>'
+        + '<button type="button"'
         + ' class="flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-[#dbe7f5] bg-[#f8fbff] text-[#3182ce] transition-colors hover:border-[#bfdbfe] hover:bg-[#eef6ff]"'
-        + ' data-product-id="' + escapeHtml(item.product_id || item.goods_id || '') + '"'
+        + ' data-product-id="' + productId + '"'
         + ' onclick="addRecommendedToCart(this)"'
         + ' aria-label="장바구니 추가">'
         + '  <span class="relative top-[-1px] text-[16px] font-semibold leading-none">+</span>'

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -439,7 +439,7 @@
 
     function sanitizeBreedInput(value) {
       return (value || '')
-        .replace(/[^A-Za-z가-힣ㄱ-ㅎ\s]/g, '')
+        .replace(/[^A-Za-z가-힣ㄱ-ㅎ()\s]/g, '')
         .replace(/\s+/g, ' ')
         .replace(/^\s+/, '');
     }


### PR DESCRIPTION
## 요약
- 웹 쪽 추천 상호작용 수집 경로를 추가합니다.
- 데이터 점검 문서와 회귀 테스트를 함께 포함합니다.
- 로컬에만 남아 있던 추천 데이터 점검 브랜치 변경분을 draft PR로 올립니다.

## 참고
- 검토 전 상태 공유용 draft PR입니다.