### PR TITLE
feat(analytics): 관리자 대시보드 실집계와 통계 화면 보강

### DIFF
--- a/services/django/templates/users/vendor_analytics.html
+++ b/services/django/templates/users/vendor_analytics.html
@@ -3,8 +3,35 @@
 
 {% block vendor_content %}
 <section class="rounded-[26px] border border-white/70 bg-white/86 px-4 py-5 shadow-[0_18px_48px_rgba(148,163,184,0.14)] backdrop-blur sm:px-6 sm:py-6 md:px-8 md:py-8">
-  <div class="min-h-[28px] sm:min-h-[32px]">
-    <h2 class="text-[20px] font-bold tracking-[-0.02em] text-[#1d4ed8] sm:text-[22px]">핵심 성과 지표</h2>
+  <div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
+    <div class="min-h-[28px] sm:min-h-[32px]">
+      <h2 class="text-[20px] font-bold tracking-[-0.02em] text-[#1d4ed8] sm:text-[22px]">핵심 성과 지표</h2>
+      <p class="mt-2 text-[13px] leading-6 text-[#64748b]">{{ vendor_analytics_data_note }}</p>
+    </div>
+    <div class="flex flex-wrap gap-2">
+      {% for option in vendor_analytics_period_options %}
+      <a href="{{ option.url }}"
+         class="inline-flex rounded-full border px-3 py-1.5 text-[12px] font-semibold transition {% if option.is_active %}border-[#2563eb] bg-[#dbeafe] text-[#1d4ed8]{% else %}border-[#dbe7f5] bg-white text-[#64748b] hover:border-[#bfdbfe] hover:text-[#1d4ed8]{% endif %}">
+        {{ option.label }}
+      </a>
+      {% endfor %}
+    </div>
+  </div>
+
+  <div class="mt-5 rounded-[20px] border border-[#dbe7f5] bg-[#f8fbff] px-4 py-4">
+    <div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      <div>
+        <p class="text-[12px] font-semibold text-[#1d4ed8]">표본 수</p>
+        <p class="mt-1 text-[12px] leading-5 text-[#475569]">{{ vendor_analytics_period_label }} 기준으로 집계한 실제 행동 로그입니다.</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        {% for item in vendor_analytics_sample_items %}
+        <span class="inline-flex rounded-full border border-[#dbe7f5] bg-white px-3 py-1 text-[12px] font-semibold text-[#334155]">
+          {{ item.label }} {{ item.value }}
+        </span>
+        {% endfor %}
+      </div>
+    </div>
   </div>
 
   <div class="mt-5 grid gap-4 md:grid-cols-2 xl:grid-cols-4">
@@ -25,8 +52,8 @@
     <p class="text-[12px] font-semibold text-[#1d4ed8]">해석 기준</p>
     <div class="mt-3 divide-y divide-[#dbe7f5] rounded-[16px] border border-[#dbe7f5] bg-white">
       <div class="grid gap-2 px-4 py-3 md:grid-cols-[140px,minmax(0,1fr)] md:items-center">
-        <p class="text-[12px] font-semibold text-[#1e293b]">이번 달 매출</p>
-        <p class="text-[12px] leading-5 text-[#475569]">당월 누적 결제 금액 기준</p>
+        <p class="text-[12px] font-semibold text-[#1e293b]">{{ vendor_analytics_summary.0.label }}</p>
+        <p class="text-[12px] leading-5 text-[#475569]">{{ vendor_analytics_revenue_basis_label }}</p>
       </div>
       <div class="grid gap-2 px-4 py-3 md:grid-cols-[140px,minmax(0,1fr)] md:items-center">
         <p class="text-[12px] font-semibold text-[#1e293b]">구매 전환율</p>
@@ -285,7 +312,7 @@
     <a href="{% url 'vendor-products' %}" class="text-[13px] font-semibold text-[#2563eb] hover:text-[#1d4ed8]">상품 목록 보기</a>
   </div>
 
-  <div class="mt-6 space-y-3 lg:hidden">
+  <div class="mt-6 space-y-3 xl:hidden">
     {% for item in vendor_performance_rows %}
     <a href="{% url 'vendor-product-detail' item.goods_id %}" class="block rounded-[20px] border border-[#e5eef8] bg-[#f8fbff] px-4 py-4 transition hover:border-[#bfdbfe] hover:bg-white">
       <div class="flex items-start justify-between gap-4">
