### PR TITLE
fix(analytics): 관리자 대시보드 0건 추이 예외 수정

### DIFF
--- a/services/django/users/pages/views_vendor.py
+++ b/services/django/users/pages/views_vendor.py
@@ -761,7 +761,7 @@ def vendor_dashboard_view(request):
                 "revenue": row.get("revenue", 0) or 0,
             }
         )
-    max_trend_value = max((point["value"] for point in trend_points), default=1)
+    max_trend_value = max((point["value"] for point in trend_points), default=0) or 1
     for point in trend_points:
         point["height_percent"] = max(18, int(point["value"] / max_trend_value * 100))
         point["revenue_label"] = _format_vendor_price(point["revenue"])

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -496,6 +496,25 @@ class VendorAdminPageTests(TestCase):
         order_trend = {point["label"]: point["value"] for point in response.context["vendor_order_trend"]}
         self.assertEqual(order_trend[today.strftime("%m/%d")], 2)
 
+    def test_vendor_dashboard_renders_when_brand_has_no_orders(self):
+        session = self.client.session
+        session["tailtalk_vendor_admin_id"] = "orijen"
+        session.save()
+
+        response = self.client.get(reverse("vendor-dashboard"))
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        primary = {item["label"]: item["value"] for item in response.context["vendor_primary_kpis"]}
+        trend = {item["label"]: item["value"] for item in response.context["vendor_trend_highlights"]}
+        order_trend = response.context["vendor_order_trend"]
+
+        self.assertEqual(primary["오늘 매출"], "₩0")
+        self.assertEqual(primary["신규 주문"], "0건")
+        self.assertEqual(trend["7일 주문"], "0건")
+        self.assertEqual(trend["7일 매출"], "₩0")
+        self.assertTrue(all(point["value"] == 0 for point in order_trend))
+        self.assertTrue(all(point["height_percent"] == 18 for point in order_trend))
+
     def test_vendor_products_filters_to_vendor_brand(self):
         session = self.client.session
         session["tailtalk_vendor_admin_id"] = "orijen"


### PR DESCRIPTION
## 변경 내용
- 최근 7일 주문 데이터가 0건일 때 대시보드 추이 막대 계산에서 나던 ZeroDivisionError 수정
- 오리젠 브랜드 주문이 하나도 없어도 관리자 대시보드가 200으로 렌더링되는 회귀 테스트 추가

## 검증
- docker compose -f deploy/local/docker-compose.yml exec -T django python manage.py test --keepdb users.tests