### PR TITLE
feat: 유저 상품 상세페이지 추가 및 리뷰 지표 정합성 개선

### DIFF
--- a/services/django/chat/api/serializers.py
+++ b/services/django/chat/api/serializers.py
@@ -1,8 +1,19 @@
 from datetime import timedelta
 
+from django.urls import reverse
 from django.utils import timezone
 
+from products.review_metrics import (
+    attach_actual_review_metrics,
+    get_actual_rating_value,
+    get_actual_review_count,
+)
+
 from ..services.chat_session_service import normalize_profile_context_type
+
+
+def build_product_detail_url(goods_id):
+    return reverse("product_detail", args=[goods_id])
 
 
 def serialize_session(session):
@@ -21,6 +32,8 @@ def serialize_session(session):
 def serialize_message(message):
     recommended_products = []
     if hasattr(message, "recommended_products"):
+        recommendations = list(message.recommended_products.all())
+        attach_actual_review_metrics([recommendation.product for recommendation in recommendations])
         recommended_products = [
             {
                 "goods_id": recommendation.product.goods_id,
@@ -28,13 +41,14 @@ def serialize_message(message):
                 "brand_name": recommendation.product.brand_name,
                 "price": recommendation.product.price,
                 "discount_price": recommendation.product.discount_price,
-                "rating": float(recommendation.product.rating) if recommendation.product.rating is not None else None,
-                "reviews": recommendation.product.review_count,
+                "rating": get_actual_rating_value(recommendation.product),
+                "reviews": get_actual_review_count(recommendation.product),
                 "thumbnail_url": recommendation.product.thumbnail_url,
-                "product_url": recommendation.product.product_url,
+                "product_url": build_product_detail_url(recommendation.product.goods_id),
+                "external_product_url": recommendation.product.product_url,
                 "rank_order": recommendation.rank_order,
             }
-            for recommendation in message.recommended_products.all()
+            for recommendation in recommendations
         ]
 
     return {

--- a/services/django/chat/pages/context_builders.py
+++ b/services/django/chat/pages/context_builders.py
@@ -1,16 +1,27 @@
 import json
 
 from django.db.models import Q
+from django.urls import reverse
 
 from orders.models import Cart, Wishlist
 from pets.future_profile import get_future_pet_profile_for_request
 from products.catalog_menu import build_catalog_menu_context
 from products.models import Product
+from products.review_metrics import (
+    attach_actual_review_metrics,
+    get_actual_rating_label,
+    get_actual_review_count,
+    with_actual_review_metrics,
+)
 from users.social_auth import SOCIAL_AUTH_ACCESS_SESSION_KEY
 
 
 def format_price(value):
     return f"{value:,}원"
+
+
+def build_product_detail_url(goods_id):
+    return reverse("product_detail", args=[goods_id])
 
 
 def display_product_name(brand_name, goods_name):
@@ -55,7 +66,7 @@ def single_product_queryset():
     for term in excluded_terms:
         query = query.exclude(goods_name__icontains=term)
 
-    return query.order_by("-review_count", "-price", "goods_id")
+    return with_actual_review_metrics(query).order_by("-_actual_review_count", "-price", "goods_id")
 
 
 def serialize_recommended_product(product):
@@ -66,9 +77,10 @@ def serialize_recommended_product(product):
         "discount_price": "",
         "brand_name": product.brand_name,
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
-        "rating": str(product.rating or "0.0"),
-        "reviews": f"리뷰 {product.review_count}",
+        "product_url": build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
+        "rating": get_actual_rating_label(product) or "-",
+        "reviews": f"리뷰 {get_actual_review_count(product)}",
     }
 
 
@@ -81,10 +93,11 @@ def serialize_cart_product(item):
         "summary": "장바구니에 담긴 상품",
         "price": format_price(price),
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
+        "product_url": build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
         "brand_name": product.brand_name,
-        "rating": str(product.rating or "0.0"),
-        "reviews": f"리뷰 {product.review_count}",
+        "rating": get_actual_rating_label(product) or "-",
+        "reviews": f"리뷰 {get_actual_review_count(product)}",
         "quantity": item.quantity,
         "unit_price": price,
         "badge": "장바구니",
@@ -443,7 +456,9 @@ def build_chat_page_context(request):
         member_pets = [serialize_pet(pet) for pet in pets]
         cart = Cart.objects.filter(user=request.user).prefetch_related("items__product").first()
         if cart:
-            cart_products = [serialize_cart_product(item) for item in cart.items.all().order_by("-added_at")]
+            cart_items = list(cart.items.all().order_by("-added_at"))
+            attach_actual_review_metrics([item.product for item in cart_items])
+            cart_products = [serialize_cart_product(item) for item in cart_items]
             cart_total = sum(product["unit_price"] * product["quantity"] for product in cart_products)
         else:
             cart_products = []

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -16,7 +16,7 @@ from chat.api_views import sessions_proxy_view
 from chat.models import ChatMessage, ChatMessageRecommendation, ChatSession, ChatSessionMemory
 from chat.pages.views import ensure_chat_api_tokens
 from pets.models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
-from products.models import Product
+from products.models import Product, Review
 from users.models import User, UserProfile
 from users.onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY
 from users.social_auth import SOCIAL_AUTH_ACCESS_SESSION_KEY, SOCIAL_AUTH_REFRESH_SESSION_KEY
@@ -339,6 +339,22 @@ class ChatProxyTests(TestCase):
             health_concern_tags=[],
             crawled_at=timezone.now(),
         )
+        Review.objects.create(
+            review_id="RV-CHAT-0001",
+            product=self.product,
+            score=5.0,
+            content="기호성이 좋습니다.",
+            author_nickname="채팅버디1",
+            written_at=timezone.now().date(),
+        )
+        Review.objects.create(
+            review_id="RV-CHAT-0002",
+            product=self.product,
+            score=4.0,
+            content="무난하게 잘 먹어요.",
+            author_nickname="채팅버디2",
+            written_at=timezone.now().date(),
+        )
         self.other_user = User.objects.create_user(
             email="other-chat-owner@example.com",
             password="Password123!",
@@ -519,6 +535,8 @@ class ChatProxyTests(TestCase):
         self.assertEqual(list_response.status_code, 200)
         assistant_payload = list_response.json()["messages"][-1]
         self.assertEqual(assistant_payload["recommended_products"][0]["goods_id"], self.product.goods_id)
+        self.assertEqual(assistant_payload["recommended_products"][0]["reviews"], 2)
+        self.assertEqual(assistant_payload["recommended_products"][0]["rating"], 4.5)
 
     @patch("chat.api_views.httpx.Client", _ExplodingHttpxClient)
     def test_session_messages_proxy_persists_error_message_when_fastapi_is_unreachable(self):

--- a/services/django/orders/api/core.py
+++ b/services/django/orders/api/core.py
@@ -6,8 +6,15 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_simplejwt.authentication import JWTAuthentication
+from django.urls import reverse
 
 from products.models import Product
+from products.review_metrics import (
+    attach_actual_review_metrics,
+    get_actual_rating_value,
+    get_actual_review_count,
+    with_actual_review_metrics,
+)
 from users.quick_purchase import serialize_quick_purchase_profile
 
 from ..models import Cart, CartItem, Order, OrderItem, UserInteraction, Wishlist, WishlistItem
@@ -81,6 +88,10 @@ def _display_product_name(brand_name, goods_name):
     return (goods_name or "").strip()
 
 
+def _build_product_detail_url(goods_id):
+    return reverse("product_detail", args=[goods_id])
+
+
 def create_user_interaction(*, user, product, interaction_type, weight=1, session_id=None):
     return UserInteraction.objects.create(
         user=user,
@@ -112,10 +123,11 @@ def serialize_product_summary(product: Product) -> dict:
         "brand": product.brand_name,
         "price": price,
         "price_label": f"{price:,}원",
-        "rating": float(product.rating) if product.rating is not None else None,
-        "review_count": product.review_count,
+        "rating": get_actual_rating_value(product),
+        "review_count": get_actual_review_count(product),
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
+        "product_url": _build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
     }
 
 
@@ -566,7 +578,7 @@ def get_product_or_400(product_id):
             field="product_id",
         )
 
