### PR TITLE
채팅 히스토리 empty state 전환 정리

### DIFF
--- a/services/django/chat/tests.py
+++ b/services/django/chat/tests.py
@@ -95,6 +95,16 @@ class ChatPageTests(TestCase):
         self.assertContains(response, "includeAuthorization: false", count=2)
         self.assertContains(response, "headers: buildChatApiHeaders()", count=2)
 
+    def test_chat_page_manages_history_empty_state_after_session_changes(self):
+        response = self.client.get(reverse("chat"))
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'data-history-empty-state="true"')
+        self.assertContains(response, "function removeHistoryEmptyState()")
+        self.assertContains(response, "function ensureHistoryEmptyState()")
+        self.assertContains(response, "removeHistoryEmptyState();")
+        self.assertContains(response, "ensureHistoryEmptyState();")
+
     def _issue_expired_tokens(self):
         refresh = RefreshToken.for_user(self.user)
         access = refresh.access_token

--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -769,7 +769,7 @@
             </span>
           </div>
           {% empty %}
-          <div class="rounded-[14px] border border-[#dbe7f5] bg-white px-[14px] py-[16px] text-center text-[12px] leading-[1.6] text-[#718096]">
+          <div data-history-empty-state="true" class="rounded-[14px] border border-[#dbe7f5] bg-white px-[14px] py-[16px] text-center text-[12px] leading-[1.6] text-[#718096]">
             저장된 대화가 아직 없습니다
           </div>
           {% endfor %}
@@ -2286,8 +2286,35 @@
       });
     }
 
+    function removeHistoryEmptyState() {
+      if (!chatHistoryList) return;
+      var emptyState = chatHistoryList.querySelector('[data-history-empty-state="true"]');
+      if (emptyState) {
+        emptyState.remove();
+      }
+    }
+
+    function ensureHistoryEmptyState() {
+      if (!chatHistoryList) return;
+      var hasSessionItems = !!chatHistoryList.querySelector('.chat-history-item[data-id]');
+      if (hasSessionItems) {
+        removeHistoryEmptyState();
+        return;
+      }
+      if (chatHistoryList.querySelector('[data-history-empty-state="true"]')) {
+        return;
+      }
+
+      var emptyState = document.createElement('div');
+      emptyState.setAttribute('data-history-empty-state', 'true');
+      emptyState.className = 'rounded-[14px] border border-[#dbe7f5] bg-white px-[14px] py-[16px] text-center text-[12px] leading-[1.6] text-[#718096]';
+      emptyState.textContent = '저장된 대화가 아직 없습니다';
+      chatHistoryList.appendChild(emptyState);
+    }
+
     function bindHistoryItems() {
       if (!chatHistoryList) return;
+      removeHistoryEmptyState();
       chatHistoryList.querySelectorAll('.chat-history-item[data-id]').forEach(function (item) {
         if (item.dataset.bound === 'true') return;
         item.dataset.bound = 'true';
@@ -2362,6 +2389,7 @@
       var item = chatHistoryList.querySelector('[data-id="' + sessionId + '"]');
       if (item) return;
       var state = ensureSessionState(sessionId);
+      removeHistoryEmptyState();
 
       var wrapper = document.createElement('div');
       wrapper.className = 'chat-history-item relative h-[40px] w-full shrink-0 cursor-pointer border-b border-[#e7edf5] transition-colors duration-150 box-border';
@@ -2466,6 +2494,7 @@
           }
           item.remove();
           delete sessionState[sessionId];
+          ensureHistoryEmptyState();
           if (activeSessionId === sessionId) {
             window.resetChatState();
           }
@@ -2831,6 +2860,7 @@
     updateRecommendationLauncher();
     renderRecommendationPanel([]);
     bindHistoryItems();
+    ensureHistoryEmptyState();
     refreshHeaderCartBadge();
     if (messageInput) {
       restoreMessageInputFocus(0);


### PR DESCRIPTION
## 배경
- 채팅 세션이 없는 상태에서 사이드바에 "저장된 대화가 아직 없습니다" 안내 렌더링
- 첫 대화 시작 후 세션 생성 시 기존 empty state 미제거
- 실제 히스토리 아이템과 빈 상태 문구 동시 노출

## 반영 내용
- 히스토리 empty state 식별자 추가
- 첫 세션 생성 시 empty state 제거 처리
- 마지막 세션 삭제 시 empty state 복구 처리
- 채팅 페이지 회귀 테스트 추가

## 검증
- `git diff --check`
- `docker compose --env-file /home/harry1749/SKN22-Final-2Team-WEB/deploy/local/.env -f /tmp/issue413-chat-history-empty/deploy/local/docker-compose.yml run --rm django python manage.py test --keepdb chat.tests.ChatPageTests`

close #413