### PR TITLE
채팅 추천 카드 평점과 리뷰 수 표시 정리

### DIFF
--- a/services/django/chat/clients/fastapi_chat_client.py
+++ b/services/django/chat/clients/fastapi_chat_client.py
@@ -1,4 +1,5 @@
 import json
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from uuid import uuid4
 
 import httpx
@@ -39,7 +40,66 @@ def stream_timeout():
     )
 
 
-def capture_sse_event(event_lines, capture):
+def _parse_decimal(value):
+    if value is None:
+        return None
+
+    normalized = str(value).strip().replace(",", "")
+    if not normalized or normalized == "-":
+        return None
+
+    try:
+        return Decimal(normalized)
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def _normalize_card_rating(value):
+    numeric = _parse_decimal(value)
+    if numeric is None:
+        return value
+    return float(numeric.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
+
+
+def _normalize_card_review_count(value):
+    numeric = _parse_decimal(value)
+    if numeric is None:
+        return value
+    return max(int(numeric), 0)
+
+
+def _normalize_product_card(card):
+    if not isinstance(card, dict):
+        return card
+
+    normalized = dict(card)
+    if "rating" in normalized:
+        normalized["rating"] = _normalize_card_rating(normalized.get("rating"))
+    if "reviews" in normalized:
+        normalized["reviews"] = _normalize_card_review_count(normalized.get("reviews"))
+    if "review_count" in normalized:
+        normalized["review_count"] = _normalize_card_review_count(normalized.get("review_count"))
+    return normalized
+
+
+def _normalize_sse_payload(payload):
+    if not isinstance(payload, dict):
+        return payload
+
+    event_type = payload.get("type")
+    if event_type not in {"products", "final"}:
+        return payload
+
+    cards = payload.get("cards")
+    if not isinstance(cards, list):
+        return payload
+
+    normalized = dict(payload)
+    normalized["cards"] = [_normalize_product_card(card) for card in cards]
+    return normalized
+
+
+def _extract_sse_payload(event_lines):
     payload = None
     for line in event_lines:
         if not line.startswith("data:"):
@@ -48,7 +108,31 @@ def capture_sse_event(event_lines, capture):
             payload = json.loads(line[5:].strip())
         except json.JSONDecodeError:
             continue
+    return payload
 
+
+def _serialize_sse_event_lines(event_lines, payload):
+    serialized_payload = json.dumps(payload, ensure_ascii=False, separators=(",", ":"))
+    serialized_lines = []
+    replaced = False
+
+    for line in event_lines:
+        if line.startswith("data:") and not replaced:
+            serialized_lines.append(f"data: {serialized_payload}")
+            replaced = True
+            continue
+        if line.startswith("data:"):
+            continue
+        serialized_lines.append(line)
+
+    if not replaced:
+        serialized_lines.append(f"data: {serialized_payload}")
+
+    return "\n".join(serialized_lines) + "\n\n"
+
+
+def capture_sse_event(event_lines, capture):
+    payload = _normalize_sse_payload(_extract_sse_payload(event_lines))
     if not payload:
         return
 
@@ -104,17 +188,25 @@ def stream_fastapi_response(url, payload, user_id, capture=None, request_id=None
                     for line in response.iter_lines():
                         if line == "":
                             if event_lines:
+                                payload = _normalize_sse_payload(_extract_sse_payload(event_lines))
                                 if capture is not None:
                                     capture_sse_event(event_lines, capture)
-                                yield "\n".join(event_lines) + "\n\n"
+                                if payload:
+                                    yield _serialize_sse_event_lines(event_lines, payload)
+                                else:
+                                    yield "\n".join(event_lines) + "\n\n"
                                 event_lines = []
                             continue
                         event_lines.append(line)
 
                     if event_lines:
+                        payload = _normalize_sse_payload(_extract_sse_payload(event_lines))
                         if capture is not None:
                             capture_sse_event(event_lines, capture)
-                        yield "\n".join(event_lines) + "\n\n"
+                        if payload:
+                            yield _serialize_sse_event_lines(event_lines, payload)
+                        else:
+                            yield "\n".join(event_lines) + "\n\n"
                 except httpx.HTTPError as exc:
                     detail, _ = map_upstream_exception(exc)
                     if capture is not None:

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -225,6 +225,8 @@ class _TimeoutHttpxClient:
 
 class _FakeHttpxClient:
     last_stream_request = None
+    card_rating = 4.5
+    card_reviews = 12
 
     def __init__(self, *args, **kwargs):
         pass
@@ -252,8 +254,8 @@ class _FakeHttpxClient:
                     "brand_name": "브랜드",
                     "price": 10000,
                     "discount_price": 9000,
-                    "rating": 4.5,
-                    "reviews": 12,
+                    "rating": self.__class__.card_rating,
+                    "reviews": self.__class__.card_reviews,
                     "thumbnail_url": "https://example.com/thumb.jpg",
                     "product_url": "https://example.com/product",
                 }
@@ -288,11 +290,20 @@ class _FakeHttpxClient:
         return _FakeStreamResponse(
             [
                 b'data: {"type":"token","content":"hel"}\n\n',
-                'data: {"type":"products","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":4.5,"reviews":12,"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}]}\n\n',
+                'data: {"type":"products","cards":[{"goods_id":"TEST-PRODUCT-1","product_name":"추천 상품","brand_name":"브랜드","price":10000,"discount_price":9000,"rating":'
+                + str(self.__class__.card_rating)
+                + ',"reviews":'
+                + json_module.dumps(self.__class__.card_reviews, ensure_ascii=False)
+                + ',"thumbnail_url":"https://example.com/thumb.jpg","product_url":"https://example.com/product"}]}\n\n',
                 f"data: {json_module.dumps(final_payload, ensure_ascii=False, separators=(',', ':'))}\n\n",
                 b'data: {"type":"done"}\n\n',
             ]
         )
+
+
+class _LongDecimalRatingHttpxClient(_FakeHttpxClient):
+    card_rating = 4.921038021380922
+    card_reviews = 24478.0
 
 
 def _read_streaming_response(response):
@@ -395,6 +406,24 @@ class ChatProxyTests(TestCase):
         self.assertEqual(_FakeHttpxClient.last_stream_request["headers"]["Accept"], "text/event-stream")
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["thread_id"], "thread-1")
         self.assertEqual(_FakeHttpxClient.last_stream_request["json"]["user_id"], str(self.user.id))
