### PR TITLE
채팅 웹에서 세션 인증을 사용해 토큰 만료 노출을 방지

### DIFF
--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -86,6 +86,15 @@ class ChatPageTests(TestCase):
         self.assertNotEqual(next_access_token, expired_tokens["access"])
         self.assertEqual(AccessToken(next_access_token)["user_id"], str(self.user.id))
 
+    def test_chat_page_uses_session_auth_for_chat_api_requests(self):
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "function buildChatApiHeaders(headers)")
+        self.assertContains(response, "return buildApiHeaders(headers, false);")
+        self.assertContains(response, "includeAuthorization: false", count=2)
+        self.assertContains(response, "headers: buildChatApiHeaders()", count=2)
+
     def _issue_expired_tokens(self):
         refresh = RefreshToken.for_user(self.user)
         access = refresh.access_token

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -1108,12 +1108,16 @@
       headerCatalogLink.setAttribute('href', '/catalog/?session=' + encodeURIComponent(activeSessionId));
     }
 
-    function buildApiHeaders(headers) {
+    function buildApiHeaders(headers, includeAuthorization) {
       var merged = Object.assign({}, headers || {});
-      if (chatApiAccessToken) {
+      if (includeAuthorization !== false && chatApiAccessToken) {
         merged['Authorization'] = 'Bearer ' + chatApiAccessToken;
       }
       return merged;
+    }
+
+    function buildChatApiHeaders(headers) {
+      return buildApiHeaders(headers, false);
     }
 
     function readJsonResponse(res) {
@@ -1128,18 +1132,24 @@
     }
 
     function requestJson(url, options) {
-      var providedHeaders = (options && options.headers) || {};
+      var requestOptions = Object.assign({}, options || {});
+      var providedHeaders = requestOptions.headers || {};
+      var includeAuthorization = requestOptions.includeAuthorization !== false;
+      delete requestOptions.includeAuthorization;
       var fetchOptions = Object.assign(
         {
           headers: buildApiHeaders({
             'Content-Type': 'application/json',
             'X-CSRFToken': csrfToken || '',
-          }),
+          }, includeAuthorization),
           credentials: 'same-origin',
         },
-        options || {}
+        requestOptions
       );
-      fetchOptions.headers = buildApiHeaders(Object.assign({}, fetchOptions.headers || {}, providedHeaders));
+      fetchOptions.headers = buildApiHeaders(
+        Object.assign({}, fetchOptions.headers || {}, providedHeaders),
+        includeAuthorization
+      );
 
       return fetch(url, fetchOptions).then(function (res) {
         return readJsonResponse(res).then(function (data) {
@@ -1423,7 +1433,7 @@
       if (!sessionId) return Promise.resolve([]);
       var retryAttempt = typeof attempt === 'number' ? attempt : 0;
       return fetch('/api/chat/sessions/' + sessionId + '/messages/', {
-        headers: buildApiHeaders(),
+        headers: buildChatApiHeaders(),
         credentials: 'same-origin',
       }).then(function (res) {
         return readJsonResponse(res).then(function (data) {
@@ -2323,7 +2333,7 @@
           }
 
           fetch('/api/chat/sessions/' + sessionId + '/messages/', {
-            headers: buildApiHeaders(),
+            headers: buildChatApiHeaders(),
             credentials: 'same-origin',
           }).then(function (res) {
             return readJsonResponse(res).then(function (data) {
@@ -2412,7 +2422,7 @@
         if (newTitle !== current) {
           fetch('/api/chat/sessions/' + item.getAttribute('data-id') + '/', {
             method: 'PATCH',
-            headers: buildApiHeaders({
+            headers: buildChatApiHeaders({
               'Content-Type': 'application/json',
               'X-CSRFToken': csrfToken || '',
             }),
@@ -2447,7 +2457,7 @@
 
       fetch('/api/chat/sessions/' + sessionId + '/', {
         method: 'DELETE',
-        headers: buildApiHeaders({ 'X-CSRFToken': csrfToken || '' }),
+        headers: buildChatApiHeaders({ 'X-CSRFToken': csrfToken || '' }),
         credentials: 'same-origin',
       }).then(function (res) {
         return readJsonResponse(res).then(function (data) {
@@ -2467,6 +2477,7 @@
       var derivedTitle = message.length > 18 ? message.slice(0, 18) + '...' : message;
       return requestJson('/api/chat/sessions/', {
         method: 'POST',
+        includeAuthorization: false,
         body: JSON.stringify({
           title: derivedTitle,
           target_pet_id: getCurrentProfileContextType() === 'pet' ? activePetId : null,
@@ -2541,6 +2552,7 @@
 
           requestJson('/api/chat/sessions/' + activeSessionId + '/', {
             method: 'PATCH',
+            includeAuthorization: false,
             body: JSON.stringify({
               target_pet_id: nextContextType === 'pet' ? activePetId : null,
               profile_context_type: nextContextType,
@@ -2633,7 +2645,7 @@
 
         fetch('/api/chat/sessions/' + sessionId + '/messages/', {
           method: 'POST',
-          headers: buildApiHeaders({
+          headers: buildChatApiHeaders({
             'Content-Type': 'application/json',
             'X-CSRFToken': csrfToken || '',
           }),


### PR DESCRIPTION
## 배경
- 채팅 페이지를 오래 열어둔 뒤 다시 메시지를 보내면 만료된 Bearer 토큰 때문에 `유효한 인증 토큰이 필요합니다.`가 노출될 수 있습니다.
- 웹 채팅은 같은 Django 서버의 세션 인증으로 충분한데, 프런트가 `/api/chat/*` 요청에도 Bearer 토큰을 계속 붙이고 있었습니다.

## 변경 내용
- 채팅 전용 헤더 생성 함수를 분리해 `/api/chat/*` 요청은 세션 쿠키만 사용하도록 정리했습니다.
- 세션 생성, 기록 조회, 제목 수정, 삭제, 메시지 전송 경로에서 Bearer 토큰 의존을 제거했습니다.
- 채팅 페이지 렌더 결과에 세션 인증 wiring이 포함되는지 회귀 테스트를 추가했습니다.

## 검증
- `git diff --check -- services/django/templates/chat/index.html services/django/chat/tests.py`
- `docker compose -f deploy/local/docker-compose.yml run --rm django python manage.py test --keepdb chat.tests.ChatPageTests`

close #403