@@ -319,8 +346,9 @@
     {% endfor %}
   </div>
 
-  <div class="mt-6 hidden overflow-hidden rounded-[22px] border border-[#e5eef8] lg:block">
-    <div class="grid grid-cols-[72px,minmax(0,1.4fr),120px,140px,110px,120px,120px] gap-3 bg-[#f8fbff] px-5 py-4 text-[12px] font-semibold uppercase tracking-[0.08em] text-[#64748b]">
+  <div class="mt-6 hidden overflow-x-auto rounded-[22px] border border-[#e5eef8] xl:block">
+    <div class="min-w-[860px]">
+      <div class="grid grid-cols-[56px,minmax(220px,1.8fr),92px,108px,88px,96px,96px] gap-2.5 bg-[#f8fbff] px-4 py-4 text-[11px] font-semibold uppercase tracking-[0.08em] text-[#64748b]">
       <span>순위</span>
       <span>상품명</span>
       <span>상태</span>
@@ -328,30 +356,31 @@
       <span>CTR</span>
       <span>전환율</span>
       <span>재구매율</span>
-    </div>
+      </div>
 
-    <div class="divide-y divide-[#e5eef8]">
-      {% for item in vendor_performance_rows %}
-      <a href="{% url 'vendor-product-detail' item.goods_id %}" class="block px-5 py-4 transition hover:bg-[#f8fbff]">
-        <div class="grid gap-3 lg:grid-cols-[72px,minmax(0,1.4fr),120px,140px,110px,120px,120px] lg:items-center">
-          <div class="text-[13px] font-semibold text-[#64748b]">#{{ forloop.counter }}</div>
-          <div class="min-w-0">
-            <p class="truncate text-[15px] font-semibold text-[#1e293b]">{{ item.goods_name }}</p>
-            <div class="mt-1 flex items-center gap-2">
-              <p class="text-[12px] text-[#94a3b8]">{{ item.goods_id }}</p>
-              <span class="inline-flex rounded-full px-2.5 py-1 text-[11px] font-semibold {% if item.strength_tone == 'blue' %}bg-[#dbeafe] text-[#1d4ed8]{% elif item.strength_tone == 'green' %}bg-[#dcfce7] text-[#15803d]{% else %}bg-[#e2e8f0] text-[#475569]{% endif %}">
-                {{ item.strength_label }}
-              </span>
+      <div class="divide-y divide-[#e5eef8]">
+        {% for item in vendor_performance_rows %}
+        <a href="{% url 'vendor-product-detail' item.goods_id %}" class="block px-4 py-4 transition hover:bg-[#f8fbff]">
+          <div class="grid grid-cols-[56px,minmax(220px,1.8fr),92px,108px,88px,96px,96px] items-center gap-2.5">
+            <div class="text-[13px] font-semibold text-[#64748b]">#{{ forloop.counter }}</div>
+            <div class="min-w-0">
+              <p class="truncate text-[14px] font-semibold text-[#1e293b]">{{ item.goods_name }}</p>
+              <div class="mt-1 flex flex-wrap items-center gap-2">
+                <p class="truncate text-[11px] text-[#94a3b8]">{{ item.goods_id }}</p>
+                <span class="inline-flex rounded-full px-2.5 py-1 text-[10px] font-semibold {% if item.strength_tone == 'blue' %}bg-[#dbeafe] text-[#1d4ed8]{% elif item.strength_tone == 'green' %}bg-[#dcfce7] text-[#15803d]{% else %}bg-[#e2e8f0] text-[#475569]{% endif %}">
+                  {{ item.strength_label }}
+                </span>
+              </div>
             </div>
+            <div class="text-[12px] font-semibold text-[#475569]">{{ item.status_label }}</div>
+            <div class="text-[13px] font-bold text-[#1e293b]">{{ item.revenue_label }}</div>
+            <div class="text-[13px] font-semibold text-[#1d4ed8]">{{ item.ctr_label }}</div>
+            <div class="text-[13px] font-semibold text-[#1e293b]">{{ item.conversion_label }}</div>
+            <div class="text-[13px] font-semibold text-[#15803d]">{{ item.repeat_label }}</div>
           </div>
