### PR TITLE
회원/반려동물 null 입력 서버 검증 보강

### DIFF
--- a/services/django/pets/api/views.py
+++ b/services/django/pets/api/views.py
@@ -82,6 +82,17 @@ def _parse_boolean(value):
     raise ValueError("neutered must be a boolean.")
 
 
+def _normalize_text(value):
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
+def _normalize_optional_text(value):
+    normalized = _normalize_text(value)
+    return normalized or None
+
+
 def _parse_vaccination_date(value):
     if value in (None, ""):
         return None
@@ -154,7 +165,7 @@ def _apply_pet_payload(pet, request, *, partial):
             raise ValueError(f"Missing required fields: {', '.join(missing)}")
 
     if "name" in request.data:
-        name = str(request.data.get("name", "")).strip()
+        name = _normalize_text(request.data.get("name"))
         if not name:
             raise ValueError("name is required.")
         pet.name = name
@@ -176,8 +187,8 @@ def _apply_pet_payload(pet, request, *, partial):
         "weight_kg": lambda value: _parse_decimal(value, "weight_kg"),
         "neutered": _parse_boolean,
         "vaccination_date": _parse_vaccination_date,
-        "budget_range": lambda value: str(value).strip(),
-        "special_notes": lambda value: str(value).strip() or None,
+        "budget_range": _normalize_text,
+        "special_notes": _normalize_optional_text,
     }
 
     for field, parser in scalar_fields.items():
@@ -192,10 +203,14 @@ def _apply_pet_payload(pet, request, *, partial):
         raise ValueError("weight_kg is required.")
 
     if "breed" in request.data:
-        resolved_breed = resolve_breed(pet.species, request.data.get("breed"))
-        if not resolved_breed:
-            raise ValueError("breed must be one of the registered breeds.")
-        pet.breed = resolved_breed
+        breed = _normalize_text(request.data.get("breed"))
+        if not breed:
+            pet.breed = None
+        else:
+            resolved_breed = resolve_breed(pet.species, breed)
+            if not resolved_breed:
+                raise ValueError("breed must be one of the registered breeds.")
+            pet.breed = resolved_breed
 
     valid_health_concerns = {choice for choice, _ in PetHealthConcern.CONCERN_CHOICES}
     valid_food_preferences = {choice for choice, _ in PetFoodPreference.FOOD_TYPE_CHOICES}

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -272,6 +272,53 @@ class PetApiTests(TestCase):
         self.assertEqual(list(pet.allergies.values_list("ingredient", flat=True)), ["연어"])
         self.assertEqual(list(pet.food_preferences.values_list("food_type", flat=True)), ["wet_pouch"])
 
+    def test_patch_pet_rejects_null_name(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Nabi",
+            species="cat",
+            gender="female",
+            budget_range="under_5",
+        )
+
+        response = self.client.patch(
+            f"/api/pets/{pet.pet_id}/",
+            {"name": None},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "name is required.")
+        pet.refresh_from_db()
+        self.assertEqual(pet.name, "Nabi")
+
+    def test_patch_pet_clears_optional_text_fields_with_null(self):
+        pet = Pet.objects.create(
+            user=self.user,
+            name="Nabi",
+            species="cat",
+            breed="브리티시 숏헤어",
+            gender="female",
+            budget_range="under_5",
+            special_notes="memo",
+        )
+
+        response = self.client.patch(
+            f"/api/pets/{pet.pet_id}/",
+            {
+                "breed": None,
+                "budget_range": None,
+                "special_notes": None,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        pet.refresh_from_db()
+        self.assertIsNone(pet.breed)
+        self.assertEqual(pet.budget_range, "")
+        self.assertIsNone(pet.special_notes)
+
     def test_delete_pet_removes_pet(self):
         pet = Pet.objects.create(
             user=self.user,

--- a/services/django/users/api/views_auth.py
+++ b/services/django/users/api/views_auth.py
@@ -19,13 +19,20 @@ from ..services.auth_service import deactivate_user_and_purge_personal_data, iss
 from .serializers import serialize_user
 
 
+def _get_stripped_request_value(request, field_name):
+    value = request.data.get(field_name)
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
 class RegisterView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request):
-        email = request.data.get("email", "").strip()
+        email = _get_stripped_request_value(request, "email")
         password = request.data.get("password", "")
-        nickname = request.data.get("nickname", "").strip()
+        nickname = _get_stripped_request_value(request, "nickname")
 
         if not email or not password:
             return Response({"detail": "email and password are required."}, status=status.HTTP_400_BAD_REQUEST)
@@ -62,7 +69,7 @@ class AuthLoginView(APIView):
     permission_classes = [AllowAny]
 
     def post(self, request):
-        email = request.data.get("email", "").strip()
+        email = _get_stripped_request_value(request, "email")
         password = request.data.get("password", "")
 
         if not email or not password:

--- a/services/django/users/auth_urls.py
+++ b/services/django/users/auth_urls.py
@@ -4,9 +4,11 @@ from .views import (
     AuthLoginView,
     AuthLogoutView,
     AuthWithdrawView,
+    RegisterView,
 )
 
 urlpatterns = [
+    path("register/", RegisterView.as_view(), name="auth-register"),
     path("login/", AuthLoginView.as_view(), name="auth-login"),
     path("logout/", AuthLogoutView.as_view(), name="auth-logout"),
     path("withdraw/", AuthWithdrawView.as_view(), name="auth-withdraw"),

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -111,6 +111,30 @@ class AuthApiTests(TestCase):
         self.assertIn("refresh", response.data)
         self.assertEqual(response.data["user"]["email"], "auth@example.com")
 
+    def test_register_treats_null_nickname_as_missing(self):
+        response = self.client.post(
+            "/api/auth/register/",
+            {
+                "email": "null-nickname@example.com",
+                "password": "Password123!",
+                "nickname": None,
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["user"]["nickname"], "nullnickname")
+
+    def test_login_rejects_null_email_without_server_error(self):
+        response = self.client.post(
+            "/api/auth/login/",
+            {"email": None, "password": "Password123!"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "email and password are required.")
+
     def test_logout_blacklists_refresh_token(self):
         login_response = self.client.post(
             "/api/auth/login/",


### PR DESCRIPTION
## 요약
- 회원/반려동물 API의 `null` 입력 처리 기준 정리
- 500 및 비정상 저장 방지 로직 추가
- 관련 Django 테스트 추가

## 변경 사항
- 로그인/회원가입 경로에서 `JSON null` 입력을 안전하게 처리하도록 보강
- 반려동물 생성/수정 경로에서 필수값과 선택값의 `null` 처리 규칙 정리
- `None` 문자열 저장과 500 응답 가능성 제거
- 회원/반려동물 관련 회귀 테스트 추가

## 관련 이슈
- closes #387

## 체크리스트
- [x] 수정 파일 문법 검증
- [ ] Django 테스트 실환경 재확인

## 리뷰 요청 사항
- `null` 입력 시 거절/정리 기준이 현재 UX와 충돌하지 않는지 확인 부탁드립니다.
- 현재 로컬에서는 DB 호스트 `postgres`에 연결할 수 없어 Django 테스트를 끝까지 실행하지 못했습니다.