### PR TITLE
feat: 추천 하네스 실행 스크립트와 FastAPI refinement 연동 추가

### DIFF
--- a/docs/planning/14_recommendation_harness_change_summary.md
+++ b/docs/planning/14_recommendation_harness_change_summary.md
@@ -1,0 +1,200 @@
+# 추천 하네스 및 멀티턴 추천 변경 요약
+
+작성일: 2026-04-09
+
+## 목적
+- 추천 로직 회귀를 로컬에서 빠르게 확인할 수 있는 하네스를 추가합니다.
+- 채팅 기반 추천에서 이전 추천 결과를 이어받는 멀티턴 refinement를 안정적으로 지원합니다.
+- 실제 변경 범위와 현재 검증 상태를 후속 작업자가 바로 이해할 수 있도록 정리합니다.
+
+## 이번 변경의 큰 축
+
+### 1. 추천 하네스 추가
+- FastAPI 내부에 추천 하네스 패키지를 추가했습니다.
+- 하네스를 두 레이어로 분리했습니다.
+  - `state harness`
+    - 사용자 발화에서 `intent`, `pet_type`, `category`, `subcategory`, `brand`, `target_pet_id` 같은 상태를 얼마나 정확히 뽑는지 검증
+  - `recommendation harness`
+    - 구조화된 상태를 입력으로 넣었을 때 실제 추천 결과가 정책에 맞는지 검증
+
+추가된 대표 파일:
+- `services/fastapi/final_ai/harness/`
+- `services/fastapi/final_ai/tests/harness/`
+- `services/fastapi/final_ai/tests/fixtures/chat_state_cases.jsonl`
+- `services/fastapi/final_ai/tests/fixtures/recommendation_cases.jsonl`
+- `scripts/run_chat_recommend_harness.py`
+- `scripts/run_recommendation_harness.py`
+- `scripts/compare_harness_reports.py`
+
+### 2. 상태 추출과 추천 fixture 확대
+- `state harness` fixture는 현재 `18`개입니다.
+- `recommendation harness` fixture는 현재 `17`개입니다.
+
+현재 커버하는 대표 시나리오:
+- 기본 추천 질문
+- 브랜드 명시 추천
+- 문맥 기반 카테고리 전환
+- 문맥 기반 펫 타입 전환
+- 건강고민 follow-up
+- 복합 질문 분해
+- 다펫 이름 기반 전환
+- 예산 제한
+- 알러지 제외
+- 프로필 기반 추천
+- 이전 추천 결과 refinement
+
+### 3. 브랜드 hard filter 추가
+- 현재 턴에서 브랜드를 명시하면 해당 브랜드만 추천 후보로 제한되도록 변경했습니다.
+- 예: `로얄캐닌 고양이 사료 추천`
+
+적용 위치:
+- `services/fastapi/final_ai/domain/intent/service.py`
+- `services/fastapi/final_ai/domain/recommendation/query_service.py`
+- `services/fastapi/final_ai/infrastructure/repositories/product_filters.py`
+- `services/fastapi/final_ai/infrastructure/search/hybrid_search.py`
+
+### 4. 멀티턴 refinement 지원 추가
+- 채팅에서 추천 결과가 생성되면 마지막 추천 상품의 `goods_id` 목록을 메모리에 저장하도록 변경했습니다.
+- 다음 턴이 `이 중에서`, `그중에서`, `방금 추천한 것 중` 같은 refinement이면 이전 추천 결과 집합 안에서만 다시 검색하도록 변경했습니다.
+
+핵심 구조:
+- `last_recommended_goods_ids`
+- `allowed_goods_ids`
+- `is_result_refinement`
+- `refinement_sort`
+
+적용 위치:
+- `services/fastapi/final_ai/application/chat/dto.py`
+- `services/fastapi/final_ai/application/chat/memory.py`
+- `services/fastapi/final_ai/graph/state.py`
+- `services/fastapi/final_ai/graph/builder.py`
+- `services/fastapi/final_ai/graph/nodes/merge_node.py`
+- `services/fastapi/final_ai/domain/intent/service.py`
+- `services/fastapi/final_ai/domain/recommendation/search_service.py`
+- `services/fastapi/final_ai/infrastructure/repositories/product_filters.py`
+
+### 5. refinement 조건의 deterministic 정렬 추가
+- refinement는 이제 단순히 이전 추천 집합으로만 좁히는 것이 아니라, 그 집합 안에서 정렬 기준도 다시 적용합니다.
+- 현재 지원 정렬:
+  - `price_low`
+  - `price_high`
+  - `popularity`
+  - `rating`
+  - `review_count`
+
+예:
+- `이 중에서 더 싼 거로 보여줘` -> `price_low`
+- `그중에서 인기 많은 거` -> `popularity`
+
+적용 위치:
+- `services/fastapi/final_ai/domain/intent/prompts.py`
+- `services/fastapi/final_ai/domain/intent/service.py`
+- `services/fastapi/final_ai/domain/recommendation/rerank_service.py`
+
+## refinement 판정 방식
+- `is_result_refinement`는 이제 LLM이 1차로 판단합니다.
+- 기존 토큰 매칭 규칙은 제거하지 않았지만, 현재는 LLM 응답에 해당 키가 없을 때만 fallback으로 사용합니다.
+
+의도:
+- refinement 여부를 문맥 이해 기반으로 판단하게 하되
+- 제어 흐름이 완전히 흔들리지 않도록 최소한의 안전장치는 유지
+
+## JSON 출력 개선
+- 하네스 결과는 레포 안 `output/harness-runs/` 아래에 저장됩니다.
+- 각 실행 결과에는 사람이 바로 읽을 수 있는 `case_summaries`를 포함합니다.
+- `state harness`는 다음 정보를 같이 저장합니다.
+  - 원문 질문
+  - 내부 정규화 질문
+  - intent
+  - filters
+  - health_concerns
+  - route
+  - refinement 여부
+- `recommendation harness`는 다음 정보를 같이 저장합니다.
+  - 추천 결과 goods_id
+  - allowed scope
+  - last recommended goods ids
+  - refinement sort
+  - policy failure
+  - result count
+
+## 테스트 및 검증
+
+### 단위 테스트
+실행 통과:
+- FastAPI:
+  - `final_ai.tests.application.test_chat_service`
+  - `final_ai.tests.domain.test_intent_service`
+  - `final_ai.tests.domain.test_search_service`
+  - `final_ai.tests.domain.test_rerank_service`
+  - `final_ai.tests.harness.test_harness`
+- Django:
+  - `chat.tests.ChatProxyTests.test_session_messages_proxy_persists_user_and_assistant_messages`
+
+의미:
+- 이전 추천 결과 `goods_id`가 Django 채팅 세션 메모리에 저장되는지 확인
+- refinement 상태가 FastAPI graph 초기 상태로 다시 복원되는지 확인
+- refinement 정렬 로직이 기대 순서를 만드는지 확인
+
+### live harness 검증
+실행 통과한 대표 결과:
+- state refinement:
+  - `output/harness-runs/state/chat_state_harness_20260409_171616.json`
+- recommendation refinement `price_low`:
+  - `output/harness-runs/recommendation/recommendation_harness_20260409_171522.json`
+- recommendation refinement `popularity`:
+  - `output/harness-runs/recommendation/recommendation_harness_20260409_171618.json`
+
+확인된 내용:
+- `이 중에서 더 싼 거로 보여줘`
+  - 이전 추천 2개 안에서만 재검색
+  - `price_low` 기준 재정렬
+- `그중에서 인기 많은 거`
+  - 같은 2개 안에서만 재검색
+  - `popularity` 기준 재정렬
+
+## Django 쪽 변경
+- Django 테스트 더블 응답에 `last_recommended_goods_ids`를 포함시켰습니다.
+- 채팅 persistence 테스트에서 해당 값이 실제 `memory.dialog_state`에 저장되는지 검증합니다.
+
+변경 파일:
+- `services/django/chat/tests.py`
+
+## 현재 작업트리 기준 주요 변경 파일
+
+### WEB 루트
+- `services/django/chat/tests.py`
+- `scripts/run_chat_recommend_harness.py`
+- `scripts/run_recommendation_harness.py`
+- `scripts/compare_harness_reports.py`
+
+### AI 서브모듈
+- `final_ai/domain/intent/prompts.py`
+- `final_ai/domain/intent/service.py`
+- `final_ai/domain/recommendation/query_service.py`
+- `final_ai/domain/recommendation/search_service.py`
+- `final_ai/domain/recommendation/rerank_service.py`
+- `final_ai/application/chat/dto.py`
+- `final_ai/application/chat/memory.py`
+- `final_ai/graph/state.py`
+- `final_ai/graph/builder.py`
+- `final_ai/graph/nodes/merge_node.py`
+- `final_ai/infrastructure/repositories/product_filters.py`
+- `final_ai/infrastructure/search/hybrid_search.py`
+- `final_ai/tests/application/test_chat_service.py`
+- `final_ai/tests/domain/test_intent_service.py`
+- `final_ai/tests/domain/test_search_service.py`
+- `final_ai/tests/domain/test_rerank_service.py`
+- `final_ai/tests/harness/test_harness.py`
+
+## 남은 작업
+- 브라우저 기준 실제 채팅 2턴 HTTP 왕복 E2E 검증
+- refinement 조건 확장
+  - 예: 성분 제외, 브랜드 재한정, 가격 상한과 refinement 조합
+- 실제 서비스 질문 로그 기반 fixture 추가 축적
+- baseline/candidate 비교 루틴 고정
+
+## 현재 리스크
+- refinement scope와 정렬은 구현됐지만, 실제 사용자 표현은 더 다양할 수 있습니다.
+- `ingredient exclusion`처럼 의미 해석이 더 복잡한 refinement는 아직 fixture를 더 쌓아야 합니다.
+- 변경사항은 아직 커밋되지 않았습니다.

--- a/scripts/compare_harness_reports.py
+++ b/scripts/compare_harness_reports.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FASTAPI_ROOT = ROOT / "services" / "fastapi"
+if str(FASTAPI_ROOT) not in sys.path:
+    sys.path.insert(0, str(FASTAPI_ROOT))
+
+from final_ai.harness import compare_harness_reports, load_report  # noqa: E402
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare baseline and candidate harness reports.")
+    parser.add_argument("--baseline", required=True, help="Baseline JSON report path.")
+    parser.add_argument("--candidate", required=True, help="Candidate JSON report path.")
+    parser.add_argument("--report", default="", help="Optional JSON comparison output path.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    baseline_report = load_report(args.baseline)
+    candidate_report = load_report(args.candidate)
+    comparison = compare_harness_reports(baseline_report, candidate_report)
+
+    print("Harness Report Comparison")
+    summary = comparison["summary"]
+    print(
+        "baseline_failed_cases={baseline_failed_cases} candidate_failed_cases={candidate_failed_cases} "
+        "delta={failed_case_delta}".format(**summary)
+    )
+    print(f"status_regressions={len(comparison['status_regressions'])}")
+    print(f"status_improvements={len(comparison['status_improvements'])}")
+
+    if comparison["status_regressions"]:
+        print("status_regression_cases=" + ", ".join(comparison["status_regressions"]))
+    if comparison["average_metric_regressions"]:
+        print("average_metric_regressions=" + ", ".join(comparison["average_metric_regressions"]))
+
+    if args.report:
+        Path(args.report).write_text(json.dumps(comparison, ensure_ascii=False, indent=2), encoding="utf-8")
+        print(f"report={args.report}")
+
+    return 0 if comparison["passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_chat_recommend_harness.py
+++ b/scripts/run_chat_recommend_harness.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FASTAPI_ROOT = ROOT / "services" / "fastapi"
+if str(FASTAPI_ROOT) not in sys.path:
+    sys.path.insert(0, str(FASTAPI_ROOT))
+
+from final_ai.harness import (  # noqa: E402
+    build_state_report,
+    load_state_cases,
+    run_state_case,
+    score_state_result,
+    write_json_report,
+)
+
+
+DEFAULT_CASES = [
+    ROOT / "services/fastapi/final_ai/tests/fixtures/chat_state_cases.jsonl",
+]
+DEFAULT_REPORT_DIR = ROOT / "output" / "harness-runs" / "state"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run chat state acquisition harness cases.")
+    parser.add_argument(
+        "--cases",
+        nargs="*",
+        default=[str(path) for path in DEFAULT_CASES],
+        help="JSONL files containing chat state harness cases.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Optional JSON report output path. If omitted, a timestamped report is written under output/harness-runs/state.",
+    )
+    parser.add_argument(
+        "--case-id",
+        action="append",
+        default=[],
+        help="Optional case_id filter. Can be passed multiple times.",
+    )
+    return parser.parse_args()
+
+
+def resolve_report_path(raw_path: str) -> Path:
+    if raw_path:
+        return Path(raw_path)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return DEFAULT_REPORT_DIR / f"chat_state_harness_{timestamp}.json"
+
+
+def filter_cases(cases, case_ids: list[str]):
+    if not case_ids:
+        return cases
+    requested = set(case_ids)
+    return [case for case in cases if case.case_id in requested]
+
+
+def main() -> int:
+    args = parse_args()
+    cases = filter_cases(load_state_cases(*args.cases), args.case_id)
+    results = [run_state_case(case) for case in cases]
+    scores = [score_state_result(result) for result in results]
+    report = build_state_report(results, scores)
+    report_path = resolve_report_path(args.report)
+
+    print("Chat State Harness")
+    print(f"cases={report['summary']['total_cases']}")
+    print(f"passed={report['summary']['passed_cases']}")
+    print(f"failed={report['summary']['failed_cases']}")
+
+    for result, score in zip(results, scores):
+        status = "PASS" if score.passed else "FAIL"
+        print(f"- [{status}] {result.case.case_id}")
+        if result.error:
+            print(f"  error={result.error}")
+        if score.failures:
+            print(f"  failures={'; '.join(score.failures)}")
+        if score.metrics:
+            metric_summary = ", ".join(f"{key}={value}" for key, value in sorted(score.metrics.items()))
+            print(f"  metrics={metric_summary}")
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json_report(report, report_path)
+    print(f"report={report_path}")
+
+    return 0 if report["summary"]["failed_cases"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/run_recommendation_harness.py
+++ b/scripts/run_recommendation_harness.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+from datetime import datetime
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+FASTAPI_ROOT = ROOT / "services" / "fastapi"
+if str(FASTAPI_ROOT) not in sys.path:
+    sys.path.insert(0, str(FASTAPI_ROOT))
+
+from final_ai.harness import (  # noqa: E402
+    build_recommendation_report,
+    load_recommendation_cases,
+    run_recommendation_case,
+    score_recommendation_result,
+    write_json_report,
+)
+
+
+DEFAULT_CASES = [
+    ROOT / "services/fastapi/final_ai/tests/fixtures/recommendation_cases.jsonl",
+    ROOT / "services/fastapi/final_ai/tests/fixtures/recommendation_regression_cases.jsonl",
+]
+DEFAULT_REPORT_DIR = ROOT / "output" / "harness-runs" / "recommendation"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run recommendation harness cases.")
+    parser.add_argument(
+        "--cases",
+        nargs="*",
+        default=[str(path) for path in DEFAULT_CASES],
+        help="JSONL files containing recommendation harness cases.",
+    )
+    parser.add_argument(
+        "--report",
+        default="",
+        help="Optional JSON report output path. If omitted, a timestamped report is written under output/harness-runs/recommendation.",
+    )
+    parser.add_argument(
+        "--case-id",
+        action="append",
+        default=[],
+        help="Optional case_id filter. Can be passed multiple times.",
+    )
+    parser.add_argument(
+        "--postgres-host",
+        default="",
+        help="Optional PostgreSQL host override for host-side harness runs.",
+    )
+    return parser.parse_args()
+
+
+def resolve_report_path(raw_path: str) -> Path:
+    if raw_path:
+        return Path(raw_path)
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    return DEFAULT_REPORT_DIR / f"recommendation_harness_{timestamp}.json"
+
+
+def prepare_db_host(raw_override: str) -> str | None:
+    if raw_override:
+        os.environ["POSTGRES_HOST"] = raw_override
+        return raw_override
+
+    current_host = (os.getenv("POSTGRES_HOST") or "").strip()
+    if current_host == "postgres" and not Path("/.dockerenv").exists():
+        os.environ["POSTGRES_HOST"] = "127.0.0.1"
+        return "127.0.0.1"
+    return None
+
+
+def filter_cases(cases, case_ids: list[str]):
+    if not case_ids:
+        return cases
+    requested = set(case_ids)
+    return [case for case in cases if case.case_id in requested]
+
+
+def main() -> int:
+    args = parse_args()
+    effective_host = prepare_db_host(args.postgres_host)
+    cases = filter_cases(load_recommendation_cases(*args.cases), args.case_id)
+    results = [run_recommendation_case(case) for case in cases]
+    scores = [score_recommendation_result(result) for result in results]
+    report = build_recommendation_report(results, scores)
+    report_path = resolve_report_path(args.report)
+
+    print("Recommendation Harness")
+    if effective_host:
+        print(f"postgres_host={effective_host}")
+    print(f"cases={report['summary']['total_cases']}")
+    print(f"passed={report['summary']['passed_cases']}")
+    print(f"failed={report['summary']['failed_cases']}")
+
+    for result, score in zip(results, scores):
+        status = "PASS" if score.passed else "FAIL"
+        print(f"- [{status}] {result.case.case_id}")
+        if result.error:
+            print(f"  error={result.error}")
+        if score.policy_failures:
+            print(f"  policy_failures={'; '.join(score.policy_failures)}")
+        if score.metrics:
+            metric_summary = ", ".join(f"{key}={value}" for key, value in sorted(score.metrics.items()))
+            print(f"  metrics={metric_summary}")
+
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    write_json_report(report, report_path)
+    print(f"report={report_path}")
+
+    return 0 if report["summary"]["failed_cases"] == 0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -279,6 +279,7 @@ class _FakeHttpxClient:
                     "budget": None,
                     "filter_relaxation_count": 0,
                     "recommend_retry_pending": False,
+                    "last_recommended_goods_ids": ["TEST-PRODUCT-1"],
                 },
                 "memory_summary": "업데이트된 요약",
                 "last_compacted_message_id": None,
@@ -508,6 +509,7 @@ class ChatProxyTests(TestCase):
         self.assertEqual(memory.summary_text, "업데이트된 요약")
         self.assertEqual(memory.dialog_state["intents"], ["recommend"])
         self.assertEqual(memory.dialog_state["filters"], {"pet_type": "고양이", "category": "사료"})
+        self.assertEqual(memory.dialog_state["last_recommended_goods_ids"], ["TEST-PRODUCT-1"])
         self.assertIsNone(memory.last_compacted_message_id)
 
         list_response = self.client.get(


### PR DESCRIPTION
## 요약
추천 하네스 실행 스크립트와 변경 요약 문서를 추가하고, FastAPI 멀티턴 refinement 변경을 WEB 저장소에 서브모듈 포인터로 반영합니다.

## 변경 사항
- 로컬에서 state/recommendation harness를 실행하고 비교할 수 있도록 스크립트를 추가했습니다.
- 추천 하네스 및 멀티턴 refinement 변경 사항을 정리한 문서를 추가했습니다.
- Django 채팅 테스트에 `last_recommended_goods_ids` persistence 검증을 추가했습니다.
- FastAPI 서브모듈을 추천 하네스/멀티턴 refinement 변경이 포함된 커밋으로 갱신했습니다.
- 로컬 live harness와 Django 테스트 기준으로 멀티턴 refinement price/popularity 흐름을 검증했습니다.

## 관련 이슈
closes #361
ref https://github.com/skn-ai22-251029/SKN22-Final-2Team-AI/pull/48

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 루트 스크립트와 AI 서브모듈 변경 범위가 현재 로컬 실행 경로와 맞는지 봐주세요.
- Django 채팅 메모리 persistence 테스트가 서브모듈 쪽 refinement 구조와 자연스럽게 연결되는지 봐주세요.