-    product = Product.objects.filter(goods_id=product_id).first()
+    product = with_actual_review_metrics(Product.objects).filter(goods_id=product_id).first()
     if product is None:
         return None, error_response(
             "product not found.",
@@ -581,6 +593,7 @@ def get_product_or_400(product_id):
 def get_cart_response(user):
     cart, _ = Cart.objects.get_or_create(user=user)
     items = list(cart.items.select_related("product").order_by("-added_at"))
+    attach_actual_review_metrics([item.product for item in items])
     serialized_items = [serialize_cart_item(item) for item in items]
     return Response(
         {
@@ -594,6 +607,7 @@ def get_cart_response(user):
 def get_wishlist_response(user):
     wishlist, _ = Wishlist.objects.get_or_create(user=user)
     items = list(wishlist.items.select_related("product").order_by("-added_at"))
+    attach_actual_review_metrics([item.product for item in items])
     serialized_items = [serialize_wishlist_item(item) for item in items]
     return Response(
         {

--- a/services/django/orders/page_urls.py
+++ b/services/django/orders/page_urls.py
@@ -1,11 +1,12 @@
 from django.urls import path
 
-from .pages import catalog, checkout, order_complete, order_list, used_products, wishlist_products
+from .pages import catalog, checkout, order_complete, order_list, product_detail, used_products, wishlist_products
 
 urlpatterns = [
     path("orders/", order_list, name="order_list"),
     path("orders/complete/<uuid:order_id>/", order_complete, name="order_complete"),
     path("products/", used_products, name="used_products"),
+    path("products/<str:goods_id>/", product_detail, name="product_detail"),
     path("wishlist/", wishlist_products, name="wishlist_products"),
     path("checkout/", checkout, name="checkout"),
     path("catalog/", catalog, name="catalog"),

--- a/services/django/orders/page_views.py
+++ b/services/django/orders/page_views.py
@@ -1,8 +1,9 @@
-from .pages import catalog, order_complete, order_list, used_products
+from .pages import catalog, order_complete, order_list, product_detail, used_products
 
 __all__ = [
     "catalog",
     "order_complete",
     "order_list",
+    "product_detail",
     "used_products",
 ]

--- a/services/django/orders/pages/__init__.py
+++ b/services/django/orders/pages/__init__.py
@@ -1,4 +1,4 @@
-from .views_catalog import catalog, checkout, used_products, wishlist_products
+from .views_catalog import catalog, checkout, product_detail, used_products, wishlist_products
 from .views_order_pages import order_complete, order_list
 
 __all__ = [
@@ -6,6 +6,7 @@ __all__ = [
     "checkout",
     "order_complete",
     "order_list",
+    "product_detail",
     "used_products",
     "wishlist_products",
 ]

--- a/services/django/orders/pages/core.py
+++ b/services/django/orders/pages/core.py
@@ -6,15 +6,118 @@ from django.db.models.functions import Coalesce
 from django.contrib.auth.decorators import login_required
 from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 
 from chat.models import ChatSession
 from products.catalog_menu import build_catalog_menu_context
-from products.models import Product
+from products.models import Product, Review
+from products.review_metrics import (
+    attach_actual_review_metrics,
+    get_actual_rating_label,
+    get_actual_review_count,
+    with_actual_review_metrics,
+)
 from ..models import Cart, Order, Wishlist
+from .detail_images import get_product_detail_image_urls
+
+PRODUCT_DETAIL_REVIEW_PAGE_SIZE = 12
 
 
 def _format_price(value):
     return f"{value:,}원"
+
+
+def _build_product_detail_url(goods_id):
+    return reverse("product_detail", args=[goods_id])
+
+
+def _format_detail_metric(value, digits=1, *, scale=1, suffix=""):
+    if value in {None, ""}:
+        return "-"
+    try:
+        normalized = float(value) * scale
+    except (TypeError, ValueError):
+        return str(value)
+    return f"{normalized:.{digits}f}{suffix}"
+
+
+def _normalize_product_tokens(value, *, limit=8):
+    tokens = []
+
+    if isinstance(value, dict):
+        for key, item in value.items():
+            key_label = str(key).strip()
+            if not key_label:
+                continue
+            if isinstance(item, (list, tuple)):
+                item_values = [str(entry).strip() for entry in item if str(entry).strip()]
+                detail = ", ".join(item_values[:2])
+                tokens.append(f"{key_label}: {detail}" if detail else key_label)
+            elif item in (None, "", [], {}):
+                tokens.append(key_label)
+            else:
+                tokens.append(f"{key_label}: {item}")
+    elif isinstance(value, (list, tuple)):
+        tokens = [str(item).strip() for item in value if str(item).strip()]
+    elif value:
+        tokens = [str(value).strip()]
+
+    return tokens[:limit]
+
+
+def _discount_rate_label(product):
+    if product.price and product.discount_price and product.price > 0 and product.discount_price < product.price:
+        return f"{int(round((1 - (product.discount_price / product.price)) * 100))}%"
+    return None
+
+
+def _format_review_date(value):
+    return value.strftime("%Y.%m.%d") if value else ""
+
+
+def _purchase_label(value):
+    if value == "repeat":
+        return "재구매"
+    if value == "first":
+        return "첫 구매"
+    return ""
+
+
+def _serialize_product_review(review):
+    return {
+        "review_id": review.review_id,
+        "author_label": (review.author_nickname or "익명").strip() or "익명",
+        "score_label": f"{review.score:.1f}" if review.score is not None else "-",
+        "content": (review.content or "").strip(),
+        "written_at_label": _format_review_date(review.written_at),
+        "purchase_label": _purchase_label(review.purchase_label),
+    }
+
+
+def _load_product_detail_reviews(product, *, page_number=1, page_size=PRODUCT_DETAIL_REVIEW_PAGE_SIZE):
+    queryset = (
+        Review.objects.filter(product=product)
+        .only("review_id", "score", "content", "author_nickname", "written_at", "purchase_label")
+        .order_by("-written_at", "-review_id")
+    )
+    paginator = Paginator(queryset, page_size)
+    page_obj = paginator.get_page(page_number)
+    review_items = [_serialize_product_review(review) for review in page_obj.object_list]
+    return page_obj, review_items
+
+
+def _build_review_page_url(request, *, page_number):
+    query_params = request.GET.copy()
+
+    if page_number <= 1:
+        query_params.pop("review_page", None)
+    else:
+        query_params["review_page"] = str(page_number)
+
+    encoded_query = query_params.urlencode()
+    if encoded_query:
+        return f"{request.path}?{encoded_query}#reviews"
+    return f"{request.path}#reviews"
 
 
 def _product_summary(product):
@@ -174,7 +277,7 @@ DEFAULT_CATALOG_PAGE_SIZE = 24
 CATALOG_SORT_OPTIONS = {
     "tailtalk": {
         "label": "TailTalk 추천순",
-        "ordering": ("-_sort_popularity_score", "-_sort_review_count", "-_sort_rating", "goods_name"),
+        "ordering": ("-_sort_has_rating", "-_sort_popularity_score", "-_sort_review_count", "-_sort_rating", "goods_name"),
     },
     "reviews": {
         "label": "리뷰 많은순",
@@ -211,14 +314,15 @@ def _serialize_catalog_item(product, *, is_wishlisted=False, cart_quantity=0):
     return {
         "product_id": product.goods_id,
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
+        "product_url": _build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
         "brand_name": product.brand_name,
         "name": _display_product_name(product.brand_name, product.goods_name),
         "summary": _product_summary(product),
         "price": product.price,
         "price_label": _format_price(product.price),
-        "rating": f"{product.rating:.1f}" if product.rating is not None else None,
-        "review_count": product.review_count or 0,
+        "rating": get_actual_rating_label(product),
+        "review_count": get_actual_review_count(product),
         "pet_type": product.pet_type,
         "category": product.category,
         "subcategory": product.subcategory,
@@ -262,9 +366,10 @@ def _catalog_brand_sort_key(value):
 
 
 def _with_catalog_sort_fields(queryset):
+    queryset = with_actual_review_metrics(queryset)
     return queryset.annotate(
         _sort_has_rating=Case(
-            When(rating__isnull=False, then=Value(1)),
+            When(_actual_review_count__gt=0, then=Value(1)),
             default=Value(0),
             output_field=IntegerField(),
         ),
@@ -274,14 +379,14 @@ def _with_catalog_sort_fields(queryset):
             output_field=DecimalField(max_digits=10, decimal_places=4),
         ),
         _sort_review_count=Coalesce(
-            "review_count",
+            "_actual_review_count",
             Value(0),
             output_field=IntegerField(),
         ),
         _sort_rating=Coalesce(
-            "rating",
+            "_actual_review_score_avg",
             Value(0),
-            output_field=DecimalField(max_digits=3, decimal_places=1),
+            output_field=DecimalField(max_digits=4, decimal_places=2),
         ),
     )
 
@@ -321,13 +426,14 @@ def _serialize_recommendation_item(recommendation, *, is_wishlisted=False, cart_
     return {
         "product_id": product.goods_id,
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
+        "product_url": _build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
         "brand_name": product.brand_name,
         "name": _display_product_name(product.brand_name, product.goods_name),
         "summary": _product_summary(product),
         "price_label": _format_price(product.price),
-        "rating": f"{product.rating:.1f}" if product.rating is not None else None,
-        "review_count": product.review_count or 0,
+        "rating": get_actual_rating_label(product),
+        "review_count": get_actual_review_count(product),
         "rank_order": recommendation.rank_order,
         "is_wishlisted": is_wishlisted,
         "cart_quantity": cart_quantity,
@@ -505,11 +611,12 @@ def _single_product_queryset():
     for term in excluded_terms:
         query = query.exclude(goods_name__icontains=term)
 
-    return query.order_by("-review_count", "-price", "goods_id")
+    return _with_catalog_sort_fields(query).order_by("-_sort_review_count", "-price", "goods_id")
 
 
 def _load_product_panels():
     base_products = list(_single_product_queryset()[:30])
+    attach_actual_review_metrics(base_products)
 
     if not base_products:
         return [], []
@@ -550,8 +657,8 @@ def _load_product_panels():
                 "name": _display_product_name(product.brand_name, product.goods_name),
                 "summary": _product_summary(product),
                 "price": product.price,
-                "rating": product.rating,
-                "review_count": product.review_count,
+                "rating": get_actual_rating_label(product),
+                "review_count": get_actual_review_count(product),
                 "quantity": (index % 3) + 1,
                 "note": _recommended_note(index),
                 "is_wishlisted": product.goods_id in wishlist_goods_ids,
@@ -567,8 +674,8 @@ def _load_product_panels():
                 "name": _display_product_name(product.brand_name, product.goods_name),
                 "summary": _product_summary(product),
                 "price": product.price,
-                "rating": product.rating,
-                "review_count": product.review_count,
+                "rating": get_actual_rating_label(product),
+                "review_count": get_actual_review_count(product),
                 "note": _recommended_note(index),
             }
         )
@@ -580,13 +687,14 @@ def _serialize_panel_product(product, quantity=1, is_wishlisted=False, note="가
     return {
         "goods_id": product.goods_id,
         "thumbnail_url": product.thumbnail_url,
-        "product_url": product.product_url,
+        "product_url": _build_product_detail_url(product.goods_id),
+        "external_product_url": product.product_url,
         "brand": product.brand_name,
         "name": _display_product_name(product.brand_name, product.goods_name),
         "summary": _product_summary(product),
         "price": product.price,
-        "rating": product.rating,
-        "review_count": product.review_count,
+        "rating": get_actual_rating_label(product),
+        "review_count": get_actual_review_count(product),
         "quantity": quantity,
         "note": note,
         "is_wishlisted": is_wishlisted,
@@ -599,6 +707,11 @@ def _load_user_product_panels(user):
 
     wishlist_items_qs = list(wishlist.items.select_related("product").order_by("-added_at"))
     wishlist_ids = {item.product_id for item in wishlist_items_qs}
+    cart_items_qs = list(cart.items.select_related("product").order_by("-added_at"))
+
+    attach_actual_review_metrics(
+        [item.product for item in cart_items_qs] + [item.product for item in wishlist_items_qs]
+    )
 
     cart_items = [
         _serialize_panel_product(
@@ -606,7 +719,7 @@ def _load_user_product_panels(user):
             quantity=item.quantity,
             is_wishlisted=item.product_id in wishlist_ids,
         )
-        for item in cart.items.select_related("product").order_by("-added_at")
+        for item in cart_items_qs
     ]
     wishlist_items = [
         _serialize_panel_product(item.product, quantity=1)
@@ -880,6 +993,118 @@ def _render_used_products(request, *, active_tab):
     )
 
 
+def _collect_related_products(product, *, limit=4):
+    base_queryset = Product.objects.filter(soldout_yn=False).exclude(goods_id=product.goods_id)
+    ordered_products = []
+    seen_goods_ids = set()
+
+    def extend(queryset, fetch_count):
+        for candidate in _with_catalog_sort_fields(queryset).order_by(*CATALOG_SORT_OPTIONS["tailtalk"]["ordering"])[:fetch_count]:
+            if candidate.goods_id in seen_goods_ids:
+                continue
+            seen_goods_ids.add(candidate.goods_id)
+            ordered_products.append(candidate)
+            if len(ordered_products) >= limit:
+                break
+
+    if product.subcategory:
+        extend(base_queryset.filter(subcategory__overlap=product.subcategory), limit * 2)
+    if len(ordered_products) < limit and product.category:
+        extend(base_queryset.filter(category__overlap=product.category), limit * 2)
+    if len(ordered_products) < limit and product.brand_name:
+        extend(base_queryset.filter(brand_name=product.brand_name), limit * 2)
+    if len(ordered_products) < limit and product.pet_type:
+        extend(base_queryset.filter(pet_type__overlap=product.pet_type), limit * 3)
+    if len(ordered_products) < limit:
+        extend(base_queryset, limit * 4)
+
+    return ordered_products[:limit]
+
+
+def _build_product_detail_context(request, product, serialized_product):
+    category_segments = list(product.category or [])
+    subcategory_segments = list(product.subcategory or [])
+    ingredient_tokens = _normalize_product_tokens(product.main_ingredients)
+    nutrition_tokens = _normalize_product_tokens(product.nutrition_info, limit=6)
+    guide_text = (product.guide_text or "").strip()
+    ingredient_text = (product.ingredient_text_ocr or "").strip()
+    has_discount = bool(
+        product.price
+        and product.discount_price
+        and product.discount_price > 0
+        and product.discount_price < product.price
+    )
+    current_price = product.discount_price if has_discount else product.price
+    discount_rate_label = _discount_rate_label(product)
+    current_price_label = _format_price(current_price)
+    original_price_label = _format_price(product.price) if has_discount else None
+    review_page_number = request.GET.get("review_page") or 1
+    review_page_obj, review_items = _load_product_detail_reviews(product, page_number=review_page_number)
+    review_count = review_page_obj.paginator.count
+
+    detail_highlights = [
+        {"label": "판매가", "value": current_price_label},
+        {"label": "정가", "value": original_price_label or current_price_label},
+        {"label": "리뷰", "value": f"{review_count:,}개"},
+        {"label": "평점", "value": serialized_product["rating"] or "-"},
+    ]
+
+    signal_rows = [
+        {"label": "추천 점수", "value": _format_detail_metric(product.popularity_score, 2)},
+        {"label": "반복 구매율", "value": _format_detail_metric(product.repeat_rate, 1, scale=100, suffix="%")},
+        {"label": "리뷰 정서", "value": _format_detail_metric(product.sentiment_avg, 1, scale=100, suffix="%")},
+        {"label": "기호성", "value": _format_detail_metric(product.aspect_palatability, 2)},
+        {"label": "배송/포장", "value": _format_detail_metric(product.aspect_delivery_packaging, 2)},
+        {"label": "가격 반응", "value": _format_detail_metric(product.aspect_price_purchase, 2)},
+    ]
+
+    info_rows = [
+        {"label": "브랜드", "value": product.brand_name},
+        {"label": "반려동물", "value": ", ".join(product.pet_type) if product.pet_type else "반려동물 공용"},
+        {"label": "카테고리", "value": " · ".join(category_segments) if category_segments else "카테고리 미지정"},
+        {"label": "세부 분류", "value": " · ".join(subcategory_segments) if subcategory_segments else "-"},
+    ]
+
+    note_sections = []
+    if guide_text:
+        note_sections.append({"title": "급여 가이드", "content": guide_text})
+    if ingredient_text:
+        note_sections.append({"title": "원재료 안내", "content": ingredient_text})
+
+    return {
+        "product_detail_status_label": "품절" if product.soldout_yn else "판매중",
+        "product_detail_status_tone": "rose" if product.soldout_yn else "green",
+        "product_detail_discount_rate_label": discount_rate_label,
+        "product_detail_current_price_label": current_price_label,
+        "product_detail_original_price_label": original_price_label,
+        "product_detail_subcategory_label": " · ".join(subcategory_segments) if subcategory_segments else "-",
+        "product_detail_highlights": detail_highlights,
+        "product_detail_signal_rows": signal_rows,
+        "product_detail_info_rows": info_rows,
+        "product_detail_ingredient_tokens": ingredient_tokens,
+        "product_detail_nutrition_tokens": nutrition_tokens,
+        "product_detail_note_sections": note_sections,
+        "product_detail_review_items": review_items,
+        "product_detail_review_count_label": f"{review_count:,}",
+        "product_detail_review_page_number": review_page_obj.number,
+        "product_detail_review_total_pages": review_page_obj.paginator.num_pages,
+        "product_detail_review_has_previous": review_page_obj.has_previous(),
+        "product_detail_review_has_next": review_page_obj.has_next(),
+        "product_detail_review_previous_url": (
+            _build_review_page_url(request, page_number=review_page_obj.previous_page_number())
+            if review_page_obj.has_previous()
+            else ""
+        ),
+        "product_detail_review_next_url": (
+            _build_review_page_url(request, page_number=review_page_obj.next_page_number())
+            if review_page_obj.has_next()
+            else ""
+        ),
+        "product_detail_review_empty_message": "아직 표시할 리뷰가 없습니다." if review_count == 0 else "리뷰 본문을 준비 중입니다.",
+        "product_detail_story_images": get_product_detail_image_urls(product),
+    }
+
+
 @login_required
 def catalog(request):
     keyword = (request.GET.get("q") or "").strip()[:50]
@@ -1008,13 +1233,17 @@ def catalog(request):
                 None,
             )
             if latest_recommendation_message is not None:
+                recommendation_items = list(
+                    latest_recommendation_message.recommended_products.select_related("product").order_by("rank_order", "created_at")
+                )
+                attach_actual_review_metrics([item.product for item in recommendation_items])
                 recommended_items = [
                     _serialize_recommendation_item(
                         recommendation,
                         is_wishlisted=recommendation.product_id in wishlist_product_ids,
                         cart_quantity=cart_quantities.get(recommendation.product_id, 0),
                     )
-                    for recommendation in latest_recommendation_message.recommended_products.select_related("product").order_by("rank_order", "created_at")
+                    for recommendation in recommendation_items
                 ]
 
     context = {
@@ -1104,6 +1333,46 @@ def catalog(request):
         **_member_nav_indicator_state(request.user),
     }
     return render(request, "orders/catalog.html", context)
+
+
+@login_required
+def product_detail(request, goods_id):
+    product = get_object_or_404(with_actual_review_metrics(Product.objects), goods_id=goods_id)
+
+    cart, _ = Cart.objects.get_or_create(user=request.user)
+    wishlist, _ = Wishlist.objects.get_or_create(user=request.user)
+    wishlist_product_ids = set(wishlist.items.values_list("product_id", flat=True))
+    cart_quantities = {
+        product_id: quantity
+        for product_id, quantity in cart.items.values_list("product_id", "quantity")
+    }
+
+    serialized_product = _serialize_catalog_item(
+        product,
+        is_wishlisted=product.goods_id in wishlist_product_ids,
+        cart_quantity=cart_quantities.get(product.goods_id, 0),
+    )
+    related_items = [
+        _serialize_catalog_item(
+            related_product,
+            is_wishlisted=related_product.goods_id in wishlist_product_ids,
+            cart_quantity=cart_quantities.get(related_product.goods_id, 0),
+        )
+        for related_product in _collect_related_products(product)
+    ]
+
+    return render(
+        request,
+        "orders/product_detail.html",
+        {
+            "product_detail": serialized_product,
+            "product_detail_related_items": related_items,
+            "product_detail_session_id": (request.GET.get("session") or "").strip(),
+            "product_detail_source": (request.GET.get("source") or "").strip(),
+            **_build_product_detail_context(request, product, serialized_product),
+            **_member_nav_indicator_state(request.user),
+        },
+    )
 
 
 @login_required

--- a/services/django/orders/pages/demo_detail_images.py
+++ b/services/django/orders/pages/demo_detail_images.py
@@ -1,0 +1,51 @@
+"""Demo-only product detail image URLs for the user product detail page."""
+
+PRODUCT_DETAIL_DEMO_IMAGE_MAP = {
+    "GP251066079": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202210/e2be246b-3cfe-45d1-ad60-fdbeeb91487f.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202210/8e7d137d-9aa4-4086-b703-2201d99d1060.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202210/0b7b6174-21b6-4a70-bd56-60a12f94b73e.jpg",
+    ),
+    "PI000003245": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202409/fd2daaeb-c9a2-4950-8803-0839ea3ecb07.jpg",
+    ),
+    "GP251127669": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202410/9a5c8bfa-0d3d-43d1-84b4-66297e4351ee.jpg",
+    ),
+    "GP251077014": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/636ccf32-2193-4280-9489-5c83ccd4f05e.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/c2b491d1-2a88-4e00-87ba-28d94b9a950d.jpg",
+    ),
+    "GP251077010": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/0c528d98-71d6-4ca1-aa6c-b035539712ea.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/1acc94b8-183e-4ca7-861a-fa9b4b249494.jpg",
+    ),
+    "GP251077022": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/59ff0586-1810-4981-902d-65e5cfafcc9e.jpg",
+    ),
+    "GP251105002": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/9a4c845f-76ad-4904-a38f-cc0cf27aab05.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/b38d88bf-5f1d-4b9e-86fa-29094fee0c2e.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/6800088e-50fa-4f3c-8664-d0e8ac0c3eb2.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/81299494-97ad-4aa3-a682-7f27bbb24548.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/df865e61-a822-4305-9f11-d8de8f06cade.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/8f8ac15c-2bcb-4db1-a7f2-1f72200ebd62.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/d9d7aa2b-315e-4d0c-ab71-605d04863de5.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/080efe03-e9c2-4258-aa55-6d10f368ffde.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/9f39e3e6-67d6-47ef-92d6-19a3b9a223f5.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/305cba54-aead-48ea-85ab-f2f952d2b9a0.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/189bd9d6-c12a-4a7d-821d-0b0206afc373.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202401/af26dfb5-0c7d-4791-8060-4dd4f9ba6281.jpg",
+    ),
+    "GP251075833": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202303/bc5674e6-7717-45e9-bbdc-b69b3fcf9fc4.jpg",
+    ),
+    "GP251077005": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202512/f37bc7aa-4ef4-4462-b81f-2c820b21e6fa.jpg",
+    ),
+    "GP251073717": (
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202508/fc04dbbb-952f-4c4c-abc3-16d96e598f65.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202508/1c820852-89dc-4701-bcee-3e60ebb4b910.jpg",
+        "https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/202508/34f5f9e0-53f0-461b-b4c0-ce1ed2514f91.jpg",
+    ),
+}

--- a/services/django/orders/pages/detail_images.py
+++ b/services/django/orders/pages/detail_images.py
@@ -1,0 +1,79 @@
+import re
+from functools import lru_cache
+from urllib.error import HTTPError, URLError
+from urllib.parse import quote, urlparse
+from urllib.request import Request, urlopen
+
+from .demo_detail_images import PRODUCT_DETAIL_DEMO_IMAGE_MAP
+
+ABOUTPET_HOST_SUFFIX = "aboutpet.co.kr"
+ABOUTPET_DETAIL_ENDPOINT = "https://www.aboutpet.co.kr/goods/getGoodsDetail?goodsId={goods_id}"
+ABOUTPET_DETAIL_IMAGE_PATTERN = re.compile(
+    r"https://prd-main-cdn\.aboutpet\.co\.kr/aboutPet/images/editor/goods_desc/[^\"'<>\s]+"
+)
+ABOUTPET_REQUEST_TIMEOUT_SECONDS = 5
+ABOUTPET_REQUEST_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+ABOUTPET_GOODS_PREFIXES = ("GP", "PI", "GI", "GS", "GO")
+
+
+def _dedupe_urls(urls):
+    seen = set()
+    ordered_urls = []
+    for url in urls:
+        normalized = (url or "").strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        ordered_urls.append(normalized)
+    return tuple(ordered_urls)
+
+
+def _is_aboutpet_product(product):
+    product_url = (getattr(product, "product_url", "") or "").strip()
+    goods_id = (getattr(product, "goods_id", "") or "").strip()
+
+    if product_url:
+        hostname = (urlparse(product_url).hostname or "").lower()
+        return hostname.endswith(ABOUTPET_HOST_SUFFIX)
+
+    return goods_id.startswith(ABOUTPET_GOODS_PREFIXES)
+
+
+def _extract_aboutpet_detail_image_urls(html):
+    return _dedupe_urls(ABOUTPET_DETAIL_IMAGE_PATTERN.findall(html or ""))
+
+
+@lru_cache(maxsize=8192)
+def _fetch_aboutpet_detail_image_urls(goods_id):
+    normalized_goods_id = (goods_id or "").strip()
+    if not normalized_goods_id:
+        return ()
+
+    request = Request(
+        ABOUTPET_DETAIL_ENDPOINT.format(goods_id=quote(normalized_goods_id)),
+        headers={"User-Agent": ABOUTPET_REQUEST_USER_AGENT},
+    )
+
+    try:
+        with urlopen(request, timeout=ABOUTPET_REQUEST_TIMEOUT_SECONDS) as response:
+            html = response.read().decode("utf-8", errors="ignore")
+    except (HTTPError, URLError, TimeoutError, ValueError):
+        return ()
+    except Exception:
+        return ()
+
+    return _extract_aboutpet_detail_image_urls(html)
+
+
+def get_product_detail_image_urls(product):
+    seeded_urls = PRODUCT_DETAIL_DEMO_IMAGE_MAP.get(getattr(product, "goods_id", ""))
+    if seeded_urls:
+        return seeded_urls
+
+    if not _is_aboutpet_product(product):
+        return ()
+
+    return _fetch_aboutpet_detail_image_urls(getattr(product, "goods_id", ""))

--- a/services/django/orders/pages/views_catalog.py
+++ b/services/django/orders/pages/views_catalog.py
@@ -1,8 +1,9 @@
-from .core import catalog, checkout, used_products, wishlist_products
+from .core import catalog, checkout, product_detail, used_products, wishlist_products
 
 __all__ = [
     "catalog",
     "checkout",
+    "product_detail",
     "used_products",
     "wishlist_products",
 ]

--- a/services/django/orders/tests.py
+++ b/services/django/orders/tests.py
@@ -1,5 +1,6 @@
 from datetime import timedelta
 from io import StringIO
+from unittest import mock
 
 from django.core.management import call_command
 from django.core.management.base import CommandError
@@ -10,10 +11,13 @@ from rest_framework.test import APIClient
 
 from chat.models import ChatMessage, ChatMessageRecommendation, ChatSession
 from orders.management.commands.seed_vendor_demo_metrics import _slugify_label
-from products.models import Product
+from products.models import Product, Review
 from users.models import User, UserProfile
 
 from .models import Cart, CartItem, Order, OrderItem, UserInteraction, Wishlist, WishlistItem
+from .pages.core import PRODUCT_DETAIL_REVIEW_PAGE_SIZE
+from .pages.demo_detail_images import PRODUCT_DETAIL_DEMO_IMAGE_MAP
+from .pages.detail_images import get_product_detail_image_urls
 
 
 class CartApiTests(TestCase):
@@ -51,9 +55,38 @@ class CartApiTests(TestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         self.assertEqual(response.data["cart_item"]["product_id"], self.product.goods_id)
         self.assertEqual(response.data["cart_item"]["quantity"], 2)
+        self.assertEqual(response.data["cart_item"]["product_url"], f"/products/{self.product.goods_id}/")
         self.assertTrue(CartItem.objects.filter(cart__user=self.user, product=self.product).exists())
         interaction = UserInteraction.objects.get(user=self.user, product=self.product, interaction_type="cart")
         self.assertEqual(interaction.weight, 2)
+
+    def test_cart_response_uses_actual_review_metrics(self):
+        Review.objects.create(
+            review_id="RV-CART-0001",
+            product=self.product,
+            score=5.0,
+            content="잘 먹어요",
+            author_nickname="버디1",
+            written_at=timezone.now().date(),
+        )
+        Review.objects.create(
+            review_id="RV-CART-0002",
+            product=self.product,
+            score=4.0,
+            content="재구매 예정",
+            author_nickname="버디2",
+            written_at=timezone.now().date(),
+        )
+
+        response = self.client.post(
+            "/api/orders/cart/",
+            {"product_id": self.product.goods_id, "quantity": 1},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["cart_item"]["review_count"], 2)
+        self.assertEqual(response.data["cart_item"]["rating"], 4.5)
 
     def test_post_cart_existing_item_increments_quantity(self):
         self.client.post("/api/orders/cart/", {"product_id": self.product.goods_id}, format="json")
@@ -690,6 +723,54 @@ class OrderPageViewTests(TestCase):
         self.user = User.objects.create_user(email="order-page@example.com", password="Password123!")
         self.client.force_login(self.user)
         UserProfile.objects.create(user=self.user, nickname="주문 페이지")
+        self.product = Product.objects.create(
+            goods_id="GI-DETAIL-1",
+            goods_name="유저 상세 테스트 상품",
+            brand_name="테스트 브랜드",
+            price=25900,
+            discount_price=21900,
+            rating=4.8,
+            review_count=2,
+            thumbnail_url="https://example.com/detail-thumb.png",
+            product_url="https://example.com/detail-product",
+            pet_type=["강아지"],
+            category=["간식"],
+            subcategory=["져키/트릿"],
+            health_concern_tags=["피부", "관절"],
+            main_ingredients=["오리", "고구마", "감자전분", "비타민E", "연어오일", "콜라겐", "유산균", "타우린"],
+            crawled_at=timezone.now(),
+        )
+        Review.objects.create(
+            review_id="RV-DETAIL-0001",
+            product=self.product,
+            score=5.0,
+            content="기호성이 정말 좋아서 금방 다 먹었어요.",
+            author_nickname="버디1001",
+            written_at=timezone.now().date(),
+            purchase_label="repeat",
+        )
+        Review.objects.create(
+            review_id="RV-DETAIL-0002",
+            product=self.product,
+            score=4.0,
+            content="포장이 깔끔했고 간식 크기도 적당합니다.",
+            author_nickname="버디1002",
+            written_at=timezone.now().date(),
+            purchase_label="first",
+        )
+        self.related_product = Product.objects.create(
+            goods_id="GI-DETAIL-2",
+            goods_name="같이 보는 상품",
+            brand_name="테스트 브랜드",
+            price=18900,
+            discount_price=16900,
+            thumbnail_url="https://example.com/detail-related.png",
+            product_url="https://example.com/detail-related",
+            pet_type=["강아지"],
+            category=["간식"],
+            subcategory=["져키/트릿"],
+            crawled_at=timezone.now(),
+        )
 
     def test_order_list_supports_demo_mode(self):
         response = self.client.get("/orders/?demo=1")
@@ -722,6 +803,173 @@ class OrderPageViewTests(TestCase):
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "현재 채팅 세션에서 추천된 상품")
         self.assertContains(response, "카탈로그 추천 상품")
+
+    def test_catalog_links_to_internal_product_detail(self):
+        response = self.client.get("/catalog/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, f"/products/{self.product.goods_id}/")
+
+    def test_tailtalk_sort_prioritizes_products_with_actual_reviews(self):
+        Product.objects.create(
+            goods_id="GI-NOREV-HP1",
+            goods_name="리뷰 없는 고점수 상품",
+            brand_name="테스트 브랜드",
+            price=12900,
+            discount_price=9900,
+            rating=9.9,
+            review_count=9999,
+            popularity_score=99.9999,
+            thumbnail_url="https://example.com/no-review-high-popularity.png",
+            product_url="https://example.com/no-review-high-popularity",
+            pet_type=["강아지"],
+            category=["간식"],
+            subcategory=["져키/트릿"],
+            crawled_at=timezone.now(),
+        )
+
+        response = self.client.get("/catalog/?sort=tailtalk")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.context["catalog_items"][0]["product_id"], self.product.goods_id)
+
+    def test_product_detail_requires_login(self):
+        self.client.logout()
+
+        response = self.client.get(f"/products/{self.product.goods_id}/")
+
+        self.assertEqual(response.status_code, status.HTTP_302_FOUND)
+        self.assertIn("/login/", response["Location"])
+
+    def test_product_detail_renders_user_sections(self):
+        CartItem.objects.create(cart=Cart.objects.create(user=self.user), product=self.product, quantity=2)
+        WishlistItem.objects.create(wishlist=Wishlist.objects.create(user=self.user), product=self.product)
+
+        response = self.client.get(f"/products/{self.product.goods_id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "유저 상세 테스트 상품")
+        self.assertContains(response, "상품 정보")
+        self.assertContains(response, "리뷰")
+        self.assertContains(response, "성분과 영양")
+        self.assertNotContains(response, "건강 태그")
+        self.assertContains(response, "21,900원")
+        self.assertContains(response, "25,900원")
+        self.assertContains(response, "타우린")
+        self.assertNotContains(response, "+2")
+        self.assertContains(response, "같이 볼 만한 상품")
+        self.assertContains(response, "기호성이 정말 좋아서 금방 다 먹었어요.")
+        self.assertContains(response, "재구매")
+        self.assertContains(response, "리뷰 (2)")
+        self.assertNotContains(response, "평점 / 리뷰")
+        self.assertNotContains(response, 'id="productDetailStorySection"', html=False)
+
+    def test_product_detail_review_pagination_keeps_all_reviews_accessible(self):
+        for index in range(3, PRODUCT_DETAIL_REVIEW_PAGE_SIZE + 3):
+            Review.objects.create(
+                review_id=f"RV-DETAIL-{index:04d}",
+                product=self.product,
+                score=4.0,
+                content=f"추가 리뷰 {index}",
+                author_nickname=f"버디{index:04d}",
+                written_at=timezone.now().date(),
+                purchase_label="repeat" if index % 2 else "first",
+            )
+
+        first_page_response = self.client.get(f"/products/{self.product.goods_id}/?review_page=1")
+
+        self.assertEqual(first_page_response.status_code, 200)
+        self.assertContains(first_page_response, "추가 리뷰 14")
+        self.assertContains(first_page_response, "?review_page=2#reviews")
+        self.assertContains(first_page_response, "1 / 2")
+        self.assertNotContains(first_page_response, "기호성이 정말 좋아서 금방 다 먹었어요.")
+
+        second_page_response = self.client.get(f"/products/{self.product.goods_id}/?review_page=2")
+
+        self.assertEqual(second_page_response.status_code, 200)
+        self.assertContains(second_page_response, "기호성이 정말 좋아서 금방 다 먹었어요.")
+        self.assertContains(second_page_response, "포장이 깔끔했고 간식 크기도 적당합니다.")
+        self.assertContains(second_page_response, "#reviews")
+        self.assertContains(second_page_response, "2 / 2")
+        self.assertNotContains(second_page_response, "추가 리뷰 14")
+
+    def test_product_detail_uses_actual_review_rows_for_review_count(self):
+        product = Product.objects.create(
+            goods_id="GP-DETAIL-NO-REVIEW",
+            goods_name="리뷰 메타만 있는 상품",
+            brand_name="테스트 브랜드",
+            price=15900,
+            discount_price=12900,
+            rating=4.9,
+            review_count=24478,
+            thumbnail_url="https://example.com/detail-no-review-thumb.png",
+            product_url="https://www.aboutpet.co.kr/goods/getGoods?goodsId=GP-DETAIL-NO-REVIEW",
+            pet_type=["고양이"],
+            category=["사료"],
+            subcategory=["건식"],
+            crawled_at=timezone.now(),
+        )
+
+        response = self.client.get(f"/products/{product.goods_id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "리뷰 (0)")
+        self.assertContains(response, "아직 표시할 리뷰가 없습니다.")
+        self.assertNotContains(response, "리뷰 (24,478)")
+
+    def test_product_detail_renders_demo_story_images_for_whitelisted_goods(self):
+        goods_id, image_urls = next(iter(PRODUCT_DETAIL_DEMO_IMAGE_MAP.items()))
+        product = Product.objects.create(
+            goods_id=goods_id,
+            goods_name="시연용 상세 이미지 상품",
+            brand_name="시연 브랜드",
+            price=24000,
+            discount_price=19900,
+            thumbnail_url="https://example.com/demo-detail-thumb.png",
+            product_url="https://example.com/demo-detail-product",
+            pet_type=["고양이"],
+            category=["사료"],
+            subcategory=["건식"],
+            crawled_at=timezone.now(),
+        )
+
+        response = self.client.get(f"/products/{product.goods_id}/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'id="productDetailStorySection"', html=False)
+        self.assertContains(response, image_urls[0])
+
+    @mock.patch("orders.pages.detail_images._fetch_aboutpet_detail_image_urls")
+    def test_detail_image_lookup_skips_non_aboutpet_external_products(self, fetch_detail_images):
+        product = Product(
+            goods_id="GI-DETAIL-EXTERNAL",
+            goods_name="외부몰 상품",
+            brand_name="외부몰 브랜드",
+            price=19900,
+            product_url="https://example.com/detail-product",
+        )
+
+        self.assertEqual(get_product_detail_image_urls(product), ())
+        fetch_detail_images.assert_not_called()
+
+    @mock.patch(
+        "orders.pages.detail_images._fetch_aboutpet_detail_image_urls",
+        return_value=("https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/story-live.jpg",),
+    )
+    def test_detail_image_lookup_fetches_for_aboutpet_products(self, fetch_detail_images):
+        product = Product(
+            goods_id="GP-LIVE-DETAIL-001",
+            goods_name="어바웃펫 상품",
+            brand_name="어바웃펫 브랜드",
+            price=19900,
+            product_url="https://www.aboutpet.co.kr/goods/getGoods?goodsId=GP-LIVE-DETAIL-001",
+        )
+
+        self.assertEqual(
+            get_product_detail_image_urls(product),
+            ("https://prd-main-cdn.aboutpet.co.kr/aboutPet/images/editor/goods_desc/story-live.jpg",),
+        )
+        fetch_detail_images.assert_called_once_with(product.goods_id)
 
 
 class SeedVendorDemoMetricsCommandTests(TestCase):

--- a/services/django/products/review_metrics.py
+++ b/services/django/products/review_metrics.py
@@ -1,0 +1,77 @@
+from django.db.models import Avg, Count
+
+from .models import Review
+
+
+def with_actual_review_metrics(queryset):
+    return queryset.annotate(
+        _actual_review_count=Count("reviews", distinct=True),
+        _actual_review_score_avg=Avg("reviews__score"),
+    )
+
+
+def attach_actual_review_metrics(products):
+    product_map = {}
+
+    for product in products:
+        if product is None:
+            continue
+        goods_id = getattr(product, "goods_id", None)
+        if not goods_id:
+            continue
+        product._actual_review_count = int(getattr(product, "_actual_review_count", 0) or 0)
+        if not hasattr(product, "_actual_review_score_avg"):
+            product._actual_review_score_avg = None
+        product_map[goods_id] = product
+
+    if not product_map:
+        return products
+
+    aggregates = (
+        Review.objects.filter(product_id__in=product_map.keys())
+        .values("product_id")
+        .annotate(
+            _actual_review_count=Count("review_id"),
+            _actual_review_score_avg=Avg("score"),
+        )
+    )
+
+    for row in aggregates:
+        product = product_map.get(row["product_id"])
+        if product is None:
+            continue
+        product._actual_review_count = int(row["_actual_review_count"] or 0)
+        product._actual_review_score_avg = row["_actual_review_score_avg"]
+
+    return products
+
+
+def get_actual_review_count(product):
+    if product is None:
+        return 0
+
+    if not hasattr(product, "_actual_review_count"):
+        attach_actual_review_metrics([product])
+
+    return int(getattr(product, "_actual_review_count", 0) or 0)
+
+
+def get_actual_rating_value(product):
+    if product is None:
+        return None
+
+    if not hasattr(product, "_actual_review_score_avg"):
+        attach_actual_review_metrics([product])
+
+    avg_score = getattr(product, "_actual_review_score_avg", None)
+    if avg_score is None:
+        return None
+
+    return round(float(avg_score), 1)
+
+
+def get_actual_rating_label(product):
+    rating_value = get_actual_rating_value(product)
+    if rating_value is None:
+        return None
+    return f"{rating_value:.1f}"

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1192,7 +1192,7 @@
 
     function trackRecommendationImpressions(sessionId, items) {
       if (!sessionId) return;
-      var normalized = normalizeRecommendedProducts(items || []);
+      var normalized = normalizeRecommendedProducts(items || [], sessionId);
       var signature = recommendationSignature(normalized);
       normalized.forEach(function (item, index) {
         var goodsId = item.product_id || item.goods_id || '';
@@ -1315,10 +1315,26 @@
       });
     }
 
-    function normalizeRecommendedProducts(products) {
+    function buildProductDetailHref(goodsId, source, sessionId) {
+      var normalized = String(goodsId || '').trim();
+      if (!normalized) return '';
+      var params = new URLSearchParams();
+      if (source) {
+        params.set('source', source);
+      }
+      if (sessionId) {
+        params.set('session', sessionId);
+      }
+      var query = params.toString();
+      return '/products/' + encodeURIComponent(normalized) + '/' + (query ? '?' + query : '');
+    }
+
+    function normalizeRecommendedProducts(products, sessionId) {
+      var recommendationSessionId = sessionId || activeSessionId || '';
       return (products || []).map(function (product) {
+        var goodsId = product.goods_id || product.product_id || '';
         return {
-          goods_id: product.goods_id || product.product_id || '',
+          goods_id: goodsId,
           product_id: product.product_id || product.goods_id || '',
           product_name: product.product_name || product.name || '추천 상품',
           brand_name: product.brand_name || product.brand || '',
@@ -1328,7 +1344,8 @@
           reviews: product.reviews,
           review_count: product.review_count,
           thumbnail_url: product.thumbnail_url || '',
-          product_url: product.product_url || '',
+          product_url: product.detail_url || buildProductDetailHref(goodsId, 'chat_recommendation', recommendationSessionId) || product.product_url || '',
+          external_product_url: product.external_product_url || product.product_url || '',
           summary: product.summary || '',
           rank_order: product.rank_order || 0,
         };
@@ -1337,7 +1354,7 @@
 
     function syncSessionRecommendedProductsStorage(sessionId, cards) {
       if (!sessionId) return;
-      sessionRecommendedProducts[sessionId] = normalizeRecommendedProducts(cards || []);
+      sessionRecommendedProducts[sessionId] = normalizeRecommendedProducts(cards || [], sessionId);
       try {
         if (sessionRecommendedProducts[sessionId].length) {
           window.localStorage.setItem(
@@ -1362,14 +1379,14 @@
       }
     }
 
-    function collectLatestRecommendedProducts(messages) {
+    function collectLatestRecommendedProducts(messages, sessionId) {
       var latest = [];
       (messages || []).forEach(function (message) {
         if (Array.isArray(message.recommended_products) && message.recommended_products.length) {
           latest = message.recommended_products;
         }
       });
-      return normalizeRecommendedProducts(latest);
+      return normalizeRecommendedProducts(latest, sessionId);
     }
 
     function hasAssistantMessages(messages) {
@@ -1381,7 +1398,7 @@
     function hydrateSessionRecommendationsFromMessages(sessionId, messages) {
       if (!sessionId) return [];
       var state = ensureSessionState(sessionId);
-      var latest = collectLatestRecommendedProducts(messages);
+      var latest = collectLatestRecommendedProducts(messages, sessionId);
       syncSessionRecommendedProductsStorage(sessionId, latest);
       if (state) {
         state.recommendationStatus = latest.length ? 'ready' : (hasAssistantMessages(messages) ? 'empty' : 'idle');
@@ -1575,10 +1592,10 @@
       var priceLabel = escapeHtml(formatPriceLabel(item.discount_price || item.price));
       var thumbnailUrl = escapeHtml(item.thumbnail_url || '');
       var reviews = escapeHtml(normalizeReviewLabel(item.reviews || item.review_count));
-      var rating = escapeHtml(item.rating || '4.7');
+      var rating = escapeHtml(item.rating || '-');
       var rankOrder = escapeHtml(item.rank_order || '0');
       var thumbnailHtml = productUrl
-        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="relative flex h-[68px] w-[68px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-br from-[#dbeafe] via-[#eff6ff] to-[#f8fafc] transition-transform hover:scale-[1.02]" data-recommendation-link="true">'
+        ? '<a href="' + productUrl + '" class="relative flex h-[68px] w-[68px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-br from-[#dbeafe] via-[#eff6ff] to-[#f8fafc] transition-transform hover:scale-[1.02]" data-recommendation-link="true">'
           + '  <img src="' + thumbnailUrl + '" alt="" class="h-full w-full object-cover" onerror="this.style.display=\'none\'; this.parentNode.querySelector(&quot;.fallback-emoji&quot;).style.display = \'flex\';">'
           + '  <div class="fallback-emoji absolute inset-0 hidden items-center justify-center text-[26px]">🛍️</div>'
           + '</a>'
@@ -1587,7 +1604,7 @@
           + '  <div class="fallback-emoji absolute inset-0 hidden items-center justify-center text-[26px]">🛍️</div>'
           + '</div>';
       var nameHtml = productUrl
-        ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="product-card-name block transition-colors hover:text-[#2b6cb0]" data-recommendation-link="true">' + productName + '</a>'
+        ? '<a href="' + productUrl + '" class="product-card-name block transition-colors hover:text-[#2b6cb0]" data-recommendation-link="true">' + productName + '</a>'
         : '<div class="product-card-name">' + productName + '</div>';
 
       return ''
@@ -1640,7 +1657,7 @@
 
     function renderRecommendationPanel(items) {
       if (!recommendationPanelBody) return;
-      var normalized = normalizeRecommendedProducts(items || []);
+      var normalized = normalizeRecommendedProducts(items || [], activeSessionId);
       if (recommendationStatus === 'loading') {
         recommendationPanelBody.innerHTML = ''
           + '<div class="rounded-[22px] border border-[#dbe7f5] bg-white px-4 py-6 text-center">'
@@ -1758,10 +1775,8 @@
         var analyticsPayload = buildRecommendationAnalyticsPayload(link);
         if (!analyticsPayload) return;
         logRecommendationInteraction(analyticsPayload.goods_id, 'click', 1, analyticsPayload.session_id || null);
-        logRecommendationInteraction(analyticsPayload.goods_id, 'detail_view', 1, analyticsPayload.session_id || null);
         if (window.tailTalkAnalytics) {
           window.tailTalkAnalytics.track('recommendation_click', analyticsPayload);
-          window.tailTalkAnalytics.track('detail_view', analyticsPayload);
         }
       });
     }

--- a/services/django/templates/orders/catalog.html
+++ b/services/django/templates/orders/catalog.html
@@ -1009,7 +1009,7 @@
         <div class="catalog-product-grid mt-6 grid gap-5 sm:grid-cols-2">
           {% for item in catalog_items %}
           <article class="catalog-card overflow-hidden rounded-[24px] border border-[#e2e8f0] bg-white shadow-[0_8px_24px_rgba(45,55,72,0.04)]">
-            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-thumb relative block overflow-hidden bg-[#f8fbff]">
+            <a href="{{ item.product_url }}?source=catalog{% if catalog_current_session_id %}&session={{ catalog_current_session_id|urlencode }}{% endif %}" class="catalog-thumb relative block overflow-hidden bg-[#f8fbff]">
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
               <button type="button"
                       class="catalog-card-wishlist wishlist-heart {% if item.is_wishlisted %}is-active {% endif %}absolute bottom-3 right-3 z-[1] inline-flex h-[28px] w-[28px] shrink-0 items-center justify-center rounded-full border border-white/80 bg-white/95 leading-none shadow-[0_8px_20px_rgba(15,23,42,0.12)] backdrop-blur-sm transition-colors"
@@ -1025,7 +1025,7 @@
               </button>
             </a>
             <div class="catalog-card-body p-4">
-              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="catalog-card-title text-[17px] font-bold leading-[1.45] text-[#2d3748] hover:text-[#3182ce]">
+              <a href="{{ item.product_url }}?source=catalog{% if catalog_current_session_id %}&session={{ catalog_current_session_id|urlencode }}{% endif %}" class="catalog-card-title text-[17px] font-bold leading-[1.45] text-[#2d3748] hover:text-[#3182ce]">
                 {{ item.name }}
               </a>
               <div class="catalog-card-meta mt-3 flex items-end justify-between gap-3">
@@ -1198,11 +1198,11 @@
         {% for item in catalog_recommended_items %}
         <article class="rounded-[20px] border border-[#e2e8f0] bg-[#fbfdff] p-4">
           <div class="flex gap-3">
-            <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="block h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[16px] bg-[#f1f5f9]">
+            <a href="{{ item.product_url }}?source=catalog_recommendation{% if catalog_current_session_id %}&session={{ catalog_current_session_id|urlencode }}{% endif %}" class="block h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[16px] bg-[#f1f5f9]">
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
             </a>
             <div class="min-w-0 flex-1">
-              <a href="{{ item.product_url }}" target="_blank" rel="noreferrer" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">{{ item.name }}</a>
+              <a href="{{ item.product_url }}?source=catalog_recommendation{% if catalog_current_session_id %}&session={{ catalog_current_session_id|urlencode }}{% endif %}" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">{{ item.name }}</a>
               <p class="mt-2 text-[12px] leading-[1.6] text-[#718096]">{{ item.summary }}</p>
               <div class="mt-3 flex items-end justify-between gap-3">
                 <div>
@@ -1768,6 +1768,20 @@
       .replace(/'/g, '&#39;');
   }
 
+  function buildProductDetailHref(goodsId, source) {
+    var normalized = String(goodsId || '').trim();
+    if (!normalized) return '';
+    var params = new URLSearchParams();
+    if (source) {
+      params.set('source', source);
+    }
+    if (catalogCurrentSessionId) {
+      params.set('session', catalogCurrentSessionId);
+    }
+    var query = params.toString();
+    return '/products/' + encodeURIComponent(normalized) + '/' + (query ? '?' + query : '');
+  }
+
   function readStoredSessionRecommendations(sessionId) {
     if (!sessionId) return [];
     try {
@@ -1785,7 +1799,7 @@
 
   function drawerItemMarkup(item) {
     var productId = escapeHtml(item.product_id || item.goods_id || '');
-    var productUrl = escapeHtml(item.product_url || '');
+    var productUrl = escapeHtml(buildProductDetailHref(item.product_id || item.goods_id || '', 'catalog_recommendation') || item.product_url || '');
     var productName = escapeHtml(item.product_name || item.name || '추천 상품');
     var summary = escapeHtml(item.summary || '');
     var priceLabel = escapeHtml(compactPriceLabel(item.price_label || item.price || '가격 정보 없음'));
@@ -1795,11 +1809,11 @@
     return ''
       + '<article class="rounded-[20px] border border-[#e2e8f0] bg-[#fbfdff] p-4">'
       + '  <div class="flex gap-3">'
-      + '    <a href="' + productUrl + '" target="_blank" rel="noreferrer" class="block h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[16px] bg-[#f1f5f9]">'
+      + '    <a href="' + productUrl + '" class="block h-[72px] w-[72px] shrink-0 overflow-hidden rounded-[16px] bg-[#f1f5f9]">'
       + '      <img src="' + thumbnailUrl + '" alt="' + productName + '" class="h-full w-full object-cover">'
       + '    </a>'
       + '    <div class="min-w-0 flex-1">'
-      + '      <a href="' + productUrl + '" target="_blank" rel="noreferrer" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">' + productName + '</a>'
+      + '      <a href="' + productUrl + '" class="block text-[14px] font-bold leading-[1.5] text-[#2d3748] hover:text-[#3182ce]">' + productName + '</a>'
       + (summary ? '      <p class="mt-2 text-[12px] leading-[1.6] text-[#718096]">' + summary + '</p>' : '')
       + '      <div class="mt-3 flex items-end justify-between gap-3">'
       + '        <div>'

--- a/services/django/templates/orders/product_detail.html
+++ b/services/django/templates/orders/product_detail.html
@@ -1,0 +1,1011 @@
+{% extends "base.html" %}
+{% block title %}{{ product_detail.name }} — TailTalk{% endblock %}
+
+{% block head %}
+<style>
+  #pageGate {
+    min-height: 100dvh;
+    background: #f8f9fb;
+  }
+
+  #pageGate > .app-shell {
+    position: relative;
+    width: min(100%, 960px);
+    min-height: 100dvh;
+    height: 100dvh;
+    margin: 0 auto;
+    overflow: hidden;
+    background: #f8f9fb;
+  }
+
+  #productDetailHeader {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 72px;
+    border-bottom: 1px solid #e2e8f0;
+    background: #fff;
+    z-index: 40;
+  }
+
+  #productDetailHeaderInner {
+    display: grid;
+    grid-template-columns: 40px auto 40px;
+    align-items: center;
+    gap: 8px;
+    height: 100%;
+    padding: 0 12px;
+  }
+
+  #productDetailHeaderLogo {
+    justify-self: center;
+    font-size: 26px;
+    font-weight: 700;
+    line-height: 1;
+    color: #2d3748;
+    white-space: nowrap;
+  }
+
+  #headerSubnav {
+    position: absolute;
+    inset: 72px 0 auto 0;
+    z-index: 35;
+    border-bottom: 1px solid #e8eef6;
+    background: rgba(255, 255, 255, 0.98);
+    backdrop-filter: blur(12px);
+  }
+
+  #headerSubnavRail {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    width: 100%;
+  }
+
+  .header-subnav-link {
+    position: relative;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    color: #4a5568;
+    transition: background-color 160ms ease, color 160ms ease;
+  }
+
+  .header-subnav-link + .header-subnav-link::before {
+    content: '';
+    position: absolute;
+    left: 0;
+    top: 10px;
+    bottom: 10px;
+    width: 1px;
+    background: #e8eef6;
+  }
+
+  .header-subnav-link:hover {
+    background: #f8fbff;
+  }
+
+  .header-subnav-link.is-active {
+    color: #2d3748;
+    background: #f8f9fb;
+  }
+
+  .header-subnav-link.has-indicator::after {
+    content: '';
+    position: absolute;
+    top: 9px;
+    right: calc(50% - 12px);
+    width: 6px;
+    height: 6px;
+    border-radius: 9999px;
+    background: #f97316;
+  }
+
+  #profileMenuWrapper {
+    position: relative;
+    height: 40px;
+    width: 40px;
+  }
+
+  #profileMenu {
+    position: absolute;
+    top: calc(100% + 10px);
+    right: 0;
+    width: 188px;
+    overflow: hidden;
+    border: 1px solid #e2e8f0;
+    border-radius: 18px;
+    background: #fff;
+    box-shadow: 0 18px 36px rgba(15, 23, 42, 0.12);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-6px);
+    transition: opacity 160ms ease, transform 160ms ease;
+    z-index: 50;
+  }
+
+  #profileMenu.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  #productDetailViewport {
+    position: absolute;
+    inset: 116px 0 0 0;
+    overflow-y: auto;
+    padding: 24px 16px 36px;
+  }
+
+  html,
+  body,
+  body.bg-white {
+    background: #f8f9fb !important;
+  }
+
+  .detail-hero-card,
+  .detail-section-card,
+  .detail-related-card {
+    border: 1px solid #dbe7f5;
+    border-radius: 28px;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 18px 48px rgba(148, 163, 184, 0.12);
+  }
+
+  .detail-hero-grid {
+    display: grid;
+    grid-template-columns: minmax(0, 320px) minmax(0, 1fr);
+    gap: 24px;
+  }
+
+  .detail-thumb {
+    overflow: hidden;
+    border: 1px solid #dbe7f5;
+    border-radius: 28px;
+    background: linear-gradient(145deg, #edf6ff 0%, #ffffff 100%);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7);
+  }
+
+  .detail-chip {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 32px;
+    border-radius: 9999px;
+    padding: 0 14px;
+    font-size: 12px;
+    font-weight: 700;
+    line-height: 1;
+  }
+
+  .detail-chip.status-green {
+    background: #dcfce7;
+    color: #15803d;
+  }
+
+  .detail-chip.status-rose {
+    background: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .detail-chip.soft {
+    background: #eef4fb;
+    color: #475569;
+  }
+
+  .detail-action-icon {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    height: 44px;
+    width: 44px;
+    border-radius: 9999px;
+    border: 1px solid #dbe7f5;
+    background: #fff;
+    color: #4a5568;
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, transform 160ms ease, box-shadow 160ms ease;
+  }
+
+  .detail-action-icon:hover {
+    transform: translateY(-1px);
+  }
+
+  .detail-action-icon.primary {
+    border-color: #2d3748;
+    background: #2d3748;
+    color: #fff;
+  }
+
+  .detail-action-icon.wishlist-heart {
+    position: relative;
+    overflow: hidden;
+  }
+
+  .detail-action-icon.wishlist-heart svg:last-child {
+    display: none;
+  }
+
+  .detail-action-icon.wishlist-heart.is-active {
+    border-color: #f3c1c1;
+    background: #fff1f2;
+    color: #e53e3e;
+  }
+
+  .detail-action-icon.wishlist-heart.is-active svg:first-child {
+    display: none;
+  }
+
+  .detail-action-icon.wishlist-heart.is-active svg:last-child {
+    display: block;
+  }
+
+  .detail-action-meta {
+    display: inline-flex;
+    align-items: center;
+    min-height: 34px;
+    border-radius: 9999px;
+    padding: 0 14px;
+    background: #eef4fb;
+    color: #475569;
+    font-size: 12px;
+    font-weight: 700;
+  }
+
+  .detail-tab-bar {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .detail-tab-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    min-height: 52px;
+    border: 1px solid #dbe7f5;
+    border-radius: 20px;
+    background: rgba(255, 255, 255, 0.94);
+    color: #475569;
+    font-size: 14px;
+    font-weight: 800;
+    letter-spacing: -0.01em;
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease, box-shadow 160ms ease;
+  }
+
+  .detail-tab-button.is-active {
+    border-color: #1e293b;
+    background: #1e293b;
+    color: #fff;
+    box-shadow: 0 14px 28px rgba(15, 23, 42, 0.16);
+  }
+
+  .detail-tab-count {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 28px;
+    min-height: 24px;
+    border-radius: 9999px;
+    padding: 0 10px;
+    background: #eef4fb;
+    color: #475569;
+    font-size: 11px;
+    font-weight: 800;
+  }
+
+  .detail-tab-button.is-active .detail-tab-count {
+    background: rgba(255, 255, 255, 0.16);
+    color: #fff;
+  }
+
+  .detail-highlight-card,
+  .detail-info-row,
+  .detail-note-card {
+    border-radius: 22px;
+    border: 1px solid #e5eef8;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+  }
+
+  .detail-related-grid {
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 14px;
+  }
+
+  .detail-related-card {
+    overflow: hidden;
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  }
+
+  .detail-related-card:hover {
+    transform: translateY(-2px);
+    border-color: #bfdbfe;
+    box-shadow: 0 20px 40px rgba(148, 163, 184, 0.16);
+  }
+
+  .detail-related-title {
+    display: -webkit-box;
+    overflow: hidden;
+    min-height: 40px;
+    -webkit-box-orient: vertical;
+    -webkit-line-clamp: 2;
+  }
+
+  .detail-review-list {
+    display: grid;
+    gap: 14px;
+  }
+
+  .detail-review-card {
+    border-radius: 22px;
+    border: 1px solid #e5eef8;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    padding: 20px;
+  }
+
+  .detail-review-pagination {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 12px;
+    border-radius: 22px;
+    border: 1px solid #e5eef8;
+    background: linear-gradient(180deg, #ffffff 0%, #f8fbff 100%);
+    padding: 14px 16px;
+  }
+
+  .detail-review-page-link {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-width: 84px;
+    min-height: 40px;
+    border-radius: 9999px;
+    border: 1px solid #dbe7f5;
+    background: #fff;
+    color: #1e293b;
+    font-size: 13px;
+    font-weight: 800;
+    transition: background-color 160ms ease, border-color 160ms ease, color 160ms ease;
+  }
+
+  .detail-review-page-link:hover {
+    border-color: #bfdbfe;
+    background: #f8fbff;
+    color: #1d4ed8;
+  }
+
+  .detail-review-page-link.is-disabled {
+    border-color: #e2e8f0;
+    background: #f8fafc;
+    color: #94a3b8;
+    pointer-events: none;
+  }
+
+  .detail-feedback-toast {
+    opacity: 0;
+    visibility: hidden;
+    transform: translate(-50%, 10px) scale(0.98);
+    transition: opacity 180ms ease, transform 180ms ease;
+  }
+
+  .detail-feedback-toast.is-open {
+    opacity: 1;
+    visibility: visible;
+    transform: translate(-50%, 0) scale(1);
+  }
+
+  .detail-story-gallery {
+    overflow: hidden;
+    border-top: 1px solid #e5eef8;
+    background: #fff;
+  }
+
+  .detail-story-image {
+    display: block;
+    width: 100%;
+    height: auto;
+    background: #fff;
+  }
+
+  @media (max-width: 1023px) {
+    .detail-hero-grid,
+    .detail-related-grid,
+    .detail-content-grid {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+  }
+
+  @media (max-width: 767px) {
+    #pageGate > .app-shell {
+      width: 100vw;
+    }
+
+    .detail-hero-grid,
+    .detail-related-grid,
+    .detail-content-grid {
+      grid-template-columns: minmax(0, 1fr);
+    }
+
+    .detail-thumb {
+      max-width: 360px;
+      margin: 0 auto;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div id="pageGate"
+     class="min-h-screen bg-[#f8f9fb]"
+     data-product-id="{{ product_detail.product_id }}"
+     data-session-id="{{ product_detail_session_id }}"
+     data-source="{{ product_detail_source }}"
+     data-cart-quantity="{{ product_detail.cart_quantity }}"
+     data-is-wishlisted="{% if product_detail.is_wishlisted %}1{% else %}0{% endif %}">
+  <div class="app-shell">
+    <header id="productDetailHeader">
+      <div id="productDetailHeaderInner">
+        <button type="button"
+                class="inline-flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                aria-label="이전으로 돌아가기"
+                onclick="goProductDetailBack()">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="m15 18-6-6 6-6"></path>
+          </svg>
+        </button>
+        <a href="/chat/" id="productDetailHeaderLogo" aria-label="메인으로 돌아가기">
+          <span class="text-[#3182ce]">Tail</span><span>Talk</span>
+        </a>
+        <div class="justify-self-end min-w-0">
+          <div id="profileMenuWrapper">
+            <button type="button"
+                    class="flex h-[40px] w-[40px] items-center justify-center rounded-full border border-[#e2e8f0] bg-white shadow-[0_2px_8px_rgba(45,55,72,0.05)]"
+                    aria-label="프로필 메뉴 열기"
+                    onclick="toggleProfileMenu()">
+              <svg viewBox="0 0 24 24" class="h-[30px] w-[30px] text-[#4a5568]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="8" r="3.2"></circle>
+                <path d="M5.5 19a6.5 6.5 0 0 1 13 0"></path>
+              </svg>
+            </button>
+            <div id="profileMenu">
+              <a href="/profile/" class="flex h-[44px] w-full items-center rounded-t-[16px] px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">내 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/pets/" class="flex h-[44px] w-full items-center px-[16px] text-[14px] text-[#2d3748] hover:bg-[#edf2f7]">반려동물 정보</a>
+              <div class="mx-[12px] h-px bg-[#edf2f7]"></div>
+              <a href="/logout/" class="flex h-[44px] w-full items-center rounded-b-[16px] px-[16px] text-[14px] text-[#ef4444] hover:bg-[#fef2f2]">로그아웃</a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </header>
+
+    <div id="headerSubnav">
+      <div id="headerSubnavRail">
+        <a href="/catalog/" class="header-subnav-link is-active" aria-label="상품 목록" title="상품 목록">
+          <svg viewBox="0 0 24 24" class="h-[17px] w-[17px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <rect x="4" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="4" width="6" height="6" rx="1.5"></rect>
+            <rect x="4" y="14" width="6" height="6" rx="1.5"></rect>
+            <rect x="14" y="14" width="6" height="6" rx="1.5"></rect>
+          </svg>
+        </a>
+        <a href="/products/" class="header-subnav-link {% if member_nav_has_cart_items %}has-indicator{% endif %}" aria-label="장바구니" title="장바구니">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <circle cx="9" cy="20" r="1.5"></circle>
+            <circle cx="18" cy="20" r="1.5"></circle>
+            <path d="M3 4h2l2.2 10.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 1-.75L20 8H7"></path>
+          </svg>
+        </a>
+        <a href="/wishlist/" class="header-subnav-link {% if member_nav_has_wishlist_items %}has-indicator{% endif %}" aria-label="관심 상품" title="관심 상품">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"></path>
+          </svg>
+        </a>
+        <a href="/orders/" class="header-subnav-link" aria-label="주문 내역" title="주문 내역">
+          <svg viewBox="0 0 24 24" class="h-[18px] w-[18px]" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <path d="M7 4.5h10"></path>
+            <path d="M7 9h10"></path>
+            <path d="M7 13.5h6"></path>
+            <rect x="4" y="3" width="16" height="18" rx="2"></rect>
+          </svg>
+        </a>
+      </div>
+    </div>
+
+    <main id="productDetailViewport">
+      <section class="detail-hero-card px-5 py-5 sm:px-6 sm:py-6 md:px-8">
+        <div class="detail-hero-grid">
+          <div class="detail-thumb">
+            <img src="{{ product_detail.thumbnail_url }}" alt="{{ product_detail.name }}" class="aspect-square w-full object-cover">
+          </div>
+
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-2 text-[13px] font-semibold text-[#64748b]">
+              <a href="/catalog/" class="text-[#2563eb] hover:text-[#1d4ed8]">상품 목록</a>
+              <span class="text-[#cbd5e1]">/</span>
+              <span>상품 상세</span>
+            </div>
+
+            <div class="mt-4 flex flex-wrap items-center gap-2">
+              <span class="detail-chip status-{{ product_detail_status_tone }}">{{ product_detail_status_label }}</span>
+              {% for item in product_detail.pet_type %}
+              <span class="detail-chip soft">{{ item }}</span>
+              {% endfor %}
+              {% if product_detail.category %}
+              <span class="detail-chip soft">{{ product_detail.category.0 }}</span>
+              {% endif %}
+            </div>
+
+            <p class="mt-4 text-[13px] font-semibold uppercase tracking-[0.12em] text-[#90a4b8]">{{ product_detail.brand_name }}</p>
+            <h1 class="mt-2 text-[28px] font-bold tracking-[-0.03em] leading-[1.2] text-[#1e293b] sm:text-[34px]">{{ product_detail.name }}</h1>
+
+            <div class="mt-6 rounded-[24px] border border-[#e5eef8] bg-[linear-gradient(180deg,#ffffff_0%,#f8fbff_100%)] px-5 py-5">
+              <div class="flex flex-wrap items-start justify-between gap-4">
+                <div class="rounded-[20px] border border-[#dbe7f5] bg-white px-4 py-3">
+                  <p class="flex items-center gap-1 text-[16px] font-bold text-[#0f172a]">
+                    <span class="text-[#f6ad55]">★</span>
+                    <span>{{ product_detail.rating|default:"-" }}</span>
+                  </p>
+                </div>
+                <div class="text-right">
+                  {% if product_detail_original_price_label %}
+                  <p class="text-[13px] font-semibold leading-none text-[#94a3b8] line-through">{{ product_detail_original_price_label }}</p>
+                  {% endif %}
+                  <div class="mt-2 flex items-end justify-end gap-2">
+                    {% if product_detail_discount_rate_label %}
+                    <span class="text-[18px] font-extrabold leading-none text-[#2563eb]">{{ product_detail_discount_rate_label }}</span>
+                    {% endif %}
+                    <p class="text-[30px] font-bold tracking-[-0.04em] leading-none text-[#0f172a]">{{ product_detail_current_price_label }}</p>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="mt-5 flex flex-wrap items-center gap-3">
+              {% if product_detail.cart_quantity %}
+              <span id="productDetailCartMeta" class="detail-action-meta">장바구니 {{ product_detail.cart_quantity }}개</span>
+              {% else %}
+              <span id="productDetailCartMeta" class="detail-action-meta hidden"></span>
+              {% endif %}
+              <div class="ml-auto flex items-center gap-3">
+                <button type="button"
+                        id="productDetailWishlistButton"
+                        class="detail-action-icon wishlist-heart {% if product_detail.is_wishlisted %}is-active{% endif %}"
+                        aria-label="{% if product_detail.is_wishlisted %}관심 상품 제거{% else %}관심 상품 추가{% endif %}"
+                        onclick="toggleProductDetailWishlist(this)">
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/>
+                  </svg>
+                  <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+                    <path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/>
+                  </svg>
+                </button>
+                <button type="button"
+                        id="productDetailCartButton"
+                        class="detail-action-icon primary"
+                        aria-label="{% if product_detail.cart_quantity %}장바구니에 더 담기{% else %}장바구니에 담기{% endif %}"
+                        onclick="addProductDetailToCart(this)">
+                  <svg width="16" height="16" viewBox="0 0 14 14" fill="none" aria-hidden="true">
+                    <path d="M7 2.2V11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                    <path d="M2.2 7H11.8" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <div class="detail-tab-bar mt-6" role="tablist" aria-label="상품 상세 탭">
+        <button type="button"
+                id="detailTabButtonInfo"
+                class="detail-tab-button is-active"
+                role="tab"
+                aria-selected="true"
+                aria-controls="detailTabPanelInfo"
+                data-detail-tab="info">
+          <span>상품 정보</span>
+        </button>
+        <button type="button"
+                id="detailTabButtonReviews"
+                class="detail-tab-button"
+                role="tab"
+                aria-selected="false"
+                aria-controls="detailTabPanelReviews"
+                data-detail-tab="reviews">
+          <span>리뷰</span>
+          <span class="detail-tab-count">{{ product_detail_review_count_label }}</span>
+        </button>
+      </div>
+
+      <div id="detailTabPanelInfo"
+           role="tabpanel"
+           aria-labelledby="detailTabButtonInfo"
+           data-detail-panel="info">
+        <section class="detail-content-grid mt-6 grid gap-6 xl:grid-cols-[1.05fr,0.95fr]">
+          <article class="detail-section-card px-5 py-5 sm:px-6 sm:py-6 md:px-8">
+            <h2 class="text-[21px] font-bold tracking-[-0.02em] text-[#1e293b]">상품 정보</h2>
+            <div class="mt-5 grid gap-3 sm:grid-cols-2">
+              {% for item in product_detail_info_rows %}
+              <div class="detail-info-row px-4 py-4">
+                <p class="text-[12px] font-semibold text-[#64748b]">{{ item.label }}</p>
+                <p class="mt-2 text-[15px] font-semibold leading-6 text-[#0f172a]">{{ item.value }}</p>
+              </div>
+              {% endfor %}
+            </div>
+          </article>
+
+          <article class="detail-section-card px-5 py-5 sm:px-6 sm:py-6 md:px-8">
+            <h2 class="text-[21px] font-bold tracking-[-0.02em] text-[#1e293b]">성분과 영양</h2>
+
+            <section class="mt-5 rounded-[24px] border border-[#e5eef8] bg-[#f8fbff] px-5 py-5">
+              <h3 class="text-[17px] font-bold tracking-[-0.02em] text-[#1e293b]">주요 성분</h3>
+              <div class="mt-4 flex flex-wrap gap-2">
+                {% for item in product_detail_ingredient_tokens %}
+                <span class="detail-chip soft">{{ item }}</span>
+                {% empty %}
+                <span class="detail-chip soft">성분 메타데이터가 없습니다</span>
+                {% endfor %}
+              </div>
+            </section>
+
+            {% if product_detail_nutrition_tokens %}
+            <section class="mt-4 rounded-[24px] border border-[#e5eef8] bg-[#f8fbff] px-5 py-5">
+              <h3 class="text-[17px] font-bold tracking-[-0.02em] text-[#1e293b]">영양 정보</h3>
+              <div class="mt-4 flex flex-wrap gap-2">
+                {% for item in product_detail_nutrition_tokens %}
+                <span class="detail-chip soft">{{ item }}</span>
+                {% endfor %}
+              </div>
+            </section>
+            {% endif %}
+          </article>
+        </section>
+
+        {% if product_detail_story_images %}
+        <section id="productDetailStorySection" class="detail-section-card mt-6 overflow-hidden">
+          <div class="px-5 py-5 sm:px-6 sm:py-6 md:px-8">
+            <h2 class="text-[21px] font-bold tracking-[-0.02em] text-[#1e293b]">상품 상세 정보</h2>
+          </div>
+          <div class="detail-story-gallery">
+            {% for image_url in product_detail_story_images %}
+            <img src="{{ image_url }}"
+                 alt="{{ product_detail.name }} 상세 이미지 {{ forloop.counter }}"
+                 class="detail-story-image"
+                 loading="lazy">
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
+
+        {% if product_detail_related_items %}
+        <section class="mt-6">
+          <div class="flex items-center justify-between gap-3">
+            <div>
+              <p class="text-[13px] font-semibold tracking-[0.08em] text-[#90a4b8]">More</p>
+              <h2 class="mt-1 text-[22px] font-bold tracking-[-0.03em] text-[#1e293b]">같이 볼 만한 상품</h2>
+            </div>
+            <a href="/catalog/" class="text-[13px] font-semibold text-[#2563eb] hover:text-[#1d4ed8]">상품 더 보기</a>
+          </div>
+
+          <div class="detail-related-grid mt-4">
+            {% for item in product_detail_related_items %}
+            <article class="detail-related-card">
+              <a href="{{ item.product_url }}?source=product_detail_related{% if product_detail_session_id %}&session={{ product_detail_session_id|urlencode }}{% endif %}" class="block">
+                <div class="aspect-square overflow-hidden bg-[#eef4fb]">
+                  <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
+                </div>
+                <div class="px-4 py-4">
+                  <p class="text-[11px] font-semibold uppercase tracking-[0.1em] text-[#90a4b8]">{{ item.brand_name }}</p>
+                  <p class="detail-related-title mt-2 text-[15px] font-bold leading-[1.35] text-[#1e293b]">{{ item.name }}</p>
+                  <p class="mt-2 text-[12px] leading-[1.6] text-[#64748b]">{{ item.summary }}</p>
+                  <div class="mt-4 flex items-end justify-between gap-3">
+                    <p class="text-[17px] font-bold text-[#0f172a]">{{ item.price_label }}</p>
+                    <p class="text-[12px] font-semibold text-[#64748b]">★ {{ item.rating|default:"-" }} · {{ item.review_count }}</p>
+                  </div>
+                </div>
+              </a>
+            </article>
+            {% endfor %}
+          </div>
+        </section>
+        {% endif %}
+      </div>
+
+      <div id="detailTabPanelReviews"
+           class="mt-6 hidden"
+           role="tabpanel"
+           aria-labelledby="detailTabButtonReviews"
+           data-detail-panel="reviews">
+        <section class="detail-section-card px-5 py-5 sm:px-6 sm:py-6 md:px-8">
+          <h2 class="text-[22px] font-bold tracking-[-0.03em] text-[#1e293b]">리뷰 ({{ product_detail_review_count_label }})</h2>
+
+          <div class="detail-review-list mt-5">
+            {% for item in product_detail_review_items %}
+            <article class="detail-review-card">
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="flex flex-wrap items-center gap-2">
+                  <p class="text-[15px] font-bold text-[#1e293b]">{{ item.author_label }}</p>
+                  {% if item.purchase_label %}
+                  <span class="detail-chip soft">{{ item.purchase_label }}</span>
+                  {% endif %}
+                </div>
+                <p class="text-[12px] font-semibold text-[#94a3b8]">{{ item.written_at_label }}</p>
+              </div>
+              <p class="mt-3 text-[13px] font-bold text-[#d97706]">★ {{ item.score_label }}</p>
+              <p class="mt-3 whitespace-pre-line text-[14px] leading-[1.8] text-[#334155]">{{ item.content|default:"리뷰 내용이 없습니다." }}</p>
+            </article>
+            {% empty %}
+            <article class="detail-review-card">
+              <p class="text-[15px] font-semibold text-[#1e293b]">{{ product_detail_review_empty_message }}</p>
+            </article>
+            {% endfor %}
+          </div>
+
+          {% if product_detail_review_total_pages > 1 %}
+          <div class="detail-review-pagination mt-5">
+            {% if product_detail_review_has_previous %}
+            <a href="{{ product_detail_review_previous_url }}" class="detail-review-page-link">이전</a>
+            {% else %}
+            <span class="detail-review-page-link is-disabled">이전</span>
+            {% endif %}
+
+            <p class="text-[13px] font-semibold text-[#64748b]">{{ product_detail_review_page_number }} / {{ product_detail_review_total_pages }}</p>
+
+            {% if product_detail_review_has_next %}
+            <a href="{{ product_detail_review_next_url }}" class="detail-review-page-link">다음</a>
+            {% else %}
+            <span class="detail-review-page-link is-disabled">다음</span>
+            {% endif %}
+          </div>
+          {% endif %}
+        </section>
+      </div>
+    </main>
+  </div>
+</div>
+
+<div id="productDetailToast"
+     class="detail-feedback-toast pointer-events-none fixed bottom-6 left-1/2 z-[60] flex min-h-[44px] min-w-[220px] max-w-[360px] items-center justify-center rounded-full bg-[#1f2937] px-[18px] py-[11px] text-center text-[13px] font-semibold text-white shadow-[0_14px_28px_rgba(15,23,42,0.28)]">
+  오류가 발생했습니다.
+</div>
+{% endblock %}
+
+{% block scripts %}
+<script>
+(function () {
+  var pageGate = document.getElementById('pageGate');
+  var profileMenu = document.getElementById('profileMenu');
+  var profileMenuWrapper = document.getElementById('profileMenuWrapper');
+  var headerCartNavLink = document.querySelector('.header-subnav-link[href="/products/"]');
+  var headerWishlistNavLink = document.querySelector('.header-subnav-link[href="/wishlist/"]');
+  var productDetailToast = document.getElementById('productDetailToast');
+  var wishlistButton = document.getElementById('productDetailWishlistButton');
+  var cartButton = document.getElementById('productDetailCartButton');
+  var cartMeta = document.getElementById('productDetailCartMeta');
+  var detailTabButtons = Array.prototype.slice.call(document.querySelectorAll('[data-detail-tab]'));
+  var detailTabPanels = Array.prototype.slice.call(document.querySelectorAll('[data-detail-panel]'));
+  var productToastTimer = null;
+  var detailState = {
+    productId: pageGate ? (pageGate.getAttribute('data-product-id') || '') : '',
+    sessionId: pageGate ? (pageGate.getAttribute('data-session-id') || '') : '',
+    source: pageGate ? (pageGate.getAttribute('data-source') || 'product_detail') : 'product_detail',
+    cartQuantity: pageGate ? Number(pageGate.getAttribute('data-cart-quantity') || '0') || 0 : 0,
+    isWishlisted: pageGate ? pageGate.getAttribute('data-is-wishlisted') === '1' : false,
+  };
+
+  window.toggleProfileMenu = function () {
+    if (!profileMenu) return;
+    profileMenu.classList.toggle('is-open');
+  };
+
+  window.goProductDetailBack = function () {
+    if (document.referrer && document.referrer.indexOf(window.location.origin) === 0) {
+      window.history.back();
+      return;
+    }
+    window.location.href = '/catalog/';
+  };
+
+  function getCsrfToken() {
+    var match = document.cookie.match(/(?:^|;\s*)csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function requestJson(url, options) {
+    var fetchOptions = Object.assign(
+      {
+        headers: {
+          'Content-Type': 'application/json',
+          'X-CSRFToken': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+      },
+      options || {}
+    );
+
+    return fetch(url, fetchOptions).then(function (response) {
+      return response.text().then(function (text) {
+        var data = {};
+        if (text) {
+          try {
+            data = JSON.parse(text);
+          } catch (error) {
+            data = {};
+          }
+        }
+        if (!response.ok) {
+          throw new Error(data.detail || '요청 처리에 실패했습니다.');
+        }
+        return data;
+      });
+    });
+  }
+
+  function showDetailToast(message) {
+    if (!productDetailToast) return;
+    productDetailToast.textContent = message || '요청 처리에 실패했습니다.';
+    productDetailToast.classList.add('is-open');
+    if (productToastTimer) {
+      window.clearTimeout(productToastTimer);
+    }
+    productToastTimer = window.setTimeout(function () {
+      productDetailToast.classList.remove('is-open');
+    }, 2400);
+  }
+
+  function refreshMemberNavIndicators() {
+    return Promise.all([
+      requestJson('/api/orders/cart/'),
+      requestJson('/api/orders/wishlist/'),
+    ]).then(function (results) {
+      var cartData = results[0] || {};
+      var wishlistData = results[1] || {};
+      if (headerCartNavLink) {
+        headerCartNavLink.classList.toggle('has-indicator', !!(cartData.items && cartData.items.length));
+      }
+      if (headerWishlistNavLink) {
+        headerWishlistNavLink.classList.toggle('has-indicator', !!(wishlistData.items && wishlistData.items.length));
+      }
+    }).catch(function () {
+      return null;
+    });
+  }
+
+  function syncActionButtons() {
+    if (wishlistButton) {
+      wishlistButton.classList.toggle('is-active', !!detailState.isWishlisted);
+      wishlistButton.setAttribute('aria-label', detailState.isWishlisted ? '관심 상품 제거' : '관심 상품 추가');
+    }
+    if (cartButton) {
+      cartButton.setAttribute('aria-label', detailState.cartQuantity > 0 ? '장바구니에 더 담기' : '장바구니에 담기');
+    }
+    if (cartMeta) {
+      cartMeta.textContent = detailState.cartQuantity > 0 ? '장바구니 ' + detailState.cartQuantity + '개' : '';
+      cartMeta.classList.toggle('hidden', detailState.cartQuantity <= 0);
+    }
+  }
+
+  function resolveDetailTab() {
+    var url = new URL(window.location.href);
+    if ((window.location.hash || '').replace('#', '') === 'reviews') {
+      return 'reviews';
+    }
+    return url.searchParams.has('review_page') ? 'reviews' : 'info';
+  }
+
+  function setDetailTab(tabName, options) {
+    detailTabButtons.forEach(function (button) {
+      var isActive = button.getAttribute('data-detail-tab') === tabName;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+      button.setAttribute('tabindex', isActive ? '0' : '-1');
+    });
+
+    detailTabPanels.forEach(function (panel) {
+      var isActive = panel.getAttribute('data-detail-panel') === tabName;
+      panel.classList.toggle('hidden', !isActive);
+    });
+
+    if (options && options.updateHash === false) {
+      return;
+    }
+
+    if (window.history && window.history.replaceState) {
+      var url = new URL(window.location.href);
+      url.hash = tabName === 'reviews' ? 'reviews' : 'info';
+      window.history.replaceState(null, '', url.toString());
+      return;
+    }
+
+    window.location.hash = tabName === 'reviews' ? 'reviews' : 'info';
+  }
+
+  function trackDetailView() {
+    if (!detailState.productId) return;
+    requestJson('/api/orders/interactions/', {
+      method: 'POST',
+      body: JSON.stringify({
+        product_id: detailState.productId,
+        interaction_type: 'detail_view',
+        session_id: detailState.sessionId || null,
+      }),
+    }).catch(function () {});
+
+    if (window.tailTalkAnalytics) {
+      window.tailTalkAnalytics.track('detail_view', {
+        goods_id: detailState.productId,
+        page_type: 'product_detail',
+        source: detailState.source || 'product_detail',
+      });
+    }
+  }
+
+  window.toggleProductDetailWishlist = function (button) {
+    if (!detailState.productId || !button) return;
+    button.disabled = true;
+    requestJson('/api/orders/wishlist/', {
+      method: detailState.isWishlisted ? 'DELETE' : 'POST',
+      body: JSON.stringify({
+        product_id: detailState.productId,
+        session_id: detailState.sessionId || null,
+      }),
+    }).then(function () {
+      detailState.isWishlisted = !detailState.isWishlisted;
+      syncActionButtons();
+      refreshMemberNavIndicators();
+      showDetailToast(detailState.isWishlisted ? '관심 상품에 담았습니다.' : '관심 상품에서 제거했습니다.');
+    }).catch(function (error) {
+      showDetailToast(error.message);
+    }).finally(function () {
+      button.disabled = false;
+    });
+  };
+
+  window.addProductDetailToCart = function (button) {
+    if (!detailState.productId || !button) return;
+    button.disabled = true;
+    requestJson('/api/orders/cart/', {
+      method: 'POST',
+      body: JSON.stringify({
+        product_id: detailState.productId,
+        quantity: 1,
+        session_id: detailState.sessionId || null,
+      }),
+    }).then(function (data) {
+      var cartItem = data.cart_item || {};
+      detailState.cartQuantity = Number(cartItem.quantity || detailState.cartQuantity + 1) || 1;
+      syncActionButtons();
+      refreshMemberNavIndicators();
+      showDetailToast('장바구니에 담았습니다.');
+    }).catch(function (error) {
+      showDetailToast(error.message);
+    }).finally(function () {
+      button.disabled = false;
+    });
+  };
+
+  document.addEventListener('mousedown', function (event) {
+    if (profileMenuWrapper && !profileMenuWrapper.contains(event.target) && profileMenu) {
+      profileMenu.classList.remove('is-open');
+    }
+  });
+
+  detailTabButtons.forEach(function (button) {
+    button.addEventListener('click', function () {
+      setDetailTab(button.getAttribute('data-detail-tab') || 'info');
+    });
+  });
+
+  window.addEventListener('hashchange', function () {
+    setDetailTab(resolveDetailTab(), { updateHash: false });
+  });
+
+  syncActionButtons();
+  refreshMemberNavIndicators();
+  setDetailTab(resolveDetailTab(), { updateHash: false });
+  trackDetailView();
+})();
+</script>
+{% endblock %}

--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -867,7 +867,7 @@
                  data-rating="{{ item.rating|default:'-' }}"
                  data-review-count="{{ item.review_count }}"
                  data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
-                 data-product-url="{{ item.product_url|default:'' }}"
+                 data-product-url="{% if item.product_url %}{{ item.product_url }}?source=cart{% endif %}"
                  data-note="{{ item.note }}">
           <div class="cart-item-actions absolute right-4 top-[22px] flex items-center gap-2">
             <button type="button"
@@ -877,7 +877,7 @@
           </div>
           <div class="cart-item-main flex items-start gap-3">
             {% if item.product_url %}
-            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="cart-item-media relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">
+            <a href="{{ item.product_url }}?source=cart" class="cart-item-media relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">
               {% if item.thumbnail_url %}
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover" />
               {% else %}
@@ -895,7 +895,7 @@
             {% endif %}
             <div class="cart-item-copy min-w-0 flex-1 pr-14">
               {% if item.product_url %}
-              <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">{{ item.name }}</a>
+              <a href="{{ item.product_url }}?source=cart" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">{{ item.name }}</a>
               {% else %}
               <p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]" data-cart-name>{{ item.name }}</p>
               {% endif %}
@@ -965,7 +965,7 @@
                  data-rating="{{ item.rating|default:'-' }}"
                  data-review-count="{{ item.review_count }}"
                  data-thumbnail-url="{{ item.thumbnail_url|default:'' }}"
-                 data-product-url="{{ item.product_url|default:'' }}"
+                 data-product-url="{% if item.product_url %}{{ item.product_url }}?source=wishlist{% endif %}"
                  data-note="{{ item.note }}">
           {% if item.product_url %}
           <div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">
@@ -974,7 +974,7 @@
                  data-wishlist-select-checkbox
                  aria-label="관심 상품 선택"
                  >
-            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="absolute inset-0 block" data-wishlist-product-link>
+            <a href="{{ item.product_url }}?source=wishlist" class="absolute inset-0 block" data-wishlist-product-link>
               {% if item.thumbnail_url %}
               <img src="{{ item.thumbnail_url }}" alt="{{ item.name }}" class="h-full w-full object-cover">
               {% else %}
@@ -1020,7 +1020,7 @@
           {% endif %}
           <div class="catalog-card-body p-4">
             {% if item.product_url %}
-            <a href="{{ item.product_url }}" target="_blank" rel="noopener noreferrer" class="catalog-card-title hover:text-[#3182ce]" data-wishlist-product-link>{{ item.name }}</a>
+            <a href="{{ item.product_url }}?source=wishlist" class="catalog-card-title hover:text-[#3182ce]" data-wishlist-product-link>{{ item.name }}</a>
             {% else %}
             <p class="catalog-card-title">{{ item.name }}</p>
             {% endif %}
@@ -1283,13 +1283,13 @@
     }, overrides || {});
   }
 
-  function trackPanelDetailView(item, source) {
+  function trackPanelProductClick(item, source) {
     if (!item) return;
     var payload = buildPanelAnalyticsPayload(item, source);
     if (!payload || !payload.goods_id) return;
-    logProductInteraction(payload.goods_id, 'detail_view', payload.quantity || 1);
+    logProductInteraction(payload.goods_id, 'click', 1);
     if (window.tailTalkAnalytics) {
-      window.tailTalkAnalytics.track('detail_view', payload);
+      window.tailTalkAnalytics.track('product_click', payload);
     }
   }
 
@@ -1593,19 +1593,34 @@
     return items;
   }
 
+  function withDetailSource(productUrl, source) {
+    var normalizedUrl = String(productUrl || '').trim();
+    if (!normalizedUrl) return '';
+    var parts = normalizedUrl.split('?');
+    var baseUrl = parts.shift();
+    var params = new URLSearchParams(parts.join('?'));
+    if (source) {
+      params.set('source', source);
+    }
+    var query = params.toString();
+    return query ? baseUrl + '?' + query : baseUrl;
+  }
+
   function cartThumbnailMarkup(productUrl, thumbnailUrl, name) {
+    var detailUrl = withDetailSource(productUrl, 'cart');
     var thumbnail = thumbnailUrl
       ? '<img src="' + escapeHtml(thumbnailUrl) + '" alt="' + escapeHtml(name) + '" class="h-full w-full object-cover" />'
       : '<span class="text-[20px] font-bold text-[#90a4b8]">?</span>';
-    if (productUrl) {
-      return '<a href="' + escapeHtml(productUrl) + '" target="_blank" rel="noopener noreferrer" class="relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">' + thumbnail + '</a>';
+    if (detailUrl) {
+      return '<a href="' + escapeHtml(detailUrl) + '" class="relative z-[1] flex h-[64px] w-[64px] shrink-0 cursor-pointer items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)] transition-transform hover:scale-[1.02]" data-cart-thumbnail-link onclick="event.stopPropagation()">' + thumbnail + '</a>';
     }
     return '<div class="flex h-[64px] w-[64px] shrink-0 items-center justify-center overflow-hidden rounded-[18px] bg-[#f8fbff] shadow-[0_4px_12px_rgba(49,130,206,0.08)]" data-cart-thumbnail-link>' + thumbnail + '</div>';
   }
 
   function cartNameMarkup(productUrl, name) {
-    if (productUrl) {
-      return '<a href="' + escapeHtml(productUrl) + '" target="_blank" rel="noopener noreferrer" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">' + escapeHtml(name) + '</a>';
+    var detailUrl = withDetailSource(productUrl, 'cart');
+    if (detailUrl) {
+      return '<a href="' + escapeHtml(detailUrl) + '" class="relative z-[1] mt-1 block cursor-pointer truncate text-[16px] font-bold text-[#2d3748] transition-colors hover:text-[#3182ce]" data-cart-name onclick="event.stopPropagation()">' + escapeHtml(name) + '</a>';
     }
     return '<p class="mt-1 truncate text-[16px] font-bold text-[#2d3748]" data-cart-name>' + escapeHtml(name) + '</p>';
   }
@@ -1620,7 +1635,7 @@
     item.setAttribute('data-rating', cartItem.rating || '-');
     item.setAttribute('data-review-count', normalizeReviewCount(cartItem.review_count || '0'));
     item.setAttribute('data-thumbnail-url', cartItem.thumbnail_url || '');
-    item.setAttribute('data-product-url', cartItem.product_url || '');
+    item.setAttribute('data-product-url', withDetailSource(cartItem.product_url || '', 'cart'));
 
     var quantityNode = item.querySelector('[data-cart-quantity]');
     if (quantityNode) {
@@ -1914,15 +1929,15 @@
     var thumbnail = data.thumbnailUrl
       ? '<img src="' + escapeHtml(data.thumbnailUrl) + '" alt="' + escapeHtml(data.name) + '" class="h-full w-full object-cover" />'
       : '<span class="flex h-full w-full items-center justify-center text-[32px] font-bold text-[#90a4b8]">?</span>';
-    var productUrl = escapeHtml(data.productUrl || '');
+    var productUrl = escapeHtml(withDetailSource(data.productUrl || '', 'wishlist'));
     var checkboxHtml = '<input type="checkbox" class="cart-item-select catalog-card-select" data-wishlist-select-checkbox aria-label="관심 상품 선택">';
     var thumbnailHtml = (
       productUrl
-        ? '<div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">' + checkboxHtml + '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="absolute inset-0 block" data-wishlist-product-link>' + thumbnail + '</a><button type="button" class="catalog-card-wishlist wishlist-heart is-active" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg></button></div>'
+        ? '<div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">' + checkboxHtml + '<a href="' + productUrl + '" class="absolute inset-0 block" data-wishlist-product-link>' + thumbnail + '</a><button type="button" class="catalog-card-wishlist wishlist-heart is-active" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg></button></div>'
         : '<div class="wishlist-item-media catalog-thumb relative overflow-hidden bg-[#f8fbff]">' + checkboxHtml + thumbnail + '<button type="button" class="catalog-card-wishlist wishlist-heart is-active" aria-label="관심 상품 상태 변경" onclick="toggleWishlistHeart(this)"><svg width="15" height="15" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"/></svg><svg width="15" height="15" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 20.4 4.9 13.8a4.8 4.8 0 0 1 6.8-6.8L12 7.3l.3-.3a4.8 4.8 0 0 1 6.8 6.8L12 20.4Z"/></svg></button></div>'
     );
     var nameHtml = productUrl
-      ? '<a href="' + productUrl + '" target="_blank" rel="noopener noreferrer" class="catalog-card-title hover:text-[#3182ce]" data-wishlist-product-link>' + escapeHtml(data.name) + '</a>'
+      ? '<a href="' + productUrl + '" class="catalog-card-title hover:text-[#3182ce]" data-wishlist-product-link>' + escapeHtml(data.name) + '</a>'
       : '<p class="catalog-card-title">' + escapeHtml(data.name) + '</p>';
 
     return [
@@ -2342,7 +2357,7 @@
       ? event.target.closest('[data-cart-thumbnail-link], [data-cart-name]')
       : null;
     if (cartLink) {
-      trackPanelDetailView(cartLink.closest('[data-cart-item]'), 'cart');
+      trackPanelProductClick(cartLink.closest('[data-cart-item]'), 'cart');
       return;
     }
 
@@ -2350,7 +2365,7 @@
       ? event.target.closest('[data-wishlist-product-link]')
       : null;
     if (wishlistLink) {
-      trackPanelDetailView(wishlistLink.closest('[data-wishlist-item]'), 'wishlist');
+      trackPanelProductClick(wishlistLink.closest('[data-wishlist-item]'), 'wishlist');
     }
   });
 


### PR DESCRIPTION
## 요약
- 유저용 상품 상세페이지를 추가하고, 리뷰/평점 지표를 실제 Review 데이터 기준으로 정렬했습니다.

## 변경 사항
- 유저 상품 상세 라우트와 템플릿을 추가하고 카탈로그, 장바구니, 찜, 채팅 추천 카드에서 내부 상세로 연결했습니다.
- 어바웃펫 상품 상세 통이미지를 DB 스키마 변경 없이 동적으로 연결했습니다.
- 리뷰 탭과 페이지네이션을 추가하고, 유저 화면 전반의 리뷰 수/평점을 실제 Review 테이블 기준 5점 만점으로 통일했습니다.
- TailTalk 추천순에서 실제 리뷰 0건 상품이 앞서지 않도록 정렬을 보정했습니다.
- 관련 테스트를 보강하고 검증을 완료했습니다.

## 관련 이슈
- close #367

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 유저 화면 전반에서 실제 리뷰 기준으로 통일한 범위와 TailTalk 추천순 보정 기준을 함께 봐주시면 됩니다.