-          <div class="text-[13px] font-semibold text-[#475569]">{{ item.status_label }}</div>
-          <div class="text-[14px] font-bold text-[#1e293b]">{{ item.revenue_label }}</div>
-          <div class="text-[14px] font-semibold text-[#1d4ed8]">{{ item.ctr_label }}</div>
-          <div class="text-[14px] font-semibold text-[#1e293b]">{{ item.conversion_label }}</div>
-          <div class="text-[14px] font-semibold text-[#15803d]">{{ item.repeat_label }}</div>
-        </div>
-      </a>
-      {% endfor %}
+        </a>
+        {% endfor %}
+      </div>
     </div>
   </div>
 </section>

--- a/services/django/users/pages/views_vendor.py
+++ b/services/django/users/pages/views_vendor.py
@@ -4,6 +4,7 @@ from decimal import Decimal, InvalidOperation
 from urllib.parse import urlencode
 
 from django.db.models import Avg, Count, F, IntegerField, Sum
+from django.db.models.functions import TruncDate
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 
@@ -688,7 +689,8 @@ def vendor_dashboard_view(request):
     if base_context is None:
         return redirect("vendor-login")
 
-    vendor_products = Product.objects.filter(brand_name=base_context["vendor_account"]["brand_name"])
+    brand_name = base_context["vendor_account"]["brand_name"]
+    vendor_products = Product.objects.filter(brand_name=brand_name)
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
     demo_pending_goods_ids = _get_demo_pending_goods_ids(vendor_products, demo_soldout_goods_ids)
     total_products = vendor_products.count()
@@ -717,19 +719,48 @@ def vendor_dashboard_view(request):
     ]
     attention_products = _build_vendor_attention_products(vendor_products, demo_soldout_goods_ids, demo_pending_goods_ids)
     active_products = max(total_products - display_soldout_products - display_pending_products, 0)
-    mock_daily_revenue = 2480000
-    mock_daily_orders = 38
-    mock_cancel_refund = 3
-    review_check_count = max(sum(1 for product in top_products if product["review_count"] >= 100), 1)
-    trend_points = [
-        {"label": "03/25", "value": 42, "revenue": 1940000},
-        {"label": "03/26", "value": 58, "revenue": 2230000},
-        {"label": "03/27", "value": 51, "revenue": 2080000},
-        {"label": "03/28", "value": 66, "revenue": 2460000},
-        {"label": "03/29", "value": 61, "revenue": 2380000},
-        {"label": "03/30", "value": 74, "revenue": 2710000},
-        {"label": "03/31", "value": 69, "revenue": 2590000},
-    ]
+    brand_order_items = OrderItem.objects.filter(product__brand_name=brand_name)
+    active_brand_order_items = brand_order_items.exclude(order__status="cancelled")
+    today_date = date.today()
+    trend_start_date = today_date - timedelta(days=6)
+    today_revenue = (
+        active_brand_order_items.filter(order__created_at__date=today_date).aggregate(
+            total=Sum(F("quantity") * F("price_at_order"), output_field=IntegerField())
+        )["total"]
+        or 0
+    )
+    today_order_count = (
+        active_brand_order_items.filter(order__created_at__date=today_date).values("order_id").distinct().count()
+    )
+    processing_order_count = (
+        brand_order_items.filter(order__status="pending").values("order_id").distinct().count()
+    )
+    cancelled_order_count = (
+        brand_order_items.filter(order__status="cancelled").values("order_id").distinct().count()
+    )
+    review_check_count = vendor_products.filter(review_count__gte=100).count()
+    trend_rows = {
+        row["order_day"]: row
+        for row in active_brand_order_items.filter(order__created_at__date__gte=trend_start_date)
+        .annotate(order_day=TruncDate("order__created_at"))
+        .values("order_day")
+        .annotate(
+            order_count=Count("order_id", distinct=True),
+            revenue=Sum(F("quantity") * F("price_at_order"), output_field=IntegerField()),
+        )
+        .order_by("order_day")
+    }
+    trend_points = []
+    for offset in range(6, -1, -1):
+        day = today_date - timedelta(days=offset)
+        row = trend_rows.get(day, {})
+        trend_points.append(
+            {
+                "label": day.strftime("%m/%d"),
+                "value": row.get("order_count", 0) or 0,
+                "revenue": row.get("revenue", 0) or 0,
+            }
+        )
     max_trend_value = max((point["value"] for point in trend_points), default=1)
     for point in trend_points:
         point["height_percent"] = max(18, int(point["value"] / max_trend_value * 100))
