### PR TITLE
fix: 품종 자동완성 키보드 선택 시 [Object object] 입력 문제 수정

### DIFF
--- a/services/django/templates/pets/add_step2.html
+++ b/services/django/templates/pets/add_step2.html
@@ -444,6 +444,10 @@
         .replace(/^\s+/, '');
     }
 
+    function getBreedLabel(item) {
+      return item && typeof item === 'object' ? (item.label || '') : String(item || '');
+    }
+
     function toChoseong(value) {
       return Array.from(value || '').map(function (char) {
         var code = char.charCodeAt(0) - 44032;
@@ -473,8 +477,10 @@
 
     function applyBreed(value) {
       if (!breedInput) return;
-      breedInput.value = value;
+      breedInput.value = sanitizeBreedInput(getBreedLabel(value)).trim();
+      clearError(breedStatus);
       closeBreedSuggestions();
+      syncNextButton();
       breedInput.focus();
     }
 
@@ -499,7 +505,7 @@
       highlightedBreedIndex = -1;
       breedSuggestions.innerHTML = '';
       items.forEach(function (item) {
-        var label = item && typeof item === 'object' ? (item.label || '') : String(item || '');
+        var label = getBreedLabel(item);
         var button = document.createElement('button');
         button.type = 'button';
         button.className = 'flex w-full items-center rounded-[8px] px-[10px] py-[9px] text-left text-[13px] leading-none text-[#2d3748] transition-colors duration-150 hover:bg-[#f8fbff]';
@@ -531,7 +537,7 @@
       }
       var normalizedKeyword = normalizeText(keyword);
       var filtered = options.filter(function (item) {
-        var label = item && typeof item === 'object' ? (item.label || '') : String(item || '');
+        var label = getBreedLabel(item);
         var searchTerms = item && typeof item === 'object' ? (item.search_terms || [label]) : [label];
         if (isChoseongQuery(normalizedKeyword)) {
           return toChoseong(normalizeText(label)).indexOf(normalizedKeyword) === 0;


### PR DESCRIPTION
## 요약
품종 자동완성에서 키보드 방향키와 엔터로 항목을 선택할 때 입력창에 `[Object object]`가 들어가던 문제를 수정했습니다.

## 변경 사항
- 품종 자동완성 항목의 표시 문자열을 추출하는 공통 함수 `getBreedLabel()`을 추가했습니다.
- 엔터 선택 경로에서도 객체 전체가 아니라 품종 `label` 문자열만 입력창에 반영되도록 `applyBreed()`를 수정했습니다.
- 자동완성 렌더링과 검색 필터링도 동일한 문자열 추출 경로를 사용하도록 정리했습니다.
- 로컬 Docker 이미지를 재빌드하고 `http://localhost/` 기준 서비스 기동을 확인했습니다.

## 관련 이슈
closes #417

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 품종 등록/수정 화면에서 방향키 아래 이동 후 엔터 선택 시 입력값이 품종명 문자열로 정상 반영되는지 확인 부탁드립니다.
- 자동완성 마우스 선택과 한글 초성 검색 경로에 부작용이 없는지 함께 봐주시면 됩니다.
