### PR TITLE
로그인 채팅 greeting Tail 색상 적용

### DIFF
--- a/services/django/templates/chat/index.html
+++ b/services/django/templates/chat/index.html
@@ -989,7 +989,7 @@
               <div id="chatEmptyState">
                 {% if chat_enabled %}
                 <div id="memberHeroTitle">
-                  안녕하세요.<br class="guest-hero-mobile-break"> TailTalk이 추천을 도와드릴게요
+                  안녕하세요.<br class="guest-hero-mobile-break"> <span class="text-[#3182ce]">Tail</span><span>Talk이 추천을 도와드릴게요</span>
                 </div>
                 <p id="memberHeroMessage">
                   제품명이나 원하는 조건을 바로 입력해 보세요.<br class="guest-hero-mobile-break">


### PR DESCRIPTION
## 요약
- 로그인 채팅 빈 상태 greeting의 Tail 텍스트 색상을 비로그인 안내와 동일하게 맞췄습니다.

## 변경 사항
- 로그인 상태 greeting 문구의 Tail 부분에 기존 비로그인 안내와 같은 파란색 스타일을 적용했습니다.
- WEB PR에는 Django 템플릿 변경만 포함하고 FastAPI 서브모듈 포인터 변경은 포함하지 않았습니다.

## 관련 이슈
- 없음

## 체크리스트
- [x] 변경 사항이 의도한 대로 동작함을 확인했다
- [ ] 관련 문서를 업데이트했다

## 리뷰 요청 사항
- 로그인 상태 새 채팅 화면에서 Tail만 파란색으로 보이는지 확인 부탁드립니다.