### PR TITLE
fix: 상품 페이지 초기 메타 갱신 반영

### DIFF
--- a/services/django/templates/orders/products.html
+++ b/services/django/templates/orders/products.html
@@ -2438,6 +2438,7 @@
   updateCartSummary();
   updateTabCounts();
   scheduleViewportSync();
+  refreshProductsData();
   window.addEventListener('resize', scheduleViewportSync);
 })();
 </script>


### PR DESCRIPTION
## 요약\n- 상품/장바구니 페이지 진입 시 최신 상품 메타를 즉시 다시 불러오도록 반영\n\n## 변경 사항\n-  하단 초기화 구간에  호출 추가\n\n## 배경\n- 운영  에서 장바구니 카드가  placeholder를 유지하는 현상이 있어, 페이지 진입 직후 최신 메타를 동기화하도록 수정합니다.