### PR TITLE
fix: 품종 자동완성 영문 검색 및 믹스 기본 지원 (#415)

### DIFF
--- a/services/django/pets/breeds.py
+++ b/services/django/pets/breeds.py
@@ -11,6 +11,24 @@ SPECIES_KEY_MAP = {
     "고양이": "cat",
 }
 
+BUILTIN_BREEDS = {
+    "dog": {
+        "믹스": [
+            "Mix",
+            "Mixed",
+            "믹스견",
+            "Mongrel",
+        ]
+    },
+    "cat": {
+        "믹스": [
+            "Mix",
+            "Mixed",
+            "믹스묘",
+        ]
+    },
+}
+
 
 def _normalize_species(species):
     return SPECIES_KEY_MAP.get((species or "").strip(), "")
@@ -22,6 +40,26 @@ def _normalize_breed_key(value):
 
 def _collapse_breed_key(value):
     return _normalize_breed_key(value).replace(" ", "")
+
+
+def _register_alias(alias_map, canonical_name, alias):
+    normalized = _normalize_breed_key(alias)
+    if not normalized:
+        return
+    alias_map[normalized.casefold()] = canonical_name
+    alias_map[_collapse_breed_key(normalized).casefold()] = canonical_name
+
+
+def _apply_builtin_breeds(options, aliases):
+    for species, breeds in BUILTIN_BREEDS.items():
+        for canonical_name, extra_aliases in breeds.items():
+            normalized_canonical = _normalize_breed_key(canonical_name)
+            if normalized_canonical not in options[species]:
+                options[species].append(normalized_canonical)
+
+            _register_alias(aliases[species], normalized_canonical, normalized_canonical)
+            for alias in extra_aliases:
+                _register_alias(aliases[species], normalized_canonical, alias)
 
 
 @lru_cache(maxsize=1)
@@ -52,11 +90,11 @@ def _breed_meta_snapshot():
         if canonical_name not in options[normalized_species]:
             options[normalized_species].append(canonical_name)
 
-        aliases[normalized_species][canonical_name.casefold()] = canonical_name
-        aliases[normalized_species][_collapse_breed_key(canonical_name).casefold()] = canonical_name
+        _register_alias(aliases[normalized_species], canonical_name, canonical_name)
         if english_name:
-            aliases[normalized_species][english_name.casefold()] = canonical_name
-            aliases[normalized_species][_collapse_breed_key(english_name).casefold()] = canonical_name
+            _register_alias(aliases[normalized_species], canonical_name, english_name)
+
+    _apply_builtin_breeds(options, aliases)
 
     return {key: list(values) for key, values in options.items()}, {key: dict(values) for key, values in aliases.items()}
 
@@ -64,6 +102,32 @@ def _breed_meta_snapshot():
 def get_breed_options(species):
     options, _ = _breed_meta_snapshot()
     return options.get(_normalize_species(species), [])
+
+
+def get_breed_search_options(species):
+    normalized_species = _normalize_species(species)
+    species_options, species_aliases = _breed_meta_snapshot()
+    canonical_names = species_options.get(normalized_species, [])
+    alias_lookup = species_aliases.get(normalized_species, {})
+
+    reverse_aliases = defaultdict(list)
+    for alias_key, canonical_name in alias_lookup.items():
+        if alias_key not in reverse_aliases[canonical_name]:
+            reverse_aliases[canonical_name].append(alias_key)
+
+    items = []
+    for canonical_name in canonical_names:
+        search_terms = []
+        for term in [canonical_name, *reverse_aliases.get(canonical_name, [])]:
+            if term and term not in search_terms:
+                search_terms.append(term)
+        items.append(
+            {
+                "label": canonical_name,
+                "search_terms": search_terms,
+            }
+        )
+    return items
 
 
 def resolve_breed(species, breed):

--- a/services/django/pets/pages/core.py
+++ b/services/django/pets/pages/core.py
@@ -6,7 +6,7 @@ from django.urls import reverse
 from orders.models import Cart, Wishlist
 
 from ..allergies import allergy_options, parse_allergy_ingredients
-from ..breeds import get_breed_options, resolve_breed
+from ..breeds import get_breed_search_options, resolve_breed
 from ..future_profile import get_future_pet_profile_for_request
 from ..models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 
@@ -90,6 +90,16 @@ def _breed_error_message(species):
 
 def _weight_error_message():
     return "몸무게를 입력해 주세요"
+
+
+def _breed_options_json():
+    return json.dumps(
+        {
+            "dog": get_breed_search_options("dog"),
+            "cat": get_breed_search_options("cat"),
+        },
+        ensure_ascii=False,
+    )
 
 
 def _normalize_gender(value):
@@ -439,10 +449,7 @@ def pet_add_details(request):
         {
             "pet": pet_seed,
             "species": species,
-            "breed_options_json": json.dumps({
-                "dog": get_breed_options("dog"),
-                "cat": get_breed_options("cat"),
-            }),
+            "breed_options_json": _breed_options_json(),
             "age_year_options": AGE_YEAR_OPTIONS,
             "age_month_options": AGE_MONTH_OPTIONS,
             "step3_data": step3_data,
@@ -492,10 +499,7 @@ def pet_add_health(request):
             {
                 "pet": pet_preview,
                 "species": species,
-                "breed_options_json": json.dumps({
-                    "dog": get_breed_options("dog"),
-                    "cat": get_breed_options("cat"),
-                }),
+                "breed_options_json": _breed_options_json(),
                 "age_year_options": AGE_YEAR_OPTIONS,
                 "age_month_options": AGE_MONTH_OPTIONS,
                 "step3_data": {
@@ -618,10 +622,7 @@ def pet_edit(request, pet_id):
         {
             "pet": _pet_step2_data(pet) | {"neutered": pet.neutered},
             "species": pet.species,
-            "breed_options_json": json.dumps({
-                "dog": get_breed_options("dog"),
-                "cat": get_breed_options("cat"),
-            }),
+            "breed_options_json": _breed_options_json(),
             "is_edit": True,
             "age_year_options": AGE_YEAR_OPTIONS,
             "age_month_options": AGE_MONTH_OPTIONS,
@@ -655,10 +656,7 @@ def pet_edit_health(request, pet_id):
                     "neutered": {"yes": True, "no": False}.get(request.POST.get("neutered", "")),
                 },
                 "species": pet.species,
-                "breed_options_json": json.dumps({
-                    "dog": get_breed_options("dog"),
-                    "cat": get_breed_options("cat"),
-                }),
+                "breed_options_json": _breed_options_json(),
                 "is_edit": True,
                 "age_year_options": AGE_YEAR_OPTIONS,
                 "age_month_options": AGE_MONTH_OPTIONS,
@@ -766,10 +764,7 @@ def preview_pet_edit(request, pet_id):
                         "neutered": True if step2_data["neutered"] == "yes" else False if step2_data["neutered"] == "no" else None,
                     },
                     "species": pet.species,
-                    "breed_options_json": json.dumps({
-                        "dog": get_breed_options("dog"),
-                        "cat": get_breed_options("cat"),
-                    }),
+                    "breed_options_json": _breed_options_json(),
                     "is_edit": True,
                     "age_year_options": AGE_YEAR_OPTIONS,
                     "age_month_options": AGE_MONTH_OPTIONS,
@@ -809,10 +804,7 @@ def preview_pet_edit(request, pet_id):
                 "neutered": pet.neutered,
             },
             "species": pet.species,
-            "breed_options_json": json.dumps({
-                "dog": get_breed_options("dog"),
-                "cat": get_breed_options("cat"),
-            }),
+            "breed_options_json": _breed_options_json(),
             "is_edit": True,
             "is_preview_edit": True,
             "age_year_options": AGE_YEAR_OPTIONS,

--- a/services/django/pets/tests.py
+++ b/services/django/pets/tests.py
@@ -9,7 +9,7 @@ from rest_framework.test import APIClient
 
 from users.models import User, UserProfile
 
-from .breeds import _breed_meta_snapshot, resolve_breed
+from .breeds import _breed_meta_snapshot, get_breed_search_options, resolve_breed
 from .models import FuturePetProfile, Pet, PetAllergy, PetFoodPreference, PetHealthConcern
 
 
@@ -206,6 +206,43 @@ class PetApiTests(TestCase):
         self.assertEqual(resolve_breed("cat", "British Shorthair"), "브리티시 숏헤어")
         self.assertEqual(resolve_breed("cat", "British   Shorthair"), "브리티시 숏헤어")
         self.assertEqual(resolve_breed("cat", "브리티시숏헤어"), "브리티시 숏헤어")
+        self.assertEqual(resolve_breed("dog", "Mix"), "믹스")
+        self.assertEqual(resolve_breed("dog", "믹스견"), "믹스")
+        self.assertEqual(resolve_breed("cat", "Mixed"), "믹스")
+        self.assertEqual(resolve_breed("cat", "믹스묘"), "믹스")
+
+    def test_get_breed_search_options_includes_english_aliases(self):
+        self.assertEqual(
+            get_breed_search_options("dog"),
+            [
+                {
+                    "label": "말티즈",
+                    "search_terms": ["말티즈", "maltese"],
+                },
+                {
+                    "label": "믹스",
+                    "search_terms": ["믹스", "mix", "mixed", "믹스견", "mongrel"],
+                }
+            ],
+        )
+        self.assertEqual(
+            get_breed_search_options("cat"),
+            [
+                {
+                    "label": "브리티시 숏헤어",
+                    "search_terms": [
+                        "브리티시 숏헤어",
+                        "브리티시숏헤어",
+                        "british shorthair",
+                        "britishshorthair",
+                    ],
+                },
+                {
+                    "label": "믹스",
+                    "search_terms": ["믹스", "mix", "mixed", "믹스묘"],
+                }
+            ],
+        )
 
     def test_post_pets_requires_weight(self):
         response = self.client.post(

--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -499,17 +499,18 @@
       highlightedBreedIndex = -1;
       breedSuggestions.innerHTML = '';
       items.forEach(function (item) {
+        var label = item && typeof item === 'object' ? (item.label || '') : String(item || '');
         var button = document.createElement('button');
         button.type = 'button';
         button.className = 'flex w-full items-center rounded-[8px] px-[10px] py-[9px] text-left text-[13px] leading-none text-[#2d3748] transition-colors duration-150 hover:bg-[#f8fbff]';
-        button.textContent = item;
+        button.textContent = label;
         button.addEventListener('mouseenter', function () {
           highlightedBreedIndex = items.indexOf(item);
           paintBreedSuggestionState();
         });
         button.addEventListener('mousedown', function (event) {
           event.preventDefault();
-          applyBreed(item);
+          applyBreed(label);
         });
         breedSuggestions.appendChild(button);
       });
@@ -530,11 +531,14 @@
       }
       var normalizedKeyword = normalizeText(keyword);
       var filtered = options.filter(function (item) {
-        var normalizedItem = normalizeText(item);
+        var label = item && typeof item === 'object' ? (item.label || '') : String(item || '');
+        var searchTerms = item && typeof item === 'object' ? (item.search_terms || [label]) : [label];
         if (isChoseongQuery(normalizedKeyword)) {
-          return toChoseong(normalizedItem).indexOf(normalizedKeyword) === 0;
+          return toChoseong(normalizeText(label)).indexOf(normalizedKeyword) === 0;
         }
-        return normalizedItem.indexOf(normalizedKeyword) !== -1;
+        return searchTerms.some(function (term) {
+          return normalizeText(term).indexOf(normalizedKeyword) !== -1;
+        });
       }).slice(0, 8);
       openBreedSuggestions(filtered);
     }


### PR DESCRIPTION
## Summary
- 품종 자동완성 데이터를 표시명과 검색 alias 구조로 정리했습니다.
- 자동완성에서 한글 canonical, 공백 제거형, 영문 품종명까지 검색되도록 맞췄습니다.
- 강아지/고양이 기본 품종으로 믹스를 추가하고 관련 alias(Mix, Mixed, 믹스견, 믹스묘)를 정규화하도록 지원했습니다.

## Verification
- Python compile로 수정한 Django 파일 문법을 확인했습니다.
- 품종 헬퍼 반환값과 resolve_breed 정규화 동작을 로컬에서 직접 확인했습니다.
- Django 전체 테스트는 로컬 SQLite 마이그레이션 제약으로 끝까지 실행하지 못했습니다.

Closes #415