### PR TITLE
feat: 채팅 검색 진행 메시지 표시

### DIFF
--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -2716,7 +2716,16 @@
                 if (!line.startsWith('data: ')) return;
                 try {
                   var evt = JSON.parse(line.slice(6));
-                  if (evt.type === 'token') {
+                  if (evt.type === 'info') {
+                    if (evt.content) {
+                      assistantText += (assistantText ? '\n' : '') + evt.content;
+                      if (assistantEl) {
+                        var infoNode = assistantEl.querySelector('.assistant-text');
+                        if (infoNode) infoNode.innerHTML = formatAssistantMessageHtml(assistantText);
+                      }
+                      scrollChatToBottom();
+                    }
+                  } else if (evt.type === 'token') {
                     assistantText += evt.content || '';
                     if (assistantEl) {
                       var p = assistantEl.querySelector('.assistant-text');


### PR DESCRIPTION
## 요약
추천 검색 전 FastAPI가 보내는 진행 메시지(info SSE)를 채팅 말풍선에 표시하도록 WEB 채팅 화면을 수정했습니다.

## 변경 사항
- 채팅 SSE 처리에서 info 이벤트를 assistant 말풍선에 누적 표시
- 최종 final 이벤트가 오면 기존처럼 최종 답변으로 교체
- FastAPI 서브모듈 포인터를 추천 검색 진행 메시지 스트리밍 커밋으로 갱신

## 관련 이슈
ref #423

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- AI PR #62가 먼저 머지된 뒤 서브모듈 포인터가 맞는지 확인 부탁드립니다.
- info 이벤트가 최종 assistant 메시지로 저장되지 않고, 최종 답변으로 교체되는 흐름을 봐 주세요.

## 검증
- services/fastapi: python -m py_compile final_ai/application/chat/search_progress.py final_ai/application/chat/graph_service.py final_ai/application/chat/service.py final_ai/contracts/sse.py
- services/fastapi: search_progress 직접 출력 검증
- services/django: python -m py_compile chat/clients/fastapi_chat_client.py chat/services/chat_stream_service.py