+
+    @patch("chat.api_views.httpx.Client", _LongDecimalRatingHttpxClient)
+    def test_chat_proxy_normalizes_recommendation_card_metrics_in_stream_payload(self):
+        response = self.client.post(
+            "/api/chat/",
+            data='{"message":"hello","thread_id":"thread-1","pet_profile":{"species":"cat"}}',
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.access_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = _read_streaming_response(response)
+        self.assertIn('"type":"products"', payload)
+        self.assertIn('"type":"final"', payload)
+        self.assertIn('"rating":4.9', payload)
+        self.assertNotIn('4.921038021380922', payload)
+        self.assertIn('"reviews":24478', payload)
+        self.assertNotIn('"reviews":24478.0', payload)
 
     def test_sessions_proxy_crud_and_message_load_are_backed_by_db(self):
         self.client.defaults["HTTP_AUTHORIZATION"] = f"Bearer {self.access_token}"

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1519,10 +1519,28 @@
       return numeric.toLocaleString('ko-KR') + '원';
     }
 
+    function parseDisplayNumber(value) {
+      if (value === null || value === undefined || value === '') return NaN;
+      if (typeof value === 'number') return value;
+      var normalized = String(value).trim().replace(/,/g, '');
+      var numeric = Number(normalized);
+      if (Number.isFinite(numeric)) {
+        return numeric;
+      }
+      var matched = normalized.match(/-?\d+(?:\.\d+)?/);
+      return matched ? Number(matched[0]) : NaN;
+    }
+
+    function formatRatingLabel(value) {
+      var numeric = parseDisplayNumber(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return '-';
+      return numeric.toFixed(1);
+    }
+
     function normalizeReviewLabel(value) {
-      var normalized = String(value || '').replace(/[^\d]/g, '');
-      if (!normalized) return '리뷰 준비 중';
-      return '리뷰 ' + Number(normalized).toLocaleString('ko-KR');
+      var numeric = parseDisplayNumber(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return '리뷰 준비 중';
+      return '리뷰 ' + Math.trunc(numeric).toLocaleString('ko-KR');
     }
 
     function setRecommendedWishlistButtonState(button, isActive) {
@@ -1602,7 +1620,7 @@
       var priceLabel = escapeHtml(formatPriceLabel(item.discount_price || item.price));
       var thumbnailUrl = escapeHtml(item.thumbnail_url || '');
       var reviews = escapeHtml(normalizeReviewLabel(item.reviews || item.review_count));
-      var rating = escapeHtml(item.rating || '-');
+      var rating = escapeHtml(formatRatingLabel(item.rating));
       var rankOrder = escapeHtml(item.rank_order || '0');
       var thumbnailHtml = productUrl
         ? '<a href="' + productUrl + '" class="relative flex h-[68px] w-[68px] shrink-0 items-center justify-center overflow-hidden rounded-[14px] bg-gradient-to-br from-[#dbeafe] via-[#eff6ff] to-[#f8fafc] transition-transform hover:scale-[1.02]" data-recommendation-link="true">'


### PR DESCRIPTION
## 작업 내용
- 실시간 추천 `products`와 `final` SSE 카드 payload의 평점과 리뷰 수를 정규화합니다.
- 채팅 추천 카드 렌더링에서 평점은 소수점 1자리, 리뷰 수는 읽기 쉬운 정수 형식으로 표시합니다.
- 긴 소수 평점과 부정확한 리뷰 수 포맷이 다시 노출되지 않도록 채팅 프록시 테스트를 추가합니다.

## 검증
- `python3 -m py_compile services/django/chat/clients/fastapi_chat_client.py services/django/chat/tests.py`
- `docker compose -f deploy/local/docker-compose.yml run --rm django python manage.py test --keepdb chat.tests`
- `docker compose -f deploy/local/docker-compose.yml run --rm django python manage.py test --keepdb`

## 관련 이슈
- closes #393
