### PR TITLE
Django 배포 smoke 정적 파일 대기 조건 정리

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -174,7 +174,8 @@ jobs:
             --env-file .deploy-django/.env \
             up -d
           for _ in $(seq 1 20); do
-            if curl --fail --silent http://127.0.0.1/static/css/main.css > /dev/null; then
+            if curl --fail --silent http://127.0.0.1/static/css/main.css > /dev/null \
+              && curl --fail --silent http://127.0.0.1/static/admin/css/base.css > /dev/null; then
               break
             fi
             sleep 3


### PR DESCRIPTION
## 작업 내용
- deploy smoke 단계가 `main.css`만 준비되면 바로 다음 검증으로 넘어가던 레이스를 정리합니다.
- `main.css`와 `admin/base.css`가 모두 준비된 뒤 최종 정적 파일 검증을 수행하도록 대기 조건을 맞춥니다.
- `#392`에서 보인 정적 파일 404를 CI workflow 레벨에서 재발하지 않도록 보강합니다.

## 검증
- 로컬 deploy smoke 재현
- `main.css`, `admin/base.css` 정적 파일 응답 확인

## 관련 PR
- #392