@@ -746,24 +777,24 @@ def vendor_dashboard_view(request):
             "vendor_primary_kpis": [
                 {
                     "label": "오늘 매출",
-                    "value": f"₩{mock_daily_revenue:,}",
-                    "description": "전일 대비 +12.4%",
+                    "value": f"₩{today_revenue:,}",
+                    "description": "브랜드 기준 오늘 결제 금액",
                     "action_label": "매출 흐름 보기",
                     "href": reverse("vendor-analytics"),
                     "tone": "blue",
                 },
                 {
                     "label": "신규 주문",
-                    "value": f"{mock_daily_orders}건",
-                    "description": "결제 완료 후 출고 대기 기준",
+                    "value": f"{today_order_count}건",
+                    "description": "오늘 생성된 브랜드 주문 기준",
                     "action_label": "주문 처리",
                     "href": f"{reverse('vendor-orders')}?focus=processing",
                     "tone": "blue",
                 },
                 {
                     "label": "취소 / 환불 대기",
-                    "value": f"{mock_cancel_refund}건",
-                    "description": "오늘 우선 확인이 필요한 클레임",
+                    "value": f"{cancelled_order_count}건",
+                    "description": "현재 취소된 브랜드 주문 기준",
                     "action_label": "클레임 확인",
                     "href": f"{reverse('vendor-orders')}?focus=refund",
                     "tone": "rose",
@@ -785,13 +816,13 @@ def vendor_dashboard_view(request):
             "vendor_queue_items": [
                 {
                     "title": "신규 주문",
-                    "count_label": f"{mock_daily_orders}건",
+                    "count_label": f"{processing_order_count}건",
                     "href": f"{reverse('vendor-orders')}?focus=processing",
                     "tone": "blue",
                 },
                 {
                     "title": "취소 / 환불",
-                    "count_label": f"{mock_cancel_refund}건",
+                    "count_label": f"{cancelled_order_count}건",
                     "href": f"{reverse('vendor-orders')}?focus=refund",
                     "tone": "rose",
                 },
@@ -944,6 +975,19 @@ def vendor_analytics_view(request):
     if base_context is None:
         return redirect("vendor-login")
 
+    period_definitions = {
+        "7": {"label": "최근 7일", "days": 7},
+        "30": {"label": "최근 30일", "days": 30},
+        "all": {"label": "전체", "days": None},
+    }
+    selected_period = (request.GET.get("period") or "30").strip() or "30"
+    if selected_period not in period_definitions:
+        selected_period = "30"
+    selected_period_meta = period_definitions[selected_period]
+    period_start_date = None
+    if selected_period_meta["days"] is not None:
+        period_start_date = date.today() - timedelta(days=selected_period_meta["days"] - 1)
+
     brand_name = base_context["vendor_account"]["brand_name"]
     vendor_products = Product.objects.filter(brand_name=brand_name)
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
@@ -957,18 +1001,20 @@ def vendor_analytics_view(request):
     average_discount_price = vendor_products.aggregate(avg=Avg("discount_price"))["avg"]
     average_price_purchase = vendor_products.exclude(aspect_price_purchase__isnull=True).aggregate(avg=Avg("aspect_price_purchase"))["avg"]
     average_delivery = vendor_products.exclude(aspect_delivery_packaging__isnull=True).aggregate(avg=Avg("aspect_delivery_packaging"))["avg"]
+    interaction_queryset = UserInteraction.objects.filter(product__brand_name=brand_name)
+    brand_order_items = OrderItem.objects.filter(product__brand_name=brand_name).exclude(order__status="cancelled")
+    if period_start_date is not None:
+        interaction_queryset = interaction_queryset.filter(created_at__date__gte=period_start_date)
+        brand_order_items = brand_order_items.filter(order__created_at__date__gte=period_start_date)
+
     interaction_counts = {
         row["interaction_type"]: row["total"]
-        for row in UserInteraction.objects.filter(product__brand_name=brand_name)
+        for row in interaction_queryset
         .values("interaction_type")
         .annotate(total=Count("id"))
     }
-    brand_order_items = OrderItem.objects.filter(product__brand_name=brand_name).exclude(order__status="cancelled")
-    current_month_start = date.today().replace(day=1)
-    monthly_revenue = (
-        brand_order_items.filter(order__created_at__date__gte=current_month_start).aggregate(
-            total=Sum(F("quantity") * F("price_at_order"), output_field=IntegerField())
-        )["total"]
+    revenue_total = (
+        brand_order_items.aggregate(total=Sum(F("quantity") * F("price_at_order"), output_field=IntegerField()))["total"]
         or 0
     )
     orders = brand_order_items.values("order_id").distinct().count()
@@ -990,12 +1036,22 @@ def vendor_analytics_view(request):
     carts = interaction_counts.get("cart", 0)
     checkout_starts = interaction_counts.get("checkout_start", 0)
     wishlist_adds = interaction_counts.get("wishlist", 0)
+    sample_total = impressions + clicks + detail_views + carts + checkout_starts + wishlist_adds + orders
     ctr = (clicks / impressions) * 100 if impressions else 0
     detail_rate = (detail_views / clicks) * 100 if clicks else 0
     cart_rate = (carts / detail_views) * 100 if detail_views else 0
     order_rate = (orders / detail_views) * 100 if detail_views else 0
     repeat_rate_percent = (repeat_buyer_count / buyer_count) * 100 if buyer_count else 0
     price_resistance = max(0.0, 100 - float((average_price_purchase or 0) * 100))
+    revenue_label = f"{selected_period_meta['label']} 매출" if selected_period != "all" else "누적 매출"
+    revenue_basis_label = (
+        f"{selected_period_meta['label']} 결제 금액 기준" if selected_period != "all" else "전체 기간 결제 금액 기준"
+    )
+    period_caption = (
+        f"{selected_period_meta['label']} 실제 이벤트 로그 기준"
+        if selected_period != "all"
+        else "전체 기간 실제 이벤트 로그 기준"
+    )
 
     funnel_items = [
         {
@@ -1187,17 +1243,38 @@ def vendor_analytics_view(request):
 
     category_breakdown = _build_vendor_breakdown_items(category_counter)
     pet_type_breakdown = _build_vendor_breakdown_items(pet_type_counter)
+    vendor_analytics_period_options = [
+        {
+            "label": option_meta["label"],
+            "url": f"{reverse('vendor-analytics')}?{urlencode({'period': option_code})}",
+            "is_active": option_code == selected_period,
+        }
+        for option_code, option_meta in period_definitions.items()
+    ]
 
     return render(
         request,
         "users/vendor_analytics.html",
         {
             **base_context,
+            "vendor_analytics_period_label": selected_period_meta["label"],
+            "vendor_analytics_period_options": vendor_analytics_period_options,
+            "vendor_analytics_data_note": (
+                f"퍼널·매출은 {period_caption}, 상품·리뷰 지표는 현재 브랜드 데이터 기준입니다."
+            ),
+            "vendor_analytics_sample_items": [
+                {"label": "노출", "value": f"{impressions:,}"},
+                {"label": "클릭", "value": f"{clicks:,}"},
+                {"label": "체크아웃 시작", "value": f"{checkout_starts:,}"},
+                {"label": "구매", "value": f"{orders:,}"},
+                {"label": "이벤트 표본", "value": f"{sample_total:,}"},
+            ],
+            "vendor_analytics_revenue_basis_label": revenue_basis_label,
             "vendor_analytics_summary": [
-                {"label": "이번 달 매출", "value": f"₩{monthly_revenue:,}", "delta": "실주문 기준", "delta_tone": "neutral"},
-                {"label": "구매 전환율", "value": f"{order_rate:.1f}%", "delta": "상세 진입 대비", "delta_tone": "neutral"},
-                {"label": "반복 구매율", "value": f"{repeat_rate_percent:.1f}%", "delta": "브랜드 구매자 기준", "delta_tone": "neutral"},
-                {"label": "평균 실판매가", "value": _format_vendor_price(average_discount_price), "delta": "브랜드 상품 평균", "delta_tone": "neutral"},
+                {"label": revenue_label, "value": f"₩{revenue_total:,}", "delta": period_caption, "delta_tone": "neutral"},
+                {"label": "구매 전환율", "value": f"{order_rate:.1f}%", "delta": f"{selected_period_meta['label']} 상세 진입 대비", "delta_tone": "neutral"},
+                {"label": "반복 구매율", "value": f"{repeat_rate_percent:.1f}%", "delta": f"{selected_period_meta['label']} 브랜드 구매자 기준", "delta_tone": "neutral"},
+                {"label": "평균 실판매가", "value": _format_vendor_price(average_discount_price), "delta": "현재 브랜드 상품 평균", "delta_tone": "neutral"},
             ],
             "vendor_funnel_items": funnel_items,
             "vendor_explicit_metrics": explicit_metrics,

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -1,3 +1,4 @@
+from datetime import timedelta
 from unittest.mock import patch
 
 from django.test import TestCase, override_settings
@@ -399,6 +400,72 @@ class VendorAdminPageTests(TestCase):
         self.assertEqual(response["Location"], reverse("vendor-login"))
 
     def test_vendor_dashboard_renders_vendor_brand_metrics(self):
+        analytics_user = User.objects.create_user(email="vendor-dashboard@example.com", password="Password123!")
+        today = timezone.localdate()
+
+        pending_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="pending",
+        )
+        OrderItem.objects.create(order=pending_order, product=self.product, quantity=1, price_at_order=49900)
+
+        completed_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="completed",
+        )
+        OrderItem.objects.create(order=completed_order, product=self.product, quantity=1, price_at_order=49900)
+
+        cancelled_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="cancelled",
+        )
+        OrderItem.objects.create(order=cancelled_order, product=self.product, quantity=1, price_at_order=49900)
+
+        old_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="completed",
+        )
+        OrderItem.objects.create(order=old_order, product=self.product, quantity=1, price_at_order=49900)
+        old_timestamp = timezone.now() - timedelta(days=3)
+        Order.objects.filter(order_id=old_order.order_id).update(created_at=old_timestamp)
+
+        other_brand_product = Product.objects.get(goods_id="GI-VENDOR-2")
+        other_brand_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="다른 브랜드 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 2",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=42000,
+            total_price=42000,
+            status="completed",
+        )
+        OrderItem.objects.create(order=other_brand_order, product=other_brand_product, quantity=1, price_at_order=42000)
+
         session = self.client.session
         session["tailtalk_vendor_admin_id"] = "orijen"
         session.save()
@@ -414,6 +481,20 @@ class VendorAdminPageTests(TestCase):
         self.assertContains(response, "상품 등록")
         self.assertContains(response, "취소/교환/반품")
         self.assertContains(response, "고객문의 / CS")
+        primary = {item["label"]: item["value"] for item in response.context["vendor_primary_kpis"]}
+        queue = {item["title"]: item["count_label"] for item in response.context["vendor_queue_items"]}
+        trend = {item["label"]: item["value"] for item in response.context["vendor_trend_highlights"]}
+        self.assertEqual(primary["오늘 매출"], "₩99,800")
+        self.assertEqual(primary["신규 주문"], "2건")
+        self.assertEqual(primary["취소 / 환불 대기"], "1건")
+        self.assertEqual(queue["신규 주문"], "1건")
+        self.assertEqual(queue["취소 / 환불"], "1건")
+        self.assertEqual(queue["리뷰 확인"], "1건")
+        self.assertEqual(trend["7일 주문"], "3건")
+        self.assertEqual(trend["7일 매출"], "₩149,700")
+
+        order_trend = {point["label"]: point["value"] for point in response.context["vendor_order_trend"]}
+        self.assertEqual(order_trend[today.strftime("%m/%d")], 2)
 
     def test_vendor_products_filters_to_vendor_brand(self):
         session = self.client.session
@@ -513,10 +594,12 @@ class VendorAdminPageTests(TestCase):
         self.assertContains(response, "통계")
         self.assertContains(response, "퍼널")
         self.assertContains(response, "우선 액션")
+        self.assertContains(response, "실제 이벤트 로그 기준")
         summary = {item["label"]: item["value"] for item in response.context["vendor_analytics_summary"]}
         funnel = {item["label"]: item["value"] for item in response.context["vendor_funnel_items"]}
         implicit = {item["label"]: item["value"] for item in response.context["vendor_implicit_metrics"]}
-        self.assertEqual(summary["이번 달 매출"], "₩49,900")
+        self.assertEqual(response.context["vendor_analytics_period_label"], "최근 30일")
+        self.assertEqual(summary["최근 30일 매출"], "₩49,900")
         self.assertEqual(summary["구매 전환율"], "100.0%")
         self.assertEqual(summary["반복 구매율"], "0.0%")
         self.assertEqual(funnel["노출"], "5")
@@ -526,6 +609,60 @@ class VendorAdminPageTests(TestCase):
         self.assertEqual(funnel["구매"], "1")
         self.assertEqual(implicit["체크아웃 시작 수"], "1회")
         self.assertEqual(implicit["관심상품 추가 수"], "1회")
+
+    def test_vendor_analytics_period_filter_excludes_old_events(self):
+        analytics_user = User.objects.create_user(email="vendor-analytics-period@example.com", password="Password123!")
+        recent_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="completed",
+        )
+        OrderItem.objects.create(order=recent_order, product=self.product, quantity=1, price_at_order=49900)
+        for interaction_type, count in (("impression", 3), ("click", 1), ("detail_view", 1)):
+            for _ in range(count):
+                UserInteraction.objects.create(
+                    user=analytics_user,
+                    product=self.product,
+                    interaction_type=interaction_type,
+                )
+
+        old_order = Order.objects.create(
+            user=analytics_user,
+            recipient_name="오리젠 고객",
+            recipient_phone="01012341234",
+            delivery_address="서울 강남구 테일톡로 1",
+            payment_method="우리카드 1234 / 일시불",
+            product_total=49900,
+            total_price=49900,
+            status="completed",
+        )
+        OrderItem.objects.create(order=old_order, product=self.product, quantity=1, price_at_order=49900)
+        old_timestamp = timezone.now() - timedelta(days=10)
+        Order.objects.filter(order_id=old_order.order_id).update(created_at=old_timestamp)
+        old_interaction = UserInteraction.objects.create(
+            user=analytics_user,
+            product=self.product,
+            interaction_type="impression",
+        )
+        UserInteraction.objects.filter(id=old_interaction.id).update(created_at=old_timestamp)
+
+        session = self.client.session
+        session["tailtalk_vendor_admin_id"] = "orijen"
+        session.save()
+
+        response = self.client.get(f"{reverse('vendor-analytics')}?period=7")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.context["vendor_analytics_period_label"], "최근 7일")
+        summary = {item["label"]: item["value"] for item in response.context["vendor_analytics_summary"]}
+        funnel = {item["label"]: item["value"] for item in response.context["vendor_funnel_items"]}
+        self.assertEqual(summary["최근 7일 매출"], "₩49,900")
+        self.assertEqual(funnel["노출"], "3")
 
     def test_vendor_orders_requires_vendor_session(self):
         response = self.client.get(reverse("vendor-orders"))


### PR DESCRIPTION
## 요약
- 관리자 대시보드 상단 KPI와 처리 대기함을 오리젠 브랜드 주문 기준 실집계로 전환
- 관리자 대시보드 최근 7일 주문/매출 추이를 실데이터 기반으로 반영
- 관리자 통계에 기간 필터, 표본 수, 데이터 출처 문구를 추가하고 상품 성과 지표 반응형 레이아웃을 보강

## 검증
- git diff --check -- services/django/users/pages/views_vendor.py services/django/templates/users/vendor_analytics.html services/django/users/tests.py
- docker compose -f deploy/local/docker-compose.yml exec -T django python manage.py test --keepdb users.tests

Closes #356
