### PR TITLE
feat: 추천 검색 진행 UI 및 상품명 종 필터 보강

### DIFF
--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -2716,7 +2716,16 @@
                 if (!line.startsWith('data: ')) return;
                 try {
                   var evt = JSON.parse(line.slice(6));
-                  if (evt.type === 'token') {
+                  if (evt.type === 'info') {
+                    if (evt.content) {
+                      assistantText += (assistantText ? '\n' : '') + evt.content;
+                      if (assistantEl) {
+                        var infoNode = assistantEl.querySelector('.assistant-text');
+                        if (infoNode) infoNode.innerHTML = formatAssistantMessageHtml(assistantText);
+                      }
+                      scrollChatToBottom();
+                    }
+                  } else if (evt.type === 'token') {
                     assistantText += evt.content || '';
                     if (assistantEl) {
                       var p = assistantEl.querySelector('.assistant-text');


### PR DESCRIPTION
## 요약
추천 검색 조건을 채팅 답변과 분리된 진행 UI로 표시하고, FastAPI 서브모듈의 상품명 기반 종 불일치 필터 변경을 반영합니다.

## 변경 사항
- SSE info 이벤트를 답변 본문에 합치지 않고 `검색 조건 확인 중` UI 영역에 누적 표시
- 최종 assistant 메시지는 실제 답변만 저장/표시되도록 진행 메시지와 분리
- FastAPI 서브모듈 포인터를 AI PR #63 커밋으로 갱신
- upstream/develop 최신 변경을 병합해 PR diff를 채팅 UI와 서브모듈 포인터로 제한

## 관련 이슈
ref #423

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [x] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 채팅 진행 UI가 답변 본문과 분리되어 보이는지 확인 부탁드립니다.
- FastAPI 서브모듈 PR skn-ai22-251029/SKN22-Final-2Team-AI#63 병합 후 WEB PR 병합이 필요합니다.

## 검증
- FastAPI `python -m py_compile` 통과
- Django `python manage.py check` 통과
- 로컬 Docker 재빌드 후 `http://127.0.0.1/` 200 OK
- 로컬 Docker 재빌드 후 `http://127.0.0.1:8001/docs` 200 OK