### PR TITLE
실제 리뷰 평점 노출을 5점 이하와 소수점 1자리로 고정

### DIFF
--- a/services/django/chat/clients/fastapi_chat_client.py
+++ b/services/django/chat/clients/fastapi_chat_client.py
@@ -58,7 +58,8 @@ def _normalize_card_rating(value):
     numeric = _parse_decimal(value)
     if numeric is None:
         return value
-    return float(numeric.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
+    clamped = min(max(numeric, Decimal("0.0")), Decimal("5.0"))
+    return float(clamped.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
 
 
 def _normalize_card_review_count(value):

--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -306,6 +306,11 @@ class _LongDecimalRatingHttpxClient(_FakeHttpxClient):
     card_reviews = 24478.0
 
 
+class _OverMaxRatingHttpxClient(_FakeHttpxClient):
+    card_rating = 9.7
+    card_reviews = 12.0
+
+
 def _read_streaming_response(response):
     chunks = []
     for chunk in response.streaming_content:
@@ -424,6 +429,20 @@ class ChatProxyTests(TestCase):
         self.assertNotIn('4.921038021380922', payload)
         self.assertIn('"reviews":24478', payload)
         self.assertNotIn('"reviews":24478.0', payload)
+
+    @patch("chat.api_views.httpx.Client", _OverMaxRatingHttpxClient)
+    def test_chat_proxy_clamps_recommendation_card_rating_to_five(self):
+        response = self.client.post(
+            "/api/chat/",
+            data='{"message":"hello","thread_id":"thread-1","pet_profile":{"species":"cat"}}',
+            content_type="application/json",
+            HTTP_AUTHORIZATION=f"Bearer {self.access_token}",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = _read_streaming_response(response)
+        self.assertIn('"rating":5.0', payload)
+        self.assertNotIn('"rating":9.7', payload)
 
     def test_sessions_proxy_crud_and_message_load_are_backed_by_db(self):
         self.client.defaults["HTTP_AUTHORIZATION"] = f"Bearer {self.access_token}"

--- a/services/django/products/review_metrics.py
+++ b/services/django/products/review_metrics.py
@@ -1,3 +1,5 @@
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+
 from django.db.models import Avg, Count
 
 from .models import Review
@@ -46,6 +48,36 @@ def attach_actual_review_metrics(products):
     return products
 
 
+def normalize_review_count(value):
+    try:
+        return max(int(value or 0), 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def normalize_rating_value(value):
+    if value is None:
+        return None
+
+    try:
+        numeric = Decimal(str(value).strip())
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+
+    if not numeric.is_finite():
+        return None
+
+    clamped = min(max(numeric, Decimal("0.0")), Decimal("5.0"))
+    return float(clamped.quantize(Decimal("0.1"), rounding=ROUND_HALF_UP))
+
+
+def normalize_rating_label(value):
+    rating_value = normalize_rating_value(value)
+    if rating_value is None or rating_value <= 0:
+        return None
+    return f"{rating_value:.1f}"
+
+
 def get_actual_review_count(product):
     if product is None:
         return 0
@@ -53,7 +85,7 @@ def get_actual_review_count(product):
     if not hasattr(product, "_actual_review_count"):
         attach_actual_review_metrics([product])
 
-    return int(getattr(product, "_actual_review_count", 0) or 0)
+    return normalize_review_count(getattr(product, "_actual_review_count", 0))
 
 
 def get_actual_rating_value(product):
@@ -67,11 +99,8 @@ def get_actual_rating_value(product):
     if avg_score is None:
         return None
 
-    return round(float(avg_score), 1)
+    return normalize_rating_value(avg_score)
 
 
 def get_actual_rating_label(product):
-    rating_value = get_actual_rating_value(product)
-    if rating_value is None:
-        return None
-    return f"{rating_value:.1f}"
+    return normalize_rating_label(get_actual_rating_value(product))

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1343,6 +1343,7 @@
       var recommendationSessionId = sessionId || activeSessionId || '';
       return (products || []).map(function (product) {
         var goodsId = product.goods_id || product.product_id || '';
+        var normalizedReviewCount = normalizeReviewCountValue(product.review_count || product.reviews);
         return {
           goods_id: goodsId,
           product_id: product.product_id || product.goods_id || '',
@@ -1350,9 +1351,9 @@
           brand_name: product.brand_name || product.brand || '',
           price: product.price || '',
           discount_price: product.discount_price || '',
-          rating: product.rating,
-          reviews: product.reviews,
-          review_count: product.review_count,
+          rating: formatRatingLabel(product.rating),
+          reviews: normalizedReviewCount,
+          review_count: normalizedReviewCount,
           thumbnail_url: product.thumbnail_url || '',
           product_url: product.detail_url || buildProductDetailHref(goodsId, 'chat_recommendation', recommendationSessionId) || product.product_url || '',
           external_product_url: product.external_product_url || product.product_url || '',
@@ -1534,13 +1535,20 @@
     function formatRatingLabel(value) {
       var numeric = parseDisplayNumber(value);
       if (!Number.isFinite(numeric) || numeric <= 0) return '-';
-      return numeric.toFixed(1);
+      var clamped = Math.min(Math.max(numeric, 0), 5);
+      return clamped.toFixed(1);
+    }
+
+    function normalizeReviewCountValue(value) {
+      var numeric = parseDisplayNumber(value);
+      if (!Number.isFinite(numeric) || numeric <= 0) return 0;
+      return Math.trunc(numeric);
     }
 
     function normalizeReviewLabel(value) {
-      var numeric = parseDisplayNumber(value);
-      if (!Number.isFinite(numeric) || numeric <= 0) return '리뷰 준비 중';
-      return '리뷰 ' + Math.trunc(numeric).toLocaleString('ko-KR');
+      var count = normalizeReviewCountValue(value);
+      if (count <= 0) return '리뷰 준비 중';
+      return '리뷰 ' + count.toLocaleString('ko-KR');
     }
 
     function setRecommendedWishlistButtonState(button, isActive) {

--- a/services/django/users/pages/views_vendor.py
+++ b/services/django/users/pages/views_vendor.py
@@ -11,6 +11,12 @@ from django.urls import reverse
 from orders.models import OrderItem, UserInteraction
 from products.catalog_menu import build_catalog_menu_context
 from products.models import Product
+from products.review_metrics import (
+    get_actual_rating_label,
+    get_actual_review_count,
+    normalize_rating_label,
+    with_actual_review_metrics,
+)
 
 VENDOR_ADMIN_SESSION_KEY = "tailtalk_vendor_admin_id"
 DEMO_VENDOR_ACCOUNTS = {
@@ -83,9 +89,7 @@ def _format_vendor_price(value):
 
 
 def _format_vendor_rating(value):
-    if value is None:
-        return "-"
-    return f"{value:.1f}"
+    return normalize_rating_label(value) or "-"
 
 
 def _format_vendor_metric(value, digits=2):
@@ -168,8 +172,8 @@ def _serialize_vendor_product(product, demo_soldout_goods_ids=None, demo_pending
         "discount_price_label": _format_vendor_price(product.discount_price),
         "discount_price_value": price_value,
         "discount_rate_label": discount_rate_label,
-        "rating_label": _format_vendor_rating(product.rating),
-        "review_count": product.review_count,
+        "rating_label": get_actual_rating_label(product) or "-",
+        "review_count": get_actual_review_count(product),
         "soldout": product.soldout_yn or is_demo_soldout,
         "pending": is_demo_pending,
         "status_label": "품절" if (product.soldout_yn or is_demo_soldout) else ("준비중" if is_demo_pending else "판매중"),
@@ -439,14 +443,14 @@ def _build_vendor_attention_products(vendor_products, demo_soldout_goods_ids, de
         )
         added_goods_ids.add(product.goods_id)
 
-    for product in vendor_products.filter(goods_id__in=demo_soldout_goods_ids).order_by("-review_count", "goods_name")[:2]:
+    for product in vendor_products.filter(goods_id__in=demo_soldout_goods_ids).order_by("-_actual_review_count", "goods_name")[:2]:
         append_item(product, "품절", "판매 재개를 위해 재고 또는 대체 노출을 먼저 확인해 주세요.", "재입고 확인", "rose")
 
-    for product in vendor_products.filter(goods_id__in=demo_pending_goods_ids).order_by("-review_count", "goods_name")[:2]:
+    for product in vendor_products.filter(goods_id__in=demo_pending_goods_ids).order_by("-_actual_review_count", "goods_name")[:2]:
         append_item(product, "검수 대기", "상품 정보와 노출 문구를 점검해 판매 상태로 전환할 수 있습니다.", "등록 검수", "amber")
 
-    low_rating_products = vendor_products.exclude(rating__isnull=True).filter(review_count__gte=30).order_by(
-        "rating", "-review_count", "goods_name"
+    low_rating_products = vendor_products.exclude(_actual_review_score_avg__isnull=True).filter(_actual_review_count__gte=30).order_by(
+        "_actual_review_score_avg", "-_actual_review_count", "goods_name"
     )[:2]
     for product in low_rating_products:
         append_item(product, "리뷰 점검", "평점과 리뷰 반응을 확인해 상세 설명 또는 CS 대응이 필요한 상품입니다.", "리뷰 확인", "blue")
@@ -457,7 +461,7 @@ def _build_vendor_attention_products(vendor_products, demo_soldout_goods_ids, de
 def _build_vendor_mock_order_rows(vendor_products, demo_soldout_goods_ids, demo_pending_goods_ids):
     serialized_products = [
         _serialize_vendor_product(product, demo_soldout_goods_ids, demo_pending_goods_ids)
-        for product in vendor_products.order_by("-review_count", "goods_name")[:8]
+        for product in vendor_products.order_by("-_actual_review_count", "goods_name")[:8]
     ]
 
     if not serialized_products:
@@ -690,14 +694,14 @@ def vendor_dashboard_view(request):
         return redirect("vendor-login")
 
     brand_name = base_context["vendor_account"]["brand_name"]
-    vendor_products = Product.objects.filter(brand_name=brand_name)
+    vendor_products = with_actual_review_metrics(Product.objects.filter(brand_name=brand_name))
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
     demo_pending_goods_ids = _get_demo_pending_goods_ids(vendor_products, demo_soldout_goods_ids)
     total_products = vendor_products.count()
     display_soldout_products = len(demo_soldout_goods_ids)
     display_pending_products = len(demo_pending_goods_ids)
-    total_reviews = vendor_products.aggregate(total=Sum("review_count"))["total"] or 0
-    average_rating = vendor_products.exclude(rating__isnull=True).aggregate(avg=Avg("rating"))["avg"]
+    total_reviews = vendor_products.aggregate(total=Sum("_actual_review_count"))["total"] or 0
+    average_rating = vendor_products.exclude(_actual_review_score_avg__isnull=True).aggregate(avg=Avg("_actual_review_score_avg"))["avg"]
     average_repeat_rate = vendor_products.exclude(repeat_rate__isnull=True).aggregate(avg=Avg("repeat_rate"))["avg"]
     average_sentiment = vendor_products.exclude(sentiment_avg__isnull=True).aggregate(avg=Avg("sentiment_avg"))["avg"]
     average_delivery_score = vendor_products.exclude(aspect_delivery_packaging__isnull=True).aggregate(avg=Avg("aspect_delivery_packaging"))["avg"]
@@ -715,7 +719,7 @@ def vendor_dashboard_view(request):
 
     top_products = [
         _serialize_vendor_product(product, demo_soldout_goods_ids, demo_pending_goods_ids)
-        for product in vendor_products.order_by("-review_count", "-rating", "goods_name")[:5]
+        for product in vendor_products.order_by("-_actual_review_count", "-_actual_review_score_avg", "goods_name")[:5]
     ]
     attention_products = _build_vendor_attention_products(vendor_products, demo_soldout_goods_ids, demo_pending_goods_ids)
     active_products = max(total_products - display_soldout_products - display_pending_products, 0)
@@ -738,7 +742,7 @@ def vendor_dashboard_view(request):
     cancelled_order_count = (
         brand_order_items.filter(order__status="cancelled").values("order_id").distinct().count()
     )
-    review_check_count = vendor_products.filter(review_count__gte=100).count()
+    review_check_count = vendor_products.filter(_actual_review_count__gte=100).count()
     trend_rows = {
         row["order_day"]: row
         for row in active_brand_order_items.filter(order__created_at__date__gte=trend_start_date)
@@ -892,7 +896,7 @@ def vendor_products_view(request):
     sort_key = request.GET.get("sort", "default")
     if sort_key not in VENDOR_PRODUCT_SORT_OPTIONS:
         sort_key = "default"
-    vendor_products = Product.objects.filter(brand_name=base_context["vendor_account"]["brand_name"])
+    vendor_products = with_actual_review_metrics(Product.objects.filter(brand_name=base_context["vendor_account"]["brand_name"]))
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
     demo_pending_goods_ids = _get_demo_pending_goods_ids(vendor_products, demo_soldout_goods_ids)
 
@@ -989,15 +993,15 @@ def vendor_analytics_view(request):
         period_start_date = date.today() - timedelta(days=selected_period_meta["days"] - 1)
 
     brand_name = base_context["vendor_account"]["brand_name"]
-    vendor_products = Product.objects.filter(brand_name=brand_name)
+    vendor_products = with_actual_review_metrics(Product.objects.filter(brand_name=brand_name))
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
     demo_pending_goods_ids = _get_demo_pending_goods_ids(vendor_products, demo_soldout_goods_ids)
     total_products = vendor_products.count()
     soldout_count = len(demo_soldout_goods_ids)
     pending_count = len(demo_pending_goods_ids)
     active_count = max(total_products - soldout_count - pending_count, 0)
-    total_reviews = vendor_products.aggregate(total=Sum("review_count"))["total"] or 0
-    average_rating = vendor_products.exclude(rating__isnull=True).aggregate(avg=Avg("rating"))["avg"]
+    total_reviews = vendor_products.aggregate(total=Sum("_actual_review_count"))["total"] or 0
+    average_rating = vendor_products.exclude(_actual_review_score_avg__isnull=True).aggregate(avg=Avg("_actual_review_score_avg"))["avg"]
     average_discount_price = vendor_products.aggregate(avg=Avg("discount_price"))["avg"]
     average_price_purchase = vendor_products.exclude(aspect_price_purchase__isnull=True).aggregate(avg=Avg("aspect_price_purchase"))["avg"]
     average_delivery = vendor_products.exclude(aspect_delivery_packaging__isnull=True).aggregate(avg=Avg("aspect_delivery_packaging"))["avg"]
@@ -1193,7 +1197,7 @@ def vendor_analytics_view(request):
     ]
 
     performance_rows = []
-    ranked_products = vendor_products.order_by("-review_count", "-rating", "goods_name")[:6]
+    ranked_products = vendor_products.order_by("-_actual_review_count", "-_actual_review_score_avg", "goods_name")[:6]
     product_interaction_counts = {
         (row["product_id"], row["interaction_type"]): row["total"]
         for row in UserInteraction.objects.filter(product__in=ranked_products)
@@ -1419,7 +1423,7 @@ def vendor_orders_view(request):
     if focus not in dict(VENDOR_ORDER_FOCUS_OPTIONS):
         focus = "all"
 
-    vendor_products = Product.objects.filter(brand_name=base_context["vendor_account"]["brand_name"])
+    vendor_products = with_actual_review_metrics(Product.objects.filter(brand_name=base_context["vendor_account"]["brand_name"]))
     demo_soldout_goods_ids = _get_demo_soldout_goods_ids(vendor_products)
     demo_pending_goods_ids = _get_demo_pending_goods_ids(vendor_products, demo_soldout_goods_ids)
     order_rows = _build_vendor_mock_order_rows(vendor_products, demo_soldout_goods_ids, demo_pending_goods_ids)

--- a/services/django/users/tests.py
+++ b/services/django/users/tests.py
@@ -10,7 +10,7 @@ from social_django.models import UserSocialAuth
 
 from orders.models import Order, OrderItem, UserInteraction
 from pets.models import FuturePetProfile, Pet
-from products.models import Product
+from products.models import Product, Review
 from users.models import SocialAccount, User, UserProfile
 from users.onboarding import ONBOARDING_FORCE_PROFILE_SESSION_KEY
 from users.social_auth import (
@@ -366,7 +366,7 @@ class VendorAdminPageTests(TestCase):
             brand_name="오리젠",
             price=54000,
             discount_price=49900,
-            rating=4.8,
+            rating=10.0,
             review_count=128,
             thumbnail_url="https://example.com/orijen-thumb.png",
             product_url="https://example.com/orijen-product",
@@ -374,6 +374,22 @@ class VendorAdminPageTests(TestCase):
             pet_type=["강아지"],
             category=["사료"],
             crawled_at=timezone.now(),
+        )
+        Review.objects.create(
+            review_id="RV-VENDOR-1",
+            product=self.product,
+            score=5.0,
+            content="기호성이 좋습니다.",
+            author_nickname="오리젠고객1",
+            written_at=timezone.now().date(),
+        )
+        Review.objects.create(
+            review_id="RV-VENDOR-2",
+            product=self.product,
+            score=4.0,
+            content="전반적으로 만족합니다.",
+            author_nickname="오리젠고객2",
+            written_at=timezone.now().date(),
         )
         Product.objects.create(
             goods_id="GI-VENDOR-2",
@@ -507,13 +523,16 @@ class VendorAdminPageTests(TestCase):
         self.assertContains(response, "고객문의 / CS")
         primary = {item["label"]: item["value"] for item in response.context["vendor_primary_kpis"]}
         queue = {item["title"]: item["count_label"] for item in response.context["vendor_queue_items"]}
+        secondary = {item["label"]: item["value"] for item in response.context["vendor_secondary_metrics"]}
         trend = {item["label"]: item["value"] for item in response.context["vendor_trend_highlights"]}
         self.assertEqual(primary["오늘 매출"], "₩99,800")
         self.assertEqual(primary["신규 주문"], "2건")
         self.assertEqual(primary["취소 / 환불 대기"], "1건")
         self.assertEqual(queue["신규 주문"], "1건")
         self.assertEqual(queue["취소 / 환불"], "1건")
-        self.assertEqual(queue["리뷰 확인"], "1건")
+        self.assertEqual(queue["리뷰 확인"], "0건")
+        self.assertEqual(secondary["평균 평점"], "4.5")
+        self.assertEqual(secondary["총 리뷰 수"], "2개")
         self.assertEqual(trend["7일 주문"], "3건")
         self.assertEqual(trend["7일 매출"], "₩149,700")
 
@@ -553,6 +572,8 @@ class VendorAdminPageTests(TestCase):
         self.assertContains(response, "운영 상품")
         self.assertContains(response, "전체")
         self.assertContains(response, "판매중")
+        self.assertEqual(response.context["vendor_product_items"][0]["rating_label"], "4.5")
+        self.assertEqual(response.context["vendor_product_items"][0]["review_count"], 2)
 
     def test_vendor_product_detail_requires_vendor_session(self):
         response = self.client.get(reverse("vendor-product-detail", args=["GI-VENDOR-1"]))
@@ -640,11 +661,14 @@ class VendorAdminPageTests(TestCase):
         self.assertContains(response, "실제 이벤트 로그 기준")
         summary = {item["label"]: item["value"] for item in response.context["vendor_analytics_summary"]}
         funnel = {item["label"]: item["value"] for item in response.context["vendor_funnel_items"]}
+        explicit = {item["label"]: item["value"] for item in response.context["vendor_explicit_metrics"]}
         implicit = {item["label"]: item["value"] for item in response.context["vendor_implicit_metrics"]}
         self.assertEqual(response.context["vendor_analytics_period_label"], "최근 30일")
         self.assertEqual(summary["최근 30일 매출"], "₩49,900")
         self.assertEqual(summary["구매 전환율"], "100.0%")
         self.assertEqual(summary["반복 구매율"], "0.0%")
+        self.assertEqual(explicit["평균 평점"], "4.5")
+        self.assertEqual(explicit["리뷰 수"], "2개")
         self.assertEqual(funnel["노출"], "5")
         self.assertEqual(funnel["클릭"], "2")
         self.assertEqual(funnel["상세 진입"], "1")


### PR DESCRIPTION
## 요약
- 채팅 추천 응답과 프런트 캐시에서 평점을 0.0~5.0 범위의 소수점 1자리로 고정합니다.
- 리뷰 수는 0 이상의 정수로 정규화합니다.
- vendor 화면이 메타데이터 평점이 아니라 실제 리뷰 기준 평점과 리뷰 수를 사용하도록 정리합니다.

## 정리
- AI 변경은 AI PR #55로 분리했습니다.
- 이 PR에는 Django 변경만 포함하고 services/fastapi 서브모듈 포인터 변경은 제외했습니다.

## 검증
- `git -C /tmp/issue396-web diff --check`
- `docker compose -f deploy/local/docker-compose.yml run --rm django python manage.py test --keepdb chat.tests users.tests`

## 참고
- AI PR: skn-ai22-251029/SKN22-Final-2Team-AI#55
- close